### PR TITLE
Enhance arbitrage sidecar with cost-adjusted scoring

### DIFF
--- a/config/predictcel.example.json
+++ b/config/predictcel.example.json
@@ -60,6 +60,18 @@
   },
   "arbitrage": {
     "min_gross_edge": 0.02,
-    "min_liquidity_usd": 5000
+    "min_liquidity_usd": 5000,
+    "variable_cost_rate": 0.0,
+    "gas_cost_per_tx_usd": 0.02,
+    "settlement_tx_count": 2,
+    "slippage_rate": 0.001,
+    "min_profitable_position_usd": 5.0,
+    "max_position_usd": 50.0,
+    "target_annualized_return": 0.10,
+    "max_annualized_return": 10.0,
+    "edge_weight": 0.35,
+    "liquidity_weight": 0.25,
+    "speed_weight": 0.20,
+    "confidence_weight": 0.20
   }
 }

--- a/src/predictcel/arb_sidecar.py
+++ b/src/predictcel/arb_sidecar.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from .config import ArbitrageConfig
 from .models import ArbitrageOpportunity, MarketSnapshot
 
+MINUTES_PER_YEAR = 525_600
+
 
 class ArbitrageSidecar:
     def __init__(self, config: ArbitrageConfig) -> None:
@@ -11,22 +13,115 @@ class ArbitrageSidecar:
     def scan(self, markets: dict[str, MarketSnapshot]) -> list[ArbitrageOpportunity]:
         opportunities: list[ArbitrageOpportunity] = []
         for market in markets.values():
-            if market.liquidity_usd < self.config.min_liquidity_usd:
-                continue
-            total_cost = market.yes_ask + market.no_ask
-            gross_edge = round(1.0 - total_cost, 6)
-            if gross_edge < self.config.min_gross_edge:
-                continue
-            opportunities.append(
-                ArbitrageOpportunity(
-                    market_id=market.market_id,
-                    topic=market.topic,
-                    yes_ask=market.yes_ask,
-                    no_ask=market.no_ask,
-                    total_cost=total_cost,
-                    gross_edge=gross_edge,
-                    liquidity_usd=market.liquidity_usd,
-                    reason="yes/no complete set costs less than one dollar",
-                )
-            )
-        return sorted(opportunities, key=lambda item: item.gross_edge, reverse=True)
+            opportunity = self._evaluate_market(market)
+            if opportunity is not None:
+                opportunities.append(opportunity)
+        return sorted(opportunities, key=lambda item: (item.quality_score, item.net_edge), reverse=True)
+
+    def _evaluate_market(self, market: MarketSnapshot) -> ArbitrageOpportunity | None:
+        if market.liquidity_usd < self.config.min_liquidity_usd:
+            return None
+        if market.yes_ask <= 0 or market.no_ask <= 0:
+            return None
+
+        total_cost = round(market.yes_ask + market.no_ask, 6)
+        gross_edge = round(1.0 - total_cost, 6)
+        if gross_edge < self.config.min_gross_edge:
+            return None
+
+        fixed_cost = self.config.gas_cost_per_tx_usd * self.config.settlement_tx_count
+        variable_cost_rate = self.config.variable_cost_rate + self.config.slippage_rate
+        net_edge_rate = gross_edge - variable_cost_rate
+        if net_edge_rate <= 0:
+            return None
+
+        min_profitable_position = max(
+            self.config.min_profitable_position_usd,
+            fixed_cost / net_edge_rate if fixed_cost > 0 else self.config.min_profitable_position_usd,
+        )
+        min_profitable_position = round(min_profitable_position, 4)
+        if min_profitable_position > self.config.max_position_usd:
+            return None
+
+        safe_position_size = min(self.config.max_position_usd, market.liquidity_usd * 0.05)
+        safe_position_size = round(max(min_profitable_position, safe_position_size), 4)
+        fixed_cost_rate = fixed_cost / safe_position_size if safe_position_size > 0 else 1.0
+        net_edge = round(net_edge_rate - fixed_cost_rate, 6)
+        if net_edge <= 0:
+            return None
+
+        annualized_return = self._annualized_return(net_edge, total_cost, market.minutes_to_resolution)
+        if annualized_return < self.config.target_annualized_return:
+            return None
+
+        liquidity_score = self._liquidity_score(market)
+        speed_score = self._speed_score(market.minutes_to_resolution)
+        confidence_score = self._confidence_score(market, net_edge)
+        edge_score = min(net_edge / max(self.config.min_gross_edge, 0.000001), 1.0)
+        quality_score = round(
+            (edge_score * self.config.edge_weight)
+            + (liquidity_score * self.config.liquidity_weight)
+            + (speed_score * self.config.speed_weight)
+            + (confidence_score * self.config.confidence_weight),
+            4,
+        )
+        gas_cost_percentage = round(fixed_cost_rate, 6)
+
+        return ArbitrageOpportunity(
+            market_id=market.market_id,
+            topic=market.topic,
+            yes_ask=market.yes_ask,
+            no_ask=market.no_ask,
+            total_cost=total_cost,
+            gross_edge=gross_edge,
+            liquidity_usd=market.liquidity_usd,
+            reason="complete-set underpricing passes cost, size, liquidity, and APR filters",
+            net_edge=net_edge,
+            annualized_return=annualized_return,
+            min_profitable_position=min_profitable_position,
+            safe_position_size=safe_position_size,
+            quality_score=quality_score,
+            liquidity_score=liquidity_score,
+            speed_score=speed_score,
+            confidence_score=confidence_score,
+            gas_cost_percentage=gas_cost_percentage,
+            resolution_risk=self._resolution_risk(market.minutes_to_resolution),
+            estimated_slippage=round(self.config.slippage_rate, 6),
+            best_execution_path="direct",
+        )
+
+    def _annualized_return(self, net_edge: float, total_cost: float, minutes_to_resolution: int) -> float:
+        minutes = max(minutes_to_resolution, 1)
+        capital_required = max(total_cost, 0.000001)
+        annualized = (net_edge / capital_required) * (MINUTES_PER_YEAR / minutes)
+        return round(min(annualized, self.config.max_annualized_return), 6)
+
+    def _liquidity_score(self, market: MarketSnapshot) -> float:
+        target = max(self.config.min_liquidity_usd * 3, 1.0)
+        return round(min(market.liquidity_usd / target, 1.0), 4)
+
+    def _speed_score(self, minutes_to_resolution: int) -> float:
+        if minutes_to_resolution <= 0:
+            return 0.0
+        if minutes_to_resolution <= 60:
+            return 0.65
+        if minutes_to_resolution <= 360:
+            return 1.0
+        if minutes_to_resolution <= 1440:
+            return 0.75
+        return 0.35
+
+    def _confidence_score(self, market: MarketSnapshot, net_edge: float) -> float:
+        orderbook_bonus = 0.15 if market.orderbook_ready else 0.0
+        spread_penalty = min(max(market.yes_spread, market.no_spread) / 0.10, 0.35)
+        edge_component = min(net_edge / max(self.config.min_gross_edge, 0.000001), 0.85)
+        return round(max(0.0, min(edge_component + orderbook_bonus - spread_penalty, 1.0)), 4)
+
+    def _resolution_risk(self, minutes_to_resolution: int) -> str:
+        if minutes_to_resolution <= 0:
+            return "HIGH"
+        if minutes_to_resolution < 60:
+            return "HIGH"
+        if minutes_to_resolution <= 1440:
+            return "LOW"
+        return "MEDIUM"

--- a/src/predictcel/config.py
+++ b/src/predictcel/config.py
@@ -26,6 +26,18 @@ class FilterConfig:
 class ArbitrageConfig:
     min_gross_edge: float
     min_liquidity_usd: float
+    variable_cost_rate: float = 0.0
+    gas_cost_per_tx_usd: float = 0.02
+    settlement_tx_count: int = 2
+    slippage_rate: float = 0.001
+    min_profitable_position_usd: float = 5.0
+    max_position_usd: float = 50.0
+    target_annualized_return: float = 0.10
+    max_annualized_return: float = 10.0
+    edge_weight: float = 0.35
+    liquidity_weight: float = 0.25
+    speed_weight: float = 0.20
+    confidence_weight: float = 0.20
 
 
 @dataclass(frozen=True)
@@ -119,6 +131,24 @@ def load_config(path: str | Path) -> AppConfig:
         raise ConfigError("Resolution window is invalid.")
     if arbitrage.min_gross_edge <= 0:
         raise ConfigError("min_gross_edge must be positive.")
+    if arbitrage.min_liquidity_usd < 0:
+        raise ConfigError("min_liquidity_usd must be non-negative.")
+    if not 0 <= arbitrage.variable_cost_rate <= 1:
+        raise ConfigError("arbitrage variable_cost_rate must be between 0 and 1.")
+    if arbitrage.gas_cost_per_tx_usd < 0:
+        raise ConfigError("arbitrage gas_cost_per_tx_usd must be non-negative.")
+    if arbitrage.settlement_tx_count < 0:
+        raise ConfigError("arbitrage settlement_tx_count must be non-negative.")
+    if not 0 <= arbitrage.slippage_rate <= 1:
+        raise ConfigError("arbitrage slippage_rate must be between 0 and 1.")
+    if arbitrage.min_profitable_position_usd < 0:
+        raise ConfigError("arbitrage min_profitable_position_usd must be non-negative.")
+    if arbitrage.max_position_usd <= 0:
+        raise ConfigError("arbitrage max_position_usd must be positive.")
+    if arbitrage.target_annualized_return < 0:
+        raise ConfigError("arbitrage target_annualized_return must be non-negative.")
+    if arbitrage.max_annualized_return <= 0:
+        raise ConfigError("arbitrage max_annualized_return must be positive.")
 
     if live_data is not None:
         if live_data.market_limit <= 0 or live_data.trade_limit <= 0:

--- a/src/predictcel/models.py
+++ b/src/predictcel/models.py
@@ -72,6 +72,18 @@ class ArbitrageOpportunity:
     gross_edge: float
     liquidity_usd: float
     reason: str
+    net_edge: float = 0.0
+    annualized_return: float = 0.0
+    min_profitable_position: float = 0.0
+    safe_position_size: float = 0.0
+    quality_score: float = 0.0
+    liquidity_score: float = 0.0
+    speed_score: float = 0.0
+    confidence_score: float = 0.0
+    gas_cost_percentage: float = 0.0
+    resolution_risk: str = "UNKNOWN"
+    estimated_slippage: float = 0.0
+    best_execution_path: str = "direct"
 
 
 @dataclass(frozen=True)

--- a/tests/test_arb_sidecar.py
+++ b/tests/test_arb_sidecar.py
@@ -3,7 +3,7 @@ from predictcel.config import ArbitrageConfig
 from predictcel.models import MarketSnapshot
 
 
-def test_detects_complete_set_underpricing() -> None:
+def test_detects_complete_set_underpricing_with_net_metrics() -> None:
     sidecar = ArbitrageSidecar(ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000))
     markets = {
         "m1": MarketSnapshot(
@@ -15,6 +15,9 @@ def test_detects_complete_set_underpricing() -> None:
             best_bid=0.44,
             liquidity_usd=9000,
             minutes_to_resolution=120,
+            yes_spread=0.02,
+            no_spread=0.02,
+            orderbook_ready=True,
         )
     }
 
@@ -22,6 +25,12 @@ def test_detects_complete_set_underpricing() -> None:
 
     assert len(opportunities) == 1
     assert round(opportunities[0].gross_edge, 2) == 0.05
+    assert opportunities[0].net_edge > 0
+    assert opportunities[0].min_profitable_position >= 5.0
+    assert opportunities[0].safe_position_size <= 50.0
+    assert opportunities[0].annualized_return >= 0.10
+    assert 0 < opportunities[0].quality_score <= 1
+    assert opportunities[0].resolution_risk == "LOW"
 
 
 def test_skips_market_when_liquidity_too_low() -> None:
@@ -42,3 +51,48 @@ def test_skips_market_when_liquidity_too_low() -> None:
     opportunities = sidecar.scan(markets)
 
     assert opportunities == []
+
+
+def test_skips_when_costs_destroy_net_edge() -> None:
+    sidecar = ArbitrageSidecar(
+        ArbitrageConfig(
+            min_gross_edge=0.02,
+            min_liquidity_usd=5000,
+            variable_cost_rate=0.03,
+            slippage_rate=0.01,
+        )
+    )
+    markets = {
+        "m1": MarketSnapshot("m1", "sports", "Example", 0.46, 0.49, 0.44, 9000, 120)
+    }
+
+    assert sidecar.scan(markets) == []
+
+
+def test_skips_when_min_profitable_position_exceeds_cap() -> None:
+    sidecar = ArbitrageSidecar(
+        ArbitrageConfig(
+            min_gross_edge=0.02,
+            min_liquidity_usd=5000,
+            gas_cost_per_tx_usd=1.0,
+            settlement_tx_count=2,
+            max_position_usd=50.0,
+        )
+    )
+    markets = {
+        "m1": MarketSnapshot("m1", "sports", "Example", 0.46, 0.49, 0.44, 9000, 120)
+    }
+
+    assert sidecar.scan(markets) == []
+
+
+def test_sorts_by_quality_score_then_net_edge() -> None:
+    sidecar = ArbitrageSidecar(ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000))
+    markets = {
+        "fast": MarketSnapshot("fast", "sports", "Fast", 0.46, 0.49, 0.44, 9000, 120, orderbook_ready=True),
+        "slow": MarketSnapshot("slow", "sports", "Slow", 0.45, 0.49, 0.44, 9000, 3000, orderbook_ready=False),
+    }
+
+    opportunities = sidecar.scan(markets)
+
+    assert [opportunity.market_id for opportunity in opportunities] == ["fast", "slow"]


### PR DESCRIPTION
## Summary
- Expand arbitrage config with conservative cost, sizing, APR, and scoring defaults while preserving the existing `scan(markets)` entrypoint.
- Add richer arbitrage opportunity fields for net edge, annualized return, minimum profitable position, safe position size, quality score, liquidity/speed/confidence scores, gas percentage, and resolution risk.
- Replace gross-edge-only ranking with cost-adjusted filtering and composite quality ranking.
- Document the new settings in the example config and add tests for cost drag, MPO cap, APR/quality metrics, and ranking.

## Scope intentionally deferred
- Cross-market arbitrage, Kalshi/external venues, ML spread prediction, and true Kelly sizing are not included in this PR.

## Testing
- Not run locally; implemented directly on GitHub per repo workflow request.