### PR TITLE
Harden Railway deployment and execution state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Instead, V1 focuses on the alpha layer we actually want to test:
 - emits paper-mode copy candidates with copyability scores
 - scans for simple YES/NO underpricing opportunities
 - can plan live copy orders from top-ranked signals
-- stores signals and execution results into SQLite
+- stores signals, duplicate-signal fingerprints, positions, and execution results into SQLite
 
 ## What V1 does not do
 
@@ -41,7 +41,7 @@ Instead, V1 focuses on the alpha layer we actually want to test:
 - do market making
 - do dispute or resolution trading
 - run on 5 minute crypto latency games
-- manage open orders, exits, or portfolio hedging yet
+- manage full portfolio hedging yet
 
 ## Quick start
 
@@ -99,9 +99,36 @@ pip install -e .[trade]
 python -m predictcel.main --config config/predictcel.example.json --db predictcel.db --live-data --live-trading
 ```
 
-When `execution.dry_run` is true, the bot only emits execution results with `dry_run` status and does not post orders.
+When `execution.dry_run` is true, the bot only emits execution results with `dry_run` status and does not post orders. Dry-run results are logged and de-duplicated, but they are not stored as open positions.
 
 To use this meaningfully, replace the example basket wallets in `config/predictcel.example.json` with real wallet addresses.
+
+## Railway deployment
+
+`railway.toml` runs PredictCel as a Railway worker, not a web service. Do not attach a public domain unless you add an HTTP status endpoint.
+
+Create a Railway volume mounted at `/data` before relying on persisted state. The default worker database path is `/data/predictcel.db`; without a volume, SQLite state can be lost on redeploy or restart.
+
+Recommended worker variables:
+- `PREDICTCEL_MODE=paper` for file-backed example mode
+- `PREDICTCEL_MODE=live-data` for public Polymarket reads without trading
+- `PREDICTCEL_MODE=dry-run-trading` for live data plus execution planning while `execution.dry_run` remains true
+- `PREDICTCEL_MODE=live-trading` only after credentials, config, and jurisdictional eligibility are verified
+- `PREDICTCEL_RUN_INTERVAL_SECONDS=300`
+- `PREDICTCEL_RUN_ONCE=false`
+- `PREDICTCEL_CONFIG=config/predictcel.example.json`
+- `PREDICTCEL_DB=/data/predictcel.db`
+
+Legacy variables still work when `PREDICTCEL_MODE` is not set:
+- `PREDICTCEL_LIVE_DATA=true`
+- `PREDICTCEL_LIVE_TRADING=true`
+
+Live trading variables:
+- `PREDICTCEL_POLY_PRIVATE_KEY`
+- `PREDICTCEL_POLY_FUNDER`
+- optional: `PREDICTCEL_POLY_HOST`
+
+The Railway worker catches per-cycle exceptions, logs JSON events, waits for the next interval, and continues. Each normal run prints a compact `summary` object with counts for markets, wallet trades, copy candidates, duplicate skips, execution intents, and open positions.
 
 ## Project layout
 
@@ -109,14 +136,14 @@ To use this meaningfully, replace the example basket wallets in `config/predictc
 - `src/predictcel/models.py` - small dataclasses used by the engines
 - `src/predictcel/markets.py` - file-backed market snapshot loading
 - `src/predictcel/wallets.py` - file-backed wallet trade loading
-- `src/predictcel/polymarket.py` - public Polymarket live ingestion, token normalization, and orderbook enrichment
+- `src/predictcel/polymarket.py` - public Polymarket live ingestion, token normalization, retries, and orderbook enrichment
 - `src/predictcel/scoring.py` - wallet quality and copyability scoring
 - `src/predictcel/copy_engine.py` - basket-consensus paper signal engine
 - `src/predictcel/arb_sidecar.py` - simple arbitrage scanner
 - `src/predictcel/execution.py` - execution planning and guarded live order submission
-- `src/predictcel/storage.py` - SQLite logging
+- `src/predictcel/storage.py` - SQLite logging, positions, and duplicate-signal fingerprints
 - `src/predictcel/main.py` - CLI entrypoint
-- `tests/` - focused unit tests for consensus, execution, arbitrage, and scoring
+- `tests/` - focused unit tests for consensus, execution, arbitrage, storage, and scoring
 
 ## Notes on scoring
 
@@ -142,6 +169,7 @@ The live mode is intentionally approximate and conservative:
 - it normalizes `clobTokenIds` from Gamma into YES and NO token identifiers when possible
 - it enriches market snapshots with public CLOB top-of-book data
 - it uses wallet trade history for basket detection only
+- it skips failed wallet fetches and keeps the rest of the cycle alive
 - it skips markets whose metadata cannot be normalized safely
 
 This is enough for signal generation and cautious execution planning, not enough for full production trading.
@@ -149,7 +177,7 @@ This is enough for signal generation and cautious execution planning, not enough
 ## Next steps
 
 Once this guarded path looks sane, the next layers should be:
-1. position and open-order awareness before repeat submissions
+1. fuller exchange fill-state reconciliation before repeat submissions
 2. explicit exit logic and portfolio caps
 3. richer basket maintenance and wallet rotation rules
 4. copyability features based on fuller order book depth and spread history

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 [build]
-builder = "NIXPACKS"
+builder = "RAILPACK"
 buildCommand = "pip install -e .[dev,trade] && python -m pytest"
 
 [deploy]

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from datetime import UTC, datetime
+from typing import Any
 
 from .arb_sidecar import ArbitrageSidecar
 from .config import load_config
@@ -10,31 +11,20 @@ from .copy_engine import CopyEngine
 from .execution import ExecutionPlanner, ExitRunner, LiveOrderExecutor, intents_as_dicts
 from .markets import load_market_snapshots
 from .models import Position
-from .polymarket import (
-    PolymarketPublicClient,
-    build_market_snapshots,
-    build_wallet_trades,
-    enrich_market_snapshots_with_orderbooks,
-)
+from .polymarket import PolymarketPublicClient, build_market_snapshots, build_wallet_trades, enrich_market_snapshots_with_orderbooks
 from .scoring import WalletQualityScorer
 from .storage import SignalStore
 from .wallets import load_wallet_trades
+
+TRUSTED_POSITION_STATUSES = {"filled", "matched", "success", "submitted"}
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="PredictCel V1 paper engine")
     parser.add_argument("--config", required=True, help="Path to config JSON file")
     parser.add_argument("--db", default="predictcel.db", help="SQLite database path")
-    parser.add_argument(
-        "--live-data",
-        action="store_true",
-        help="Fetch live public market and wallet data from Polymarket instead of local example files",
-    )
-    parser.add_argument(
-        "--live-trading",
-        action="store_true",
-        help="Submit live orders for planned copy trades when execution is enabled and credentials are configured",
-    )
+    parser.add_argument("--live-data", action="store_true", help="Fetch live public market and wallet data from Polymarket instead of local example files")
+    parser.add_argument("--live-trading", action="store_true", help="Submit live orders for planned copy trades when execution is enabled and credentials are configured")
     return parser
 
 
@@ -42,100 +32,58 @@ def main() -> None:
     args = build_parser().parse_args()
     config = load_config(args.config)
     use_live_data = bool(args.live_data or (config.live_data and config.live_data.enabled))
+    trades, markets = _load_live_inputs(config) if use_live_data else (load_wallet_trades(config.wallet_trades_path), load_market_snapshots(config.market_snapshots_path))
 
-    if use_live_data:
-        trades, markets = _load_live_inputs(config)
-    else:
-        trades = load_wallet_trades(config.wallet_trades_path)
-        markets = load_market_snapshots(config.market_snapshots_path)
-
-    wallet_quality_scorer = WalletQualityScorer(config.filters)
-    wallet_qualities = wallet_quality_scorer.score(trades, markets)
-
-    copy_engine = CopyEngine(config)
-    arb_sidecar = ArbitrageSidecar(config.arbitrage)
-
-    copy_candidates = copy_engine.evaluate(trades, markets, wallet_qualities)
-    arbitrage_opportunities = arb_sidecar.scan(markets)
+    wallet_qualities = WalletQualityScorer(config.filters).score(trades, markets)
+    copy_candidates = CopyEngine(config).evaluate(trades, markets, wallet_qualities)
+    arbitrage_opportunities = ArbitrageSidecar(config.arbitrage).scan(markets)
 
     execution_intents: list = []
     execution_results: list = []
     close_intents: list = []
     close_results: list = []
-    updated_positions: list = []
-
+    skipped_duplicate_signals = 0
     store = SignalStore(args.db)
 
     if args.live_trading:
         if config.execution is None or not config.execution.enabled:
             raise ValueError("--live-trading was requested but execution is not enabled in config.")
-
-        held_market_ids = store.get_held_market_ids()
         current_exposure_usd = store.get_total_exposure()
-
-        exit_runner = ExitRunner(config.execution, config.live_data)
         open_positions = store.get_open_positions()
-
         if open_positions:
-            close_intents, updated_positions = exit_runner.evaluate_and_close(open_positions, markets)
-            if close_intents:
-                executor = LiveOrderExecutor(config.execution, config.live_data)
-                close_results = executor.execute(close_intents)
-            closed_market_ids = {
-                result.market_id
-                for result in close_results
-                if result.status != "error"
-            }
+            close_intents, updated_positions = ExitRunner(config.execution, config.live_data).evaluate_and_close(open_positions, markets)
+            close_results = LiveOrderExecutor(config.execution, config.live_data).execute(close_intents) if close_intents else []
+            closed_market_ids = {result.market_id for result in close_results if _is_trusted_execution_result(result)}
             for pos in updated_positions:
-                store.update_position(
-                    market_id=pos.market_id,
-                    current_price=pos.current_price,
-                    unrealized_pnl=pos.unrealized_pnl,
-                    status="closed" if pos.market_id in closed_market_ids else pos.status,
-                )
+                store.update_position(pos.market_id, pos.current_price, pos.unrealized_pnl, "closed" if pos.market_id in closed_market_ids else pos.status)
             current_exposure_usd = store.get_total_exposure()
 
-        planner = ExecutionPlanner(config.execution, config.execution.position)
-        execution_intents = planner.plan(
-            copy_candidates,
-            markets,
-            held_market_ids,
-            current_exposure_usd,
-        )
-        executor = LiveOrderExecutor(config.execution, config.live_data)
-        execution_results = executor.execute(execution_intents)
-
-        now = datetime.now(UTC)
-        position_config = config.execution.position
-        for result in execution_results:
-            if result.status != "error":
-                store.save_position(
-                    Position(
-                        market_id=result.market_id,
-                        topic=result.topic,
-                        side=result.side,
-                        token_id=result.token_id,
-                        entry_price=result.worst_price,
-                        entry_amount_usd=result.amount_usd,
-                        current_price=result.worst_price,
-                        unrealized_pnl=0.0,
-                        opened_at=now,
-                        last_updated=now,
-                        take_profit_pct=position_config.take_profit_pct,
-                        stop_loss_pct=position_config.stop_loss_pct,
-                        max_hold_minutes=position_config.max_hold_minutes,
-                        status="open",
-                    )
-                )
+        fresh_candidates, skipped_duplicate_signals = _filter_duplicate_candidates(store, copy_candidates)
+        execution_intents = ExecutionPlanner(config.execution, config.execution.position).plan(fresh_candidates, markets, store.get_held_market_ids(), current_exposure_usd)
+        execution_results = LiveOrderExecutor(config.execution, config.live_data).execute(execution_intents)
+        _persist_execution_side_effects(store, config, execution_results)
 
     store.save_copy_candidates(copy_candidates)
     store.save_arbitrage_opportunities(arbitrage_opportunities)
     store.save_execution_results(execution_results + close_results)
-    portfolio_summary = _portfolio_summary(store, config)
-
+    open_positions = store.get_open_positions()
+    summary = {
+        "markets_loaded": len(markets),
+        "wallet_trades_loaded": len(trades),
+        "wallets_scored": len(wallet_qualities),
+        "copy_candidates": len(copy_candidates),
+        "skipped_duplicate_signals": skipped_duplicate_signals,
+        "arbitrage_opportunities": len(arbitrage_opportunities),
+        "execution_intents": len(execution_intents),
+        "execution_results": len(execution_results),
+        "close_intents": len(close_intents),
+        "close_results": len(close_results),
+        "open_positions": len(open_positions),
+    }
     print(json.dumps({
         "mode": "live" if use_live_data else "file",
-        "portfolio_summary": portfolio_summary,
+        "summary": summary,
+        "portfolio_summary": _portfolio_summary(store, config),
         "wallet_qualities": {wallet: quality.__dict__ for wallet, quality in wallet_qualities.items()},
         "copy_candidates": [candidate.__dict__ for candidate in copy_candidates],
         "arbitrage_opportunities": [opportunity.__dict__ for opportunity in arbitrage_opportunities],
@@ -143,42 +91,50 @@ def main() -> None:
         "execution_results": [result.__dict__ for result in execution_results],
         "close_intents": intents_as_dicts(close_intents),
         "close_results": [result.__dict__ for result in close_results],
-        "open_positions": [pos.__dict__ for pos in updated_positions],
-    }, indent=2))
+        "open_positions": [pos.__dict__ for pos in open_positions],
+    }, indent=2, default=str))
 
 
-def _portfolio_summary(store: SignalStore, config) -> dict:
+def _persist_execution_side_effects(store: SignalStore, config: Any, execution_results: list) -> None:
+    now = datetime.now(UTC)
+    position_config = config.execution.position
+    for result in execution_results:
+        if result.status == "dry_run" or _is_trusted_execution_result(result):
+            store.mark_signal_seen(result.market_id, result.topic, result.side)
+        if not _is_trusted_execution_result(result):
+            continue
+        store.save_position(Position(result.market_id, result.topic, result.side, result.token_id, result.worst_price, result.amount_usd, result.worst_price, 0.0, now, now, position_config.take_profit_pct, position_config.stop_loss_pct, position_config.max_hold_minutes, "open"))
+
+
+def _portfolio_summary(store: SignalStore, config: Any) -> dict:
     if config.execution is None or config.execution.exposure is None:
         return store.get_portfolio_summary(starting_bankroll_usd=0.0)
-    return store.get_portfolio_summary(
-        starting_bankroll_usd=config.execution.exposure.max_total_exposure_usd
-    )
+    return store.get_portfolio_summary(starting_bankroll_usd=config.execution.exposure.max_total_exposure_usd)
 
 
 def _load_live_inputs(config):
     if config.live_data is None:
         raise ValueError("--live-data was requested but live_data is not configured.")
-
-    client = PolymarketPublicClient(
-        gamma_base_url=config.live_data.gamma_base_url,
-        data_base_url=config.live_data.data_base_url,
-        clob_base_url=config.live_data.clob_base_url,
-        timeout_seconds=config.live_data.request_timeout_seconds,
-    )
-    topic_by_wallet = {
-        wallet: basket.topic
-        for basket in config.baskets
-        for wallet in basket.wallets
-    }
-    wallet_payloads = {
-        wallet: client.fetch_wallet_trades(wallet, config.live_data.trade_limit)
-        for wallet in topic_by_wallet
-    }
+    client = PolymarketPublicClient(config.live_data.gamma_base_url, config.live_data.data_base_url, config.live_data.clob_base_url, config.live_data.request_timeout_seconds)
+    topic_by_wallet = {wallet: basket.topic for basket in config.baskets for wallet in basket.wallets}
+    wallet_payloads = {}
+    for wallet in topic_by_wallet:
+        try:
+            wallet_payloads[wallet] = client.fetch_wallet_trades(wallet, config.live_data.trade_limit)
+        except Exception:
+            wallet_payloads[wallet] = []
     trades = build_wallet_trades(wallet_payloads, topic_by_wallet)
-    market_payload = client.fetch_active_markets(config.live_data.market_limit)
-    markets = build_market_snapshots(market_payload)
-    markets = enrich_market_snapshots_with_orderbooks(markets, client)
-    return trades, markets
+    markets = build_market_snapshots(client.fetch_active_markets(config.live_data.market_limit))
+    return trades, enrich_market_snapshots_with_orderbooks(markets, client)
+
+
+def _filter_duplicate_candidates(store: SignalStore, candidates: list) -> tuple[list, int]:
+    fresh = [candidate for candidate in candidates if not store.has_recent_signal(candidate.market_id, candidate.topic, candidate.side)]
+    return fresh, len(candidates) - len(fresh)
+
+
+def _is_trusted_execution_result(result) -> bool:
+    return str(result.status).strip().lower() in TRUSTED_POSITION_STATUSES and bool(str(result.order_id).strip())
 
 
 if __name__ == "__main__":

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -17,11 +19,15 @@ class PolymarketPublicClient:
         data_base_url: str = "https://data-api.polymarket.com",
         clob_base_url: str = "https://clob.polymarket.com",
         timeout_seconds: int = 15,
+        max_retries: int = 3,
+        retry_base_delay_seconds: float = 0.5,
     ) -> None:
         self.gamma_base_url = gamma_base_url.rstrip("/")
         self.data_base_url = data_base_url.rstrip("/")
         self.clob_base_url = clob_base_url.rstrip("/")
         self.timeout_seconds = timeout_seconds
+        self.max_retries = max(max_retries, 1)
+        self.retry_base_delay_seconds = retry_base_delay_seconds
 
     def fetch_active_markets(self, limit: int) -> list[dict[str, Any]]:
         query = urlencode({"limit": limit, "closed": "false", "active": "true"})
@@ -45,8 +51,15 @@ class PolymarketPublicClient:
 
     def _get_json(self, url: str) -> Any:
         request = Request(url, headers={"User-Agent": "PredictCel/0.1"})
-        with urlopen(request, timeout=self.timeout_seconds) as response:
-            return json.loads(response.read().decode("utf-8"))
+        for attempt in range(self.max_retries):
+            try:
+                with urlopen(request, timeout=self.timeout_seconds) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
+                if attempt >= self.max_retries - 1:
+                    raise
+                time.sleep(self.retry_base_delay_seconds * (2 ** attempt))
+        return None
 
 
 def build_market_snapshots(items: list[dict[str, Any]]) -> dict[str, MarketSnapshot]:
@@ -67,7 +80,7 @@ def enrich_market_snapshots_with_orderbooks(
         try:
             yes_book = client.fetch_order_book(snapshot.yes_token_id) if snapshot.yes_token_id else {}
             no_book = client.fetch_order_book(snapshot.no_token_id) if snapshot.no_token_id else {}
-        except OSError:
+        except Exception:
             enriched[market_id] = snapshot
             continue
 

--- a/src/predictcel/railway.py
+++ b/src/predictcel/railway.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import time
+import traceback
+from datetime import UTC, datetime
 
 from .main import main as run_cli
+
+VALID_MODES = {"paper", "live-data", "dry-run-trading", "live-trading"}
 
 
 def main() -> None:
@@ -12,7 +17,16 @@ def main() -> None:
     run_once = _env_enabled("PREDICTCEL_RUN_ONCE", default=False)
 
     while True:
-        _run_once_from_env()
+        try:
+            _run_once_from_env()
+        except Exception as exc:  # pragma: no cover - defensive worker boundary
+            _log_event(
+                "predictcel_run_error",
+                {
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                },
+            )
         if run_once:
             return
         time.sleep(max(interval_seconds, 30))
@@ -21,13 +35,23 @@ def main() -> None:
 def _run_once_from_env() -> None:
     config_path = os.getenv("PREDICTCEL_CONFIG", "config/predictcel.example.json")
     db_path = os.getenv("PREDICTCEL_DB", "/data/predictcel.db")
+    mode = os.getenv("PREDICTCEL_MODE", "").strip().lower()
 
     argv = ["predictcel", "--config", config_path, "--db", db_path]
-    if _env_enabled("PREDICTCEL_LIVE_DATA", default=False):
-        argv.append("--live-data")
-    if _env_enabled("PREDICTCEL_LIVE_TRADING", default=False):
-        argv.append("--live-trading")
+    if mode:
+        if mode not in VALID_MODES:
+            raise ValueError(f"Invalid PREDICTCEL_MODE={mode!r}. Expected one of {sorted(VALID_MODES)}.")
+        if mode in {"live-data", "dry-run-trading", "live-trading"}:
+            argv.append("--live-data")
+        if mode in {"dry-run-trading", "live-trading"}:
+            argv.append("--live-trading")
+    else:
+        if _env_enabled("PREDICTCEL_LIVE_DATA", default=False):
+            argv.append("--live-data")
+        if _env_enabled("PREDICTCEL_LIVE_TRADING", default=False):
+            argv.append("--live-trading")
 
+    _log_event("predictcel_run_start", {"mode": mode or "legacy-env", "db_path": db_path})
     previous_argv = sys.argv
     try:
         sys.argv = argv
@@ -41,6 +65,10 @@ def _env_enabled(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _log_event(event: str, payload: dict) -> None:
+    print(json.dumps({"event": event, "ts": datetime.now(UTC).isoformat(), **payload}, sort_keys=True), flush=True)
 
 
 if __name__ == "__main__":

--- a/src/predictcel/storage.py
+++ b/src/predictcel/storage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from dataclasses import asdict
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Iterable
 
@@ -73,6 +73,17 @@ class SignalStore:
                 stop_loss_pct REAL NOT NULL,
                 max_hold_minutes INTEGER NOT NULL,
                 status TEXT NOT NULL
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS signal_fingerprints (
+                fingerprint TEXT PRIMARY KEY,
+                market_id TEXT NOT NULL,
+                topic TEXT NOT NULL,
+                side TEXT NOT NULL,
+                created_at TEXT NOT NULL
             )
             """
         )
@@ -239,10 +250,38 @@ class SignalStore:
         cursor.execute(
             "UPDATE positions SET current_price = ?, unrealized_pnl = ?, "
             "last_updated = ?, status = ? WHERE market_id = ? AND status IN ('open', 'closing')",
-            (current_price, unrealized_pnl, datetime.now().isoformat(), status, market_id),
+            (current_price, unrealized_pnl, datetime.now(UTC).isoformat(), status, market_id),
+        )
+        self.connection.commit()
+
+    def make_signal_fingerprint(self, market_id: str, topic: str, side: str) -> str:
+        return f"{topic.strip().lower()}:{market_id.strip()}:{side.strip().upper()}"
+
+    def has_recent_signal(self, market_id: str, topic: str, side: str, ttl_minutes: int = 1440) -> bool:
+        cutoff = datetime.now(UTC) - timedelta(minutes=ttl_minutes)
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "SELECT created_at FROM signal_fingerprints WHERE fingerprint = ?",
+            (self.make_signal_fingerprint(market_id, topic, side),),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return False
+        return _parse_dt(row[0]) >= cutoff
+
+    def mark_signal_seen(self, market_id: str, topic: str, side: str) -> None:
+        cursor = self.connection.cursor()
+        fingerprint = self.make_signal_fingerprint(market_id, topic, side)
+        cursor.execute(
+            "INSERT OR REPLACE INTO signal_fingerprints (fingerprint, market_id, topic, side, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (fingerprint, market_id, topic, side, datetime.now(UTC).isoformat()),
         )
         self.connection.commit()
 
 
 def _parse_dt(value: str) -> datetime:
-    return datetime.fromisoformat(value)
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -85,3 +85,17 @@ def test_portfolio_summary_tracks_closed_winrate_and_pnl() -> None:
     finally:
         store.connection.close()
         db_path.unlink(missing_ok=True)
+
+
+def test_signal_fingerprints_prevent_recent_duplicates() -> None:
+    store, db_path = make_store()
+    try:
+        assert store.has_recent_signal("m1", "GeoPolitics", "yes") is False
+
+        store.mark_signal_seen("m1", "GeoPolitics", "yes")
+
+        assert store.has_recent_signal("m1", "geopolitics", "YES") is True
+        assert store.has_recent_signal("m1", "geopolitics", "NO") is False
+    finally:
+        store.connection.close()
+        db_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Switch Railway config to Railpack and document worker/volume/env-mode setup.
- Add resilient Railway worker loop with JSON lifecycle/error logs and `PREDICTCEL_MODE` presets.
- Add retries for public Polymarket API reads and tolerate per-wallet live-data failures.
- Add run summary counts, duplicate signal fingerprinting, and safer execution state handling so dry-run results do not become open positions.
- Add storage coverage for signal fingerprint duplicate protection.

## Notes
- This was implemented directly on GitHub per request; no local test run was performed.
- Railway should be configured as a worker with a volume mounted at `/data` before relying on persisted SQLite state.