### PR TITLE
Add weighted consensus scoring for copy signals

### DIFF
--- a/config/predictcel.example.json
+++ b/config/predictcel.example.json
@@ -32,6 +32,16 @@
     "max_retries": 3,
     "retry_base_delay_seconds": 1.0
   },
+  "consensus": {
+    "recency_half_life_seconds": 1800,
+    "min_weighted_consensus": 0.60,
+    "confidence_prior_strength": 2.0,
+    "min_confidence_score": 0.50,
+    "conflict_penalty_weight": 0.25,
+    "bankroll_usd": 100.0,
+    "kelly_fraction": 0.25,
+    "max_suggested_position_usd": 10.0
+  },
   "baskets": [
     {
       "topic": "geopolitics",

--- a/src/predictcel/config.py
+++ b/src/predictcel/config.py
@@ -23,6 +23,18 @@ class FilterConfig:
 
 
 @dataclass(frozen=True)
+class ConsensusConfig:
+    recency_half_life_seconds: int = 1800
+    min_weighted_consensus: float = 0.60
+    confidence_prior_strength: float = 2.0
+    min_confidence_score: float = 0.50
+    conflict_penalty_weight: float = 0.25
+    bankroll_usd: float = 100.0
+    kelly_fraction: float = 0.25
+    max_suggested_position_usd: float = 10.0
+
+
+@dataclass(frozen=True)
 class ArbitrageConfig:
     min_gross_edge: float
     min_liquidity_usd: float
@@ -90,6 +102,7 @@ class AppConfig:
     market_snapshots_path: str
     live_data: LiveDataConfig | None
     execution: ExecutionConfig | None
+    consensus: ConsensusConfig = ConsensusConfig()
 
 
 class ConfigError(ValueError):
@@ -109,6 +122,7 @@ def load_config(path: str | Path) -> AppConfig:
     ]
     filters = FilterConfig(**payload["filters"])
     arbitrage = ArbitrageConfig(**payload["arbitrage"])
+    consensus = ConsensusConfig(**payload.get("consensus", {}))
     live_data_payload = payload.get("live_data")
     live_data = LiveDataConfig(**live_data_payload) if live_data_payload else None
     execution_payload = payload.get("execution")
@@ -129,6 +143,22 @@ def load_config(path: str | Path) -> AppConfig:
         raise ConfigError("max_price_drift must be between 0 and 1.")
     if filters.min_minutes_to_resolution >= filters.max_minutes_to_resolution:
         raise ConfigError("Resolution window is invalid.")
+    if consensus.recency_half_life_seconds <= 0:
+        raise ConfigError("consensus recency_half_life_seconds must be positive.")
+    if not 0 <= consensus.min_weighted_consensus <= 1:
+        raise ConfigError("consensus min_weighted_consensus must be between 0 and 1.")
+    if consensus.confidence_prior_strength < 0:
+        raise ConfigError("consensus confidence_prior_strength must be non-negative.")
+    if not 0 <= consensus.min_confidence_score <= 1:
+        raise ConfigError("consensus min_confidence_score must be between 0 and 1.")
+    if not 0 <= consensus.conflict_penalty_weight <= 1:
+        raise ConfigError("consensus conflict_penalty_weight must be between 0 and 1.")
+    if consensus.bankroll_usd <= 0:
+        raise ConfigError("consensus bankroll_usd must be positive.")
+    if not 0 <= consensus.kelly_fraction <= 1:
+        raise ConfigError("consensus kelly_fraction must be between 0 and 1.")
+    if consensus.max_suggested_position_usd <= 0:
+        raise ConfigError("consensus max_suggested_position_usd must be positive.")
     if arbitrage.min_gross_edge <= 0:
         raise ConfigError("min_gross_edge must be positive.")
     if arbitrage.min_liquidity_usd < 0:
@@ -194,6 +224,7 @@ def load_config(path: str | Path) -> AppConfig:
         market_snapshots_path=payload["market_snapshots_path"],
         live_data=live_data,
         execution=execution,
+        consensus=consensus,
     )
 
 

--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 
 from .config import AppConfig, BasketRule
 from .models import CopyCandidate, MarketSnapshot, WalletQuality, WalletTrade
@@ -68,18 +68,36 @@ class CopyEngine:
         if market.minutes_to_resolution > self.config.filters.max_minutes_to_resolution:
             return None
 
-        side_counts = Counter(trade.side.upper() for trade in valid_trades)
-        side, _ = side_counts.most_common(1)[0]
-        aligned = [trade for trade in valid_trades if trade.side.upper() == side]
+        wallet_votes = self._latest_wallet_votes(valid_trades)
+        weighted_by_side: dict[str, float] = defaultdict(float)
+        raw_by_side: Counter = Counter()
+        for trade in wallet_votes.values():
+            side = trade.side.upper()
+            weighted_by_side[side] += self._trade_weight(trade, wallet_qualities)
+            raw_by_side[side] += 1
+
+        if not weighted_by_side:
+            return None
+        side = max(weighted_by_side, key=weighted_by_side.get)
+        aligned = [trade for trade in wallet_votes.values() if trade.side.upper() == side]
         if not aligned:
             return None
 
         aligned_wallets = sorted({trade.wallet for trade in aligned})
         consensus_ratio = len(aligned_wallets) / len(basket.wallets)
+        total_weight = sum(weighted_by_side.values())
+        aligned_weight = weighted_by_side[side]
+        weighted_consensus = round(aligned_weight / total_weight, 4) if total_weight else 0.0
         if consensus_ratio < basket.quorum_ratio:
             return None
+        if weighted_consensus < self.config.consensus.min_weighted_consensus:
+            return None
 
-        reference_price = sum(trade.price for trade in aligned) / len(aligned)
+        confidence_score = self._confidence_score(aligned_weight, total_weight)
+        if confidence_score < self.config.consensus.min_confidence_score:
+            return None
+
+        reference_price = self._weighted_reference_price(aligned, wallet_qualities)
         current_price = market.yes_ask if side == "YES" else market.no_ask
         drift = abs(current_price - reference_price)
         if drift > self.config.filters.max_price_drift:
@@ -91,8 +109,10 @@ class CopyEngine:
         side_spread = market.yes_spread if side == "YES" else market.no_spread
         side_ask_size = market.yes_ask_size if side == "YES" else market.no_ask_size
         side_depth_usd = side_ask_size * current_price
-        copyability_score = compute_copyability_score(
-            consensus_ratio=consensus_ratio,
+        conflict_penalty = self._conflict_penalty(aligned_weight, total_weight)
+        recency_score = self._recency_score(aligned)
+        base_score = compute_copyability_score(
+            consensus_ratio=weighted_consensus,
             wallet_quality_score=wallet_quality_score,
             average_age_seconds=average_age,
             drift=drift,
@@ -101,6 +121,8 @@ class CopyEngine:
             side_depth_usd=side_depth_usd,
             filters=self.config.filters,
         )
+        copyability_score = round(max(0.0, min(1.0, (base_score * 0.75) + (confidence_score * 0.15) + (recency_score * 0.10) - conflict_penalty)), 4)
+        suggested_position_usd = self._suggested_position_size(current_price, confidence_score, copyability_score)
 
         return CopyCandidate(
             topic=topic,
@@ -113,5 +135,62 @@ class CopyEngine:
             source_wallets=aligned_wallets,
             wallet_quality_score=wallet_quality_score,
             copyability_score=copyability_score,
-            reason="basket consensus, quality scoring, age, liquidity, drift, and orderbook filters passed",
+            reason="weighted basket consensus, confidence, recency, liquidity, drift, and orderbook filters passed",
+            weighted_consensus=weighted_consensus,
+            confidence_score=confidence_score,
+            conflict_penalty=conflict_penalty,
+            recency_score=recency_score,
+            suggested_position_usd=suggested_position_usd,
         )
+
+    def _latest_wallet_votes(self, trades: list[WalletTrade]) -> dict[str, WalletTrade]:
+        latest: dict[str, WalletTrade] = {}
+        for trade in trades:
+            existing = latest.get(trade.wallet)
+            if existing is None or trade.age_seconds < existing.age_seconds:
+                latest[trade.wallet] = trade
+        return latest
+
+    def _trade_weight(self, trade: WalletTrade, wallet_qualities: dict[str, WalletQuality]) -> float:
+        quality = wallet_qualities.get(trade.wallet)
+        quality_weight = quality.score if quality is not None else 0.5
+        recency_weight = 0.5 ** (trade.age_seconds / self.config.consensus.recency_half_life_seconds)
+        size_weight = min(max(trade.size_usd / max(self.config.filters.min_position_size_usd, 1.0), 0.25), 3.0)
+        return max(quality_weight * recency_weight * size_weight, 0.0001)
+
+    def _weighted_reference_price(self, trades: list[WalletTrade], wallet_qualities: dict[str, WalletQuality]) -> float:
+        weighted_sum = 0.0
+        total_weight = 0.0
+        for trade in trades:
+            weight = self._trade_weight(trade, wallet_qualities)
+            weighted_sum += trade.price * weight
+            total_weight += weight
+        return weighted_sum / total_weight if total_weight else sum(trade.price for trade in trades) / len(trades)
+
+    def _confidence_score(self, aligned_weight: float, total_weight: float) -> float:
+        prior = self.config.consensus.confidence_prior_strength
+        posterior_mean = (aligned_weight + prior * 0.5) / (total_weight + prior) if total_weight + prior else 0.0
+        sample_strength = min(total_weight / (total_weight + prior), 1.0) if total_weight + prior else 0.0
+        return round(max(0.0, min(1.0, posterior_mean * sample_strength)), 4)
+
+    def _conflict_penalty(self, aligned_weight: float, total_weight: float) -> float:
+        if total_weight <= 0:
+            return 0.0
+        conflict_ratio = max(0.0, 1.0 - (aligned_weight / total_weight))
+        return round(conflict_ratio * self.config.consensus.conflict_penalty_weight, 4)
+
+    def _recency_score(self, trades: list[WalletTrade]) -> float:
+        if not trades:
+            return 0.0
+        weights = [0.5 ** (trade.age_seconds / self.config.consensus.recency_half_life_seconds) for trade in trades]
+        return round(sum(weights) / len(weights), 4)
+
+    def _suggested_position_size(self, price: float, confidence_score: float, copyability_score: float) -> float:
+        if price <= 0 or price >= 1:
+            return 0.0
+        b = (1.0 - price) / price
+        p = max(0.0, min(1.0, (confidence_score + copyability_score) / 2.0))
+        q = 1.0 - p
+        kelly_fraction = max(0.0, ((b * p) - q) / b) if b > 0 else 0.0
+        raw_size = self.config.consensus.bankroll_usd * kelly_fraction * self.config.consensus.kelly_fraction
+        return round(min(max(raw_size, 0.0), self.config.consensus.max_suggested_position_usd), 4)

--- a/src/predictcel/models.py
+++ b/src/predictcel/models.py
@@ -60,6 +60,11 @@ class CopyCandidate:
     wallet_quality_score: float
     copyability_score: float
     reason: str
+    weighted_consensus: float = 0.0
+    confidence_score: float = 0.0
+    conflict_penalty: float = 0.0
+    recency_score: float = 0.0
+    suggested_position_usd: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -1,7 +1,10 @@
+from dataclasses import replace
+
 from predictcel.config import (
     ArbitrageConfig,
     AppConfig,
     BasketRule,
+    ConsensusConfig,
     ExecutionConfig,
     ExposureConfig,
     FilterConfig,
@@ -12,7 +15,7 @@ from predictcel.copy_engine import CopyEngine
 from predictcel.models import MarketSnapshot, WalletQuality, WalletTrade
 
 
-def make_config() -> AppConfig:
+def make_config(consensus: ConsensusConfig | None = None) -> AppConfig:
     return AppConfig(
         baskets=[BasketRule(topic="geopolitics", wallets=["w1", "w2", "w3"], quorum_ratio=0.66)],
         filters=FilterConfig(
@@ -50,7 +53,34 @@ def make_config() -> AppConfig:
             max_retries=3,
             retry_base_delay_seconds=1.0,
         ),
+        consensus=consensus or ConsensusConfig(min_confidence_score=0.35),
     )
+
+
+def make_market() -> MarketSnapshot:
+    return MarketSnapshot(
+        market_id="m1",
+        topic="unknown",
+        title="Example",
+        yes_ask=0.61,
+        no_ask=0.42,
+        best_bid=0.59,
+        liquidity_usd=10000,
+        minutes_to_resolution=180,
+        yes_ask_size=250,
+        no_ask_size=220,
+        yes_spread=0.02,
+        no_spread=0.03,
+        orderbook_ready=True,
+    )
+
+
+def make_qualities() -> dict[str, WalletQuality]:
+    return {
+        "w1": WalletQuality(wallet="w1", topic="geopolitics", score=0.8, eligible_trade_count=3, average_age_seconds=500, average_drift=0.01, reason="test"),
+        "w2": WalletQuality(wallet="w2", topic="geopolitics", score=0.7, eligible_trade_count=2, average_age_seconds=700, average_drift=0.02, reason="test"),
+        "w3": WalletQuality(wallet="w3", topic="geopolitics", score=0.3, eligible_trade_count=2, average_age_seconds=900, average_drift=0.03, reason="test"),
+    }
 
 
 def test_emits_candidate_when_quorum_and_drift_pass() -> None:
@@ -59,35 +89,18 @@ def test_emits_candidate_when_quorum_and_drift_pass() -> None:
         WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.58, size_usd=200, age_seconds=600),
         WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.6, size_usd=220, age_seconds=800),
     ]
-    markets = {
-        "m1": MarketSnapshot(
-            market_id="m1",
-            topic="unknown",
-            title="Example",
-            yes_ask=0.61,
-            no_ask=0.42,
-            best_bid=0.59,
-            liquidity_usd=10000,
-            minutes_to_resolution=180,
-            yes_ask_size=250,
-            no_ask_size=220,
-            yes_spread=0.02,
-            no_spread=0.03,
-            orderbook_ready=True,
-        )
-    }
-    wallet_qualities = {
-        "w1": WalletQuality(wallet="w1", topic="geopolitics", score=0.8, eligible_trade_count=3, average_age_seconds=500, average_drift=0.01, reason="test"),
-        "w2": WalletQuality(wallet="w2", topic="geopolitics", score=0.7, eligible_trade_count=2, average_age_seconds=700, average_drift=0.02, reason="test"),
-    }
 
-    candidates = engine.evaluate(trades, markets, wallet_qualities)
+    candidates = engine.evaluate(trades, {"m1": make_market()}, make_qualities())
 
     assert len(candidates) == 1
     assert candidates[0].side == "YES"
     assert candidates[0].market_id == "m1"
     assert candidates[0].topic == "geopolitics"
     assert candidates[0].wallet_quality_score == 0.75
+    assert candidates[0].weighted_consensus >= 0.6
+    assert candidates[0].confidence_score > 0
+    assert candidates[0].recency_score > 0
+    assert candidates[0].suggested_position_usd >= 0
     assert candidates[0].copyability_score > 0
 
 
@@ -97,24 +110,53 @@ def test_skips_candidate_when_drift_is_too_large() -> None:
         WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.4, size_usd=200, age_seconds=600),
         WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.41, size_usd=220, age_seconds=800),
     ]
-    markets = {
-        "m1": MarketSnapshot(
-            market_id="m1",
-            topic="unknown",
-            title="Example",
-            yes_ask=0.61,
-            no_ask=0.42,
-            best_bid=0.59,
-            liquidity_usd=10000,
-            minutes_to_resolution=180,
-            yes_ask_size=250,
-            no_ask_size=220,
-            yes_spread=0.02,
-            no_spread=0.03,
-            orderbook_ready=True,
-        )
-    }
 
-    candidates = engine.evaluate(trades, markets, {})
+    candidates = engine.evaluate(trades, {"m1": make_market()}, {})
 
     assert candidates == []
+
+
+def test_weighted_consensus_can_reject_raw_quorum_with_stale_low_quality_votes() -> None:
+    consensus = ConsensusConfig(min_weighted_consensus=0.75, min_confidence_score=0.20, recency_half_life_seconds=600)
+    engine = CopyEngine(make_config(consensus))
+    trades = [
+        WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.59, size_usd=100, age_seconds=3400),
+        WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.6, size_usd=100, age_seconds=3400),
+        WalletTrade(wallet="w3", topic="geopolitics", market_id="m1", side="NO", price=0.41, size_usd=300, age_seconds=60),
+    ]
+
+    candidates = engine.evaluate(trades, {"m1": make_market()}, make_qualities())
+
+    assert candidates == []
+
+
+def test_conflicting_vote_reduces_copyability_score() -> None:
+    consensus = ConsensusConfig(min_weighted_consensus=0.50, min_confidence_score=0.20, conflict_penalty_weight=0.25)
+    engine = CopyEngine(make_config(consensus))
+    base_trades = [
+        WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.58, size_usd=200, age_seconds=300),
+        WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.59, size_usd=200, age_seconds=300),
+    ]
+    conflict_trades = base_trades + [
+        WalletTrade(wallet="w3", topic="geopolitics", market_id="m1", side="NO", price=0.41, size_usd=100, age_seconds=300),
+    ]
+
+    clean = engine.evaluate(base_trades, {"m1": make_market()}, make_qualities())[0]
+    conflicted = engine.evaluate(conflict_trades, {"m1": make_market()}, make_qualities())[0]
+
+    assert conflicted.conflict_penalty > clean.conflict_penalty
+    assert conflicted.copyability_score < clean.copyability_score
+
+
+def test_suggested_position_size_is_capped() -> None:
+    consensus = ConsensusConfig(min_confidence_score=0.20, bankroll_usd=1000.0, kelly_fraction=1.0, max_suggested_position_usd=12.0)
+    engine = CopyEngine(make_config(consensus))
+    market = replace(make_market(), yes_ask=0.40)
+    trades = [
+        WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.39, size_usd=300, age_seconds=60),
+        WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.40, size_usd=300, age_seconds=60),
+    ]
+
+    candidate = engine.evaluate(trades, {"m1": market}, make_qualities())[0]
+
+    assert candidate.suggested_position_usd <= 12.0


### PR DESCRIPTION
## Summary
- Add configurable consensus controls for recency half-life, weighted consensus threshold, Bayesian-style confidence, conflict penalty, and advisory Kelly-style sizing.
- Extend copy candidates with weighted consensus, confidence, conflict penalty, recency score, and suggested position size fields.
- Replace raw side-count consensus internals with latest-wallet-vote, quality/recency/size-weighted consensus while preserving the existing `CopyEngine.evaluate(...)` API.
- Add tests for weighted quorum rejection, conflict penalties, advisory position sizing caps, and existing drift/quorum behavior.

## Scope intentionally deferred
- No live execution sizing changes, dynamic basket rotation, regime-aware wallet performance, or parameter optimization in this PR.

## Testing
- Not run locally; implemented directly on GitHub per repo workflow request.