### PR TITLE
Fix Railpack requirements install phase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-# Default installs are paper/test safe. Install live trading support explicitly with:
-# pip install -e .[trade]
--e .
+# Intentionally empty for Railway/Railpack auto-detection.
+# Railpack runs this file before copying the full app, so do not put `-e .` here.
+# The real build install is defined in railway.toml:
+# pip install -e .[dev]
+# Live trading support remains explicit: pip install -e .[trade]


### PR DESCRIPTION
## Summary
- Remove `-e .` from `requirements.txt` because Railpack runs `pip install -r requirements.txt` before the full app source is copied.
- Keep the real editable dev install in `railway.toml` via `pip install -e .[dev] && python -m pytest`.

## Why
Railway failed during `pip install -r requirements.txt` with `README.md cannot be found` and `src does not exist`, which happens because the requirements phase only has partial files available.

## Testing
Not run locally; this directly addresses the Railway log error.