### PR TITLE
Fix arbitrage rejection test fixtures

### DIFF
--- a/tests/test_arb_sidecar.py
+++ b/tests/test_arb_sidecar.py
@@ -58,7 +58,7 @@ def test_skips_when_costs_destroy_net_edge() -> None:
         ArbitrageConfig(
             min_gross_edge=0.02,
             min_liquidity_usd=5000,
-            variable_cost_rate=0.03,
+            variable_cost_rate=0.05,
             slippage_rate=0.01,
         )
     )
@@ -74,7 +74,7 @@ def test_skips_when_min_profitable_position_exceeds_cap() -> None:
         ArbitrageConfig(
             min_gross_edge=0.02,
             min_liquidity_usd=5000,
-            gas_cost_per_tx_usd=1.0,
+            gas_cost_per_tx_usd=2.0,
             settlement_tx_count=2,
             max_position_usd=50.0,
         )


### PR DESCRIPTION
## Summary
- Adjust arbitrage test fixture inputs so they actually trigger the intended rejection paths.
- Raise variable+slippage costs above gross edge for the net-edge rejection test.
- Raise fixed gas cost enough for minimum profitable position to exceed the configured cap.

## Why
Railway reached pytest successfully, but two tests failed because their fixture values still produced valid arbitrage opportunities under the enhanced formulas.

## Testing
Railway reported 27 passing tests and 2 failing tests before this patch. This patch targets those two fixtures.