### PR TITLE
Add auto-updating wallet discovery and market regime scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ It still does not place trades.
 python -m predictcel.main --config config/predictcel.example.json --db predictcel.db --live-data
 ```
 
+### Wallet discovery reports
+
+Wallet discovery is report-only by default. It reads candidate wallets from public Polymarket data, classifies their trade topics, scores candidate quality, recommends basket assignments, and writes JSON plans without changing your config.
+
+```bash
+python -m predictcel.main discover-wallets --config config/predictcel.example.json --output-dir data
+```
+
+The command writes:
+- `wallet_discovery_report.json` for scored candidates and rejection reasons
+- `basket_assignments.json` for topic affinities and recommended baskets
+- `basket_manager_plan.json` for proposed add/observe actions
+
 ### Guarded live trading mode
 
 This path remains opt-in and should be treated carefully.
@@ -142,6 +155,11 @@ The Railway worker catches per-cycle exceptions, logs JSON events, waits for the
 - `src/predictcel/scoring.py` - wallet quality and copyability scoring
 - `src/predictcel/copy_engine.py` - basket-consensus paper signal engine
 - `src/predictcel/arb_sidecar.py` - simple arbitrage scanner
+- `src/predictcel/wallet_topics.py` - wallet topic classification from trade metadata
+- `src/predictcel/wallet_sources.py` - public wallet source adapters
+- `src/predictcel/wallet_discovery.py` - wallet discovery pipeline and JSON reports
+- `src/predictcel/basket_assignment.py` - wallet-to-basket assignment scoring
+- `src/predictcel/basket_manager.py` - report-only basket action planner
 - `src/predictcel/execution.py` - execution planning and guarded live order submission
 - `src/predictcel/storage.py` - SQLite logging, positions, and duplicate-signal fingerprints
 - `src/predictcel/main.py` - CLI entrypoint

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current version is intentionally small and safe:
 Instead, V1 focuses on the alpha layer we actually want to test:
 - topic baskets of source wallets
 - quorum-based consensus signals
-- copyability filters like drift, liquidity, category match, and orderbook quality
+- copyability filters like drift, liquidity, category match, orderbook quality, and market regime
 - wallet quality ranking from recent behavior
 - deterministic arbitrage detection from market snapshots
 
@@ -29,6 +29,7 @@ Instead, V1 focuses on the alpha layer we actually want to test:
   - live public Polymarket read mode
 - evaluates wallet quality from recent eligible trades
 - evaluates basket consensus per market
+- classifies copy-signal markets as trend, range, transition, or unstable regimes
 - emits paper-mode copy candidates with copyability scores
 - scans for simple YES/NO underpricing opportunities
 - can plan live copy orders from top-ranked signals
@@ -77,9 +78,9 @@ It still does not place trades.
 python -m predictcel.main --config config/predictcel.example.json --db predictcel.db --live-data
 ```
 
-### Wallet discovery reports
+### Wallet discovery and basket auto-update
 
-Wallet discovery is report-only by default. It reads candidate wallets from public Polymarket data, classifies their trade topics, scores candidate quality, recommends basket assignments, and writes JSON plans without changing your config.
+Wallet discovery defaults to `auto_update`. It reads candidate wallets from public Polymarket data, classifies their trade topics, scores candidate quality, recommends basket assignments, writes JSON reports, and appends approved `add` actions to the configured basket JSON.
 
 ```bash
 python -m predictcel.main discover-wallets --config config/predictcel.example.json --output-dir data
@@ -88,7 +89,12 @@ python -m predictcel.main discover-wallets --config config/predictcel.example.js
 The command writes:
 - `wallet_discovery_report.json` for scored candidates and rejection reasons
 - `basket_assignments.json` for topic affinities and recommended baskets
-- `basket_manager_plan.json` for proposed add/observe actions
+- `basket_manager_plan.json` for add/observe actions
+- `updated_config` when `wallet_discovery.mode` is `auto_update`
+
+Use `wallet_discovery.mode: "propose_config"` to write `predictcel.proposed.json` without touching the source config. Use `wallet_discovery.mode: "report_only"` to write reports only.
+
+Use `--config-output path/to/config.json` to send auto-updated or proposed config output to a separate file.
 
 ### Guarded live trading mode
 
@@ -153,13 +159,13 @@ The Railway worker catches per-cycle exceptions, logs JSON events, waits for the
 - `src/predictcel/wallets.py` - file-backed wallet trade loading
 - `src/predictcel/polymarket.py` - public Polymarket live ingestion, token normalization, retries, and orderbook enrichment
 - `src/predictcel/scoring.py` - wallet quality and copyability scoring
-- `src/predictcel/copy_engine.py` - basket-consensus paper signal engine
+- `src/predictcel/copy_engine.py` - basket-consensus paper signal engine with market regime scoring
 - `src/predictcel/arb_sidecar.py` - simple arbitrage scanner
 - `src/predictcel/wallet_topics.py` - wallet topic classification from trade metadata
 - `src/predictcel/wallet_sources.py` - public wallet source adapters
-- `src/predictcel/wallet_discovery.py` - wallet discovery pipeline and JSON reports
+- `src/predictcel/wallet_discovery.py` - wallet discovery pipeline, JSON reports, and config mutation
 - `src/predictcel/basket_assignment.py` - wallet-to-basket assignment scoring
-- `src/predictcel/basket_manager.py` - report-only basket action planner
+- `src/predictcel/basket_manager.py` - basket action planner
 - `src/predictcel/execution.py` - execution planning and guarded live order submission
 - `src/predictcel/storage.py` - SQLite logging, positions, and duplicate-signal fingerprints
 - `src/predictcel/main.py` - CLI entrypoint
@@ -180,6 +186,7 @@ Copyability score is currently based on:
 - available market liquidity
 - side-specific spread from the public order book
 - side-specific top-of-book ask depth
+- market regime score from trend/range/unstable classification
 
 These are intentionally simple V1 heuristics. They are meant to rank and filter, not to pretend we already have production alpha.
 

--- a/config/predictcel.example.json
+++ b/config/predictcel.example.json
@@ -42,9 +42,19 @@
     "kelly_fraction": 0.25,
     "max_suggested_position_usd": 10.0
   },
+  "market_regime": {
+    "enabled": true,
+    "trend_price_skew": 0.15,
+    "range_price_skew": 0.08,
+    "max_stable_spread": 0.06,
+    "min_depth_usd": 50.0,
+    "trend_bonus": 0.05,
+    "range_bonus": 0.02,
+    "unstable_penalty": 0.10
+  },
   "wallet_discovery": {
     "enabled": true,
-    "mode": "report_only",
+    "mode": "auto_update",
     "candidate_limit": 100,
     "trade_limit_per_wallet": 100,
     "min_trades": 20,

--- a/config/predictcel.example.json
+++ b/config/predictcel.example.json
@@ -42,6 +42,27 @@
     "kelly_fraction": 0.25,
     "max_suggested_position_usd": 10.0
   },
+  "wallet_discovery": {
+    "enabled": true,
+    "mode": "report_only",
+    "candidate_limit": 100,
+    "trade_limit_per_wallet": 100,
+    "min_trades": 20,
+    "min_recent_trades": 5,
+    "recent_window_seconds": 2592000,
+    "min_avg_trade_size_usd": 10.0,
+    "min_assignment_score": 0.50,
+    "exclude_existing_wallets": true,
+    "max_wallets_per_basket": 20,
+    "max_new_wallets_per_run": 3,
+    "topics": {
+      "geopolitics": ["election", "trump", "biden", "war", "federal", "senate", "president"],
+      "sports": ["nba", "nfl", "mlb", "nhl", "ufc", "soccer", "football", "tennis"],
+      "crypto": ["btc", "eth", "sol", "bitcoin", "ethereum", "crypto"],
+      "macro": ["economy", "gdp", "inflation", "rates", "stock", "fed", "recession"],
+      "weather": ["weather", "rain", "snow", "hurricane", "temperature", "storm"]
+    }
+  },
   "baskets": [
     {
       "topic": "geopolitics",

--- a/src/predictcel/basket_assignment.py
+++ b/src/predictcel/basket_assignment.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from .config import WalletDiscoveryConfig
+from .models import BasketAssignment, WalletDiscoveryCandidate
+
+
+class BasketAssignmentEngine:
+    def __init__(self, config: WalletDiscoveryConfig) -> None:
+        self.config = config
+
+    def assign(self, candidate: WalletDiscoveryCandidate) -> BasketAssignment:
+        recommended = [
+            topic
+            for topic, affinity in candidate.topic_profile.topic_affinities.items()
+            if topic in self.config.topics and affinity >= 0.15
+        ]
+        if not recommended and candidate.topic_profile.primary_topic in self.config.topics:
+            recommended = [candidate.topic_profile.primary_topic]
+
+        confidence = self._confidence(candidate.score)
+        reasons = [
+            f"primary_topic={candidate.topic_profile.primary_topic}",
+            f"specialization={candidate.topic_profile.specialization_score:.4f}",
+            f"recent_trades={candidate.recent_trades}",
+            f"avg_trade_size_usd={candidate.avg_trade_size_usd:.2f}",
+        ]
+        if candidate.rejected_reasons:
+            reasons.extend(f"warning={reason}" for reason in candidate.rejected_reasons)
+
+        return BasketAssignment(
+            wallet_address=candidate.wallet_address,
+            primary_topic=candidate.topic_profile.primary_topic,
+            recommended_baskets=recommended[:3],
+            topic_affinities=candidate.topic_profile.topic_affinities,
+            overall_score=round(candidate.score, 4),
+            confidence=confidence,
+            reasons=reasons,
+        )
+
+    def _confidence(self, score: float) -> str:
+        if score >= 0.70:
+            return "HIGH"
+        if score >= 0.50:
+            return "MEDIUM"
+        return "LOW"

--- a/src/predictcel/basket_manager.py
+++ b/src/predictcel/basket_manager.py
@@ -32,13 +32,21 @@ class BasketManagerPlanner:
                 if added_by_basket.get(basket, 0) >= self.config.wallet_discovery.max_new_wallets_per_run:
                     actions.append(self._action("observe", basket, assignment, "max new wallets per run reached"))
                     continue
-                actions.append(self._action("add", basket, assignment, "report-only recommendation; manual approval required"))
+                actions.append(self._action("add", basket, assignment, self._add_reason()))
                 added_by_basket[basket] = added_by_basket.get(basket, 0) + 1
                 added = True
             if not added and not assignment.recommended_baskets:
                 actions.append(self._action("observe", assignment.primary_topic, assignment, "no configured basket matched topic profile"))
 
         return actions
+
+    def _add_reason(self) -> str:
+        mode = self.config.wallet_discovery.mode
+        if mode == "auto_update":
+            return "auto-update eligible recommendation"
+        if mode == "propose_config":
+            return "config proposal recommendation"
+        return "report-only recommendation; manual approval required"
 
     def _action(self, action: str, basket: str, assignment: BasketAssignment, reason: str) -> BasketManagerAction:
         return BasketManagerAction(

--- a/src/predictcel/basket_manager.py
+++ b/src/predictcel/basket_manager.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from .config import AppConfig
+from .models import BasketAssignment, BasketManagerAction
+
+
+class BasketManagerPlanner:
+    def __init__(self, config: AppConfig) -> None:
+        self.config = config
+        self.current_by_topic = {basket.topic: {wallet.lower() for wallet in basket.wallets} for basket in config.baskets}
+
+    def plan(self, assignments: list[BasketAssignment]) -> list[BasketManagerAction]:
+        actions: list[BasketManagerAction] = []
+        added_by_basket: dict[str, int] = {topic: 0 for topic in self.current_by_topic}
+
+        for assignment in sorted(assignments, key=lambda item: item.overall_score, reverse=True):
+            if assignment.overall_score < self.config.wallet_discovery.min_assignment_score:
+                actions.append(self._action("observe", assignment.primary_topic, assignment, "below assignment score threshold"))
+                continue
+            if assignment.confidence == "LOW":
+                actions.append(self._action("observe", assignment.primary_topic, assignment, "low confidence assignment"))
+                continue
+
+            added = False
+            for basket in assignment.recommended_baskets:
+                current = self.current_by_topic.get(basket, set())
+                if assignment.wallet_address.lower() in current:
+                    continue
+                if len(current) + added_by_basket.get(basket, 0) >= self.config.wallet_discovery.max_wallets_per_basket:
+                    actions.append(self._action("observe", basket, assignment, "basket is at max wallet capacity"))
+                    continue
+                if added_by_basket.get(basket, 0) >= self.config.wallet_discovery.max_new_wallets_per_run:
+                    actions.append(self._action("observe", basket, assignment, "max new wallets per run reached"))
+                    continue
+                actions.append(self._action("add", basket, assignment, "report-only recommendation; manual approval required"))
+                added_by_basket[basket] = added_by_basket.get(basket, 0) + 1
+                added = True
+            if not added and not assignment.recommended_baskets:
+                actions.append(self._action("observe", assignment.primary_topic, assignment, "no configured basket matched topic profile"))
+
+        return actions
+
+    def _action(self, action: str, basket: str, assignment: BasketAssignment, reason: str) -> BasketManagerAction:
+        return BasketManagerAction(
+            action=action,
+            basket=basket,
+            wallet_address=assignment.wallet_address,
+            score=assignment.overall_score,
+            confidence=assignment.confidence,
+            reason=reason,
+        )

--- a/src/predictcel/config.py
+++ b/src/predictcel/config.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def _default_topic_keywords() -> dict[str, list[str]]:
+    return {
+        "geopolitics": ["election", "trump", "biden", "war", "federal", "senate", "president"],
+        "sports": ["nba", "nfl", "mlb", "nhl", "ufc", "soccer", "football", "tennis"],
+        "crypto": ["btc", "eth", "sol", "bitcoin", "ethereum", "crypto"],
+        "macro": ["economy", "gdp", "inflation", "rates", "stock", "fed", "recession"],
+        "weather": ["weather", "rain", "snow", "hurricane", "temperature", "storm"],
+    }
 
 
 @dataclass(frozen=True)
@@ -32,6 +42,23 @@ class ConsensusConfig:
     bankroll_usd: float = 100.0
     kelly_fraction: float = 0.25
     max_suggested_position_usd: float = 10.0
+
+
+@dataclass(frozen=True)
+class WalletDiscoveryConfig:
+    enabled: bool = False
+    mode: str = "report_only"
+    candidate_limit: int = 100
+    trade_limit_per_wallet: int = 100
+    min_trades: int = 20
+    min_recent_trades: int = 5
+    recent_window_seconds: int = 2_592_000
+    min_avg_trade_size_usd: float = 10.0
+    min_assignment_score: float = 0.50
+    exclude_existing_wallets: bool = True
+    max_wallets_per_basket: int = 20
+    max_new_wallets_per_run: int = 3
+    topics: dict[str, list[str]] = field(default_factory=_default_topic_keywords)
 
 
 @dataclass(frozen=True)
@@ -103,6 +130,7 @@ class AppConfig:
     live_data: LiveDataConfig | None
     execution: ExecutionConfig | None
     consensus: ConsensusConfig = ConsensusConfig()
+    wallet_discovery: WalletDiscoveryConfig = WalletDiscoveryConfig()
 
 
 class ConfigError(ValueError):
@@ -123,6 +151,7 @@ def load_config(path: str | Path) -> AppConfig:
     filters = FilterConfig(**payload["filters"])
     arbitrage = ArbitrageConfig(**payload["arbitrage"])
     consensus = ConsensusConfig(**payload.get("consensus", {}))
+    wallet_discovery = WalletDiscoveryConfig(**payload.get("wallet_discovery", {}))
     live_data_payload = payload.get("live_data")
     live_data = LiveDataConfig(**live_data_payload) if live_data_payload else None
     execution_payload = payload.get("execution")
@@ -159,6 +188,20 @@ def load_config(path: str | Path) -> AppConfig:
         raise ConfigError("consensus kelly_fraction must be between 0 and 1.")
     if consensus.max_suggested_position_usd <= 0:
         raise ConfigError("consensus max_suggested_position_usd must be positive.")
+    if wallet_discovery.mode not in {"report_only", "propose_config", "auto_update"}:
+        raise ConfigError("wallet_discovery mode must be report_only, propose_config, or auto_update.")
+    if wallet_discovery.candidate_limit <= 0 or wallet_discovery.trade_limit_per_wallet <= 0:
+        raise ConfigError("wallet_discovery candidate and trade limits must be positive.")
+    if wallet_discovery.min_trades < 0 or wallet_discovery.min_recent_trades < 0:
+        raise ConfigError("wallet_discovery trade filters must be non-negative.")
+    if wallet_discovery.recent_window_seconds <= 0:
+        raise ConfigError("wallet_discovery recent_window_seconds must be positive.")
+    if wallet_discovery.min_avg_trade_size_usd < 0:
+        raise ConfigError("wallet_discovery min_avg_trade_size_usd must be non-negative.")
+    if not 0 <= wallet_discovery.min_assignment_score <= 1:
+        raise ConfigError("wallet_discovery min_assignment_score must be between 0 and 1.")
+    if wallet_discovery.max_wallets_per_basket <= 0 or wallet_discovery.max_new_wallets_per_run <= 0:
+        raise ConfigError("wallet_discovery basket limits must be positive.")
     if arbitrage.min_gross_edge <= 0:
         raise ConfigError("min_gross_edge must be positive.")
     if arbitrage.min_liquidity_usd < 0:
@@ -225,6 +268,7 @@ def load_config(path: str | Path) -> AppConfig:
         live_data=live_data,
         execution=execution,
         consensus=consensus,
+        wallet_discovery=wallet_discovery,
     )
 
 

--- a/src/predictcel/config.py
+++ b/src/predictcel/config.py
@@ -45,9 +45,21 @@ class ConsensusConfig:
 
 
 @dataclass(frozen=True)
+class MarketRegimeConfig:
+    enabled: bool = True
+    trend_price_skew: float = 0.15
+    range_price_skew: float = 0.08
+    max_stable_spread: float = 0.06
+    min_depth_usd: float = 50.0
+    trend_bonus: float = 0.05
+    range_bonus: float = 0.02
+    unstable_penalty: float = 0.10
+
+
+@dataclass(frozen=True)
 class WalletDiscoveryConfig:
     enabled: bool = False
-    mode: str = "report_only"
+    mode: str = "auto_update"
     candidate_limit: int = 100
     trade_limit_per_wallet: int = 100
     min_trades: int = 20
@@ -130,6 +142,7 @@ class AppConfig:
     live_data: LiveDataConfig | None
     execution: ExecutionConfig | None
     consensus: ConsensusConfig = ConsensusConfig()
+    market_regime: MarketRegimeConfig = MarketRegimeConfig()
     wallet_discovery: WalletDiscoveryConfig = WalletDiscoveryConfig()
 
 
@@ -151,6 +164,7 @@ def load_config(path: str | Path) -> AppConfig:
     filters = FilterConfig(**payload["filters"])
     arbitrage = ArbitrageConfig(**payload["arbitrage"])
     consensus = ConsensusConfig(**payload.get("consensus", {}))
+    market_regime = MarketRegimeConfig(**payload.get("market_regime", {}))
     wallet_discovery = WalletDiscoveryConfig(**payload.get("wallet_discovery", {}))
     live_data_payload = payload.get("live_data")
     live_data = LiveDataConfig(**live_data_payload) if live_data_payload else None
@@ -188,6 +202,16 @@ def load_config(path: str | Path) -> AppConfig:
         raise ConfigError("consensus kelly_fraction must be between 0 and 1.")
     if consensus.max_suggested_position_usd <= 0:
         raise ConfigError("consensus max_suggested_position_usd must be positive.")
+    if not 0 <= market_regime.trend_price_skew <= 0.5:
+        raise ConfigError("market_regime trend_price_skew must be between 0 and 0.5.")
+    if not 0 <= market_regime.range_price_skew <= 0.5:
+        raise ConfigError("market_regime range_price_skew must be between 0 and 0.5.")
+    if market_regime.range_price_skew > market_regime.trend_price_skew:
+        raise ConfigError("market_regime range_price_skew cannot exceed trend_price_skew.")
+    if market_regime.max_stable_spread < 0 or market_regime.min_depth_usd < 0:
+        raise ConfigError("market_regime spread and depth thresholds must be non-negative.")
+    if market_regime.unstable_penalty < 0:
+        raise ConfigError("market_regime unstable_penalty must be non-negative.")
     if wallet_discovery.mode not in {"report_only", "propose_config", "auto_update"}:
         raise ConfigError("wallet_discovery mode must be report_only, propose_config, or auto_update.")
     if wallet_discovery.candidate_limit <= 0 or wallet_discovery.trade_limit_per_wallet <= 0:
@@ -268,6 +292,7 @@ def load_config(path: str | Path) -> AppConfig:
         live_data=live_data,
         execution=execution,
         consensus=consensus,
+        market_regime=market_regime,
         wallet_discovery=wallet_discovery,
     )
 

--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 
 from .config import AppConfig, BasketRule
-from .models import CopyCandidate, MarketSnapshot, WalletQuality, WalletTrade
+from .models import CopyCandidate, MarketRegime, MarketSnapshot, WalletQuality, WalletTrade
 from .scoring import compute_copyability_score
 
 
@@ -111,6 +111,7 @@ class CopyEngine:
         side_depth_usd = side_ask_size * current_price
         conflict_penalty = self._conflict_penalty(aligned_weight, total_weight)
         recency_score = self._recency_score(aligned)
+        regime = self._classify_market_regime(market, side, current_price, side_spread, side_depth_usd)
         base_score = compute_copyability_score(
             consensus_ratio=weighted_consensus,
             wallet_quality_score=wallet_quality_score,
@@ -121,7 +122,7 @@ class CopyEngine:
             side_depth_usd=side_depth_usd,
             filters=self.config.filters,
         )
-        copyability_score = round(max(0.0, min(1.0, (base_score * 0.75) + (confidence_score * 0.15) + (recency_score * 0.10) - conflict_penalty)), 4)
+        copyability_score = round(max(0.0, min(1.0, (base_score * 0.70) + (confidence_score * 0.15) + (recency_score * 0.10) + (regime.score * 0.05) - conflict_penalty)), 4)
         suggested_position_usd = self._suggested_position_size(current_price, confidence_score, copyability_score)
 
         return CopyCandidate(
@@ -135,12 +136,15 @@ class CopyEngine:
             source_wallets=aligned_wallets,
             wallet_quality_score=wallet_quality_score,
             copyability_score=copyability_score,
-            reason="weighted basket consensus, confidence, recency, liquidity, drift, and orderbook filters passed",
+            reason="weighted basket consensus, market regime, confidence, recency, liquidity, drift, and orderbook filters passed",
             weighted_consensus=weighted_consensus,
             confidence_score=confidence_score,
             conflict_penalty=conflict_penalty,
             recency_score=recency_score,
             suggested_position_usd=suggested_position_usd,
+            market_regime=regime.label,
+            regime_score=regime.score,
+            regime_reason=regime.reason,
         )
 
     def _latest_wallet_votes(self, trades: list[WalletTrade]) -> dict[str, WalletTrade]:
@@ -184,6 +188,26 @@ class CopyEngine:
             return 0.0
         weights = [0.5 ** (trade.age_seconds / self.config.consensus.recency_half_life_seconds) for trade in trades]
         return round(sum(weights) / len(weights), 4)
+
+    def _classify_market_regime(self, market: MarketSnapshot, side: str, current_price: float, side_spread: float, side_depth_usd: float) -> MarketRegime:
+        config = self.config.market_regime
+        if not config.enabled:
+            return MarketRegime("DISABLED", 0.5, "market regime scoring disabled")
+
+        if side_spread > config.max_stable_spread or side_depth_usd < config.min_depth_usd:
+            score = max(0.0, 0.5 - config.unstable_penalty)
+            return MarketRegime("UNSTABLE", round(score, 4), "spread or top-of-book depth failed stable regime thresholds")
+
+        skew = abs(current_price - 0.5)
+        if skew >= config.trend_price_skew:
+            directional_match = (side == "YES" and current_price > 0.5) or (side == "NO" and current_price > 0.5)
+            score = 0.75 + config.trend_bonus if directional_match else 0.60
+            return MarketRegime("TREND", round(min(score, 1.0), 4), "price is directionally skewed with stable orderbook conditions")
+
+        if skew <= config.range_price_skew:
+            return MarketRegime("RANGE", round(min(0.65 + config.range_bonus, 1.0), 4), "price is near the midpoint with stable two-sided conditions")
+
+        return MarketRegime("TRANSITION", 0.55, "price is between range and trend thresholds")
 
     def _suggested_position_size(self, price: float, confidence_score: float, copyability_score: float) -> float:
         if price <= 0 or price >= 1:

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from datetime import UTC, datetime
 from typing import Any
 
@@ -14,6 +15,7 @@ from .models import Position
 from .polymarket import PolymarketPublicClient, build_market_snapshots, build_wallet_trades, enrich_market_snapshots_with_orderbooks
 from .scoring import WalletQualityScorer
 from .storage import SignalStore
+from .wallet_discovery import WalletDiscoveryPipeline
 from .wallets import load_wallet_trades
 
 TRUSTED_POSITION_STATUSES = {"filled", "matched", "success", "submitted"}
@@ -28,7 +30,19 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def build_discovery_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="PredictCel wallet discovery reports")
+    parser.add_argument("discover-wallets")
+    parser.add_argument("--config", required=True, help="Path to config JSON file")
+    parser.add_argument("--output-dir", default="data", help="Directory for discovery JSON reports")
+    return parser
+
+
 def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "discover-wallets":
+        _run_wallet_discovery()
+        return
+
     args = build_parser().parse_args()
     config = load_config(args.config)
     use_live_data = bool(args.live_data or (config.live_data and config.live_data.enabled))
@@ -93,6 +107,13 @@ def main() -> None:
         "close_results": [result.__dict__ for result in close_results],
         "open_positions": [pos.__dict__ for pos in open_positions],
     }, indent=2, default=str))
+
+
+def _run_wallet_discovery() -> None:
+    args = build_discovery_parser().parse_args()
+    config = load_config(args.config)
+    files = WalletDiscoveryPipeline(config).write_reports(args.output_dir)
+    print(json.dumps({"mode": "wallet_discovery", "reports": files}, indent=2))
 
 
 def _persist_execution_side_effects(store: SignalStore, config: Any, execution_results: list) -> None:

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -32,7 +32,6 @@ def build_parser() -> argparse.ArgumentParser:
 
 def build_discovery_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="PredictCel wallet discovery reports")
-    parser.add_argument("discover-wallets")
     parser.add_argument("--config", required=True, help="Path to config JSON file")
     parser.add_argument("--output-dir", default="data", help="Directory for discovery JSON reports")
     return parser
@@ -40,7 +39,7 @@ def build_discovery_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "discover-wallets":
-        _run_wallet_discovery()
+        _run_wallet_discovery(sys.argv[2:])
         return
 
     args = build_parser().parse_args()
@@ -109,8 +108,8 @@ def main() -> None:
     }, indent=2, default=str))
 
 
-def _run_wallet_discovery() -> None:
-    args = build_discovery_parser().parse_args()
+def _run_wallet_discovery(argv: list[str]) -> None:
+    args = build_discovery_parser().parse_args(argv)
     config = load_config(args.config)
     files = WalletDiscoveryPipeline(config).write_reports(args.output_dir)
     print(json.dumps({"mode": "wallet_discovery", "reports": files}, indent=2))

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -34,6 +34,7 @@ def build_discovery_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="PredictCel wallet discovery reports")
     parser.add_argument("--config", required=True, help="Path to config JSON file")
     parser.add_argument("--output-dir", default="data", help="Directory for discovery JSON reports")
+    parser.add_argument("--config-output", default=None, help="Optional target for proposed or auto-updated config JSON")
     return parser
 
 
@@ -111,7 +112,7 @@ def main() -> None:
 def _run_wallet_discovery(argv: list[str]) -> None:
     args = build_discovery_parser().parse_args(argv)
     config = load_config(args.config)
-    files = WalletDiscoveryPipeline(config).write_reports(args.output_dir)
+    files = WalletDiscoveryPipeline(config).write_reports(args.output_dir, args.config, args.config_output)
     print(json.dumps({"mode": "wallet_discovery", "reports": files}, indent=2))
 
 

--- a/src/predictcel/models.py
+++ b/src/predictcel/models.py
@@ -48,6 +48,13 @@ class WalletQuality:
 
 
 @dataclass(frozen=True)
+class MarketRegime:
+    label: str
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
 class CopyCandidate:
     topic: str
     market_id: str
@@ -65,6 +72,9 @@ class CopyCandidate:
     conflict_penalty: float = 0.0
     recency_score: float = 0.0
     suggested_position_usd: float = 0.0
+    market_regime: str = "UNKNOWN"
+    regime_score: float = 0.0
+    regime_reason: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/predictcel/models.py
+++ b/src/predictcel/models.py
@@ -68,6 +68,47 @@ class CopyCandidate:
 
 
 @dataclass(frozen=True)
+class WalletTopicProfile:
+    topic_affinities: dict[str, float]
+    primary_topic: str
+    specialization_score: float
+
+
+@dataclass(frozen=True)
+class WalletDiscoveryCandidate:
+    wallet_address: str
+    source: str
+    total_trades: int
+    recent_trades: int
+    avg_trade_size_usd: float
+    topic_profile: WalletTopicProfile
+    score: float
+    confidence: str
+    rejected_reasons: list[str]
+
+
+@dataclass(frozen=True)
+class BasketAssignment:
+    wallet_address: str
+    primary_topic: str
+    recommended_baskets: list[str]
+    topic_affinities: dict[str, float]
+    overall_score: float
+    confidence: str
+    reasons: list[str]
+
+
+@dataclass(frozen=True)
+class BasketManagerAction:
+    action: str
+    basket: str
+    wallet_address: str
+    score: float
+    confidence: str
+    reason: str
+
+
+@dataclass(frozen=True)
 class ArbitrageOpportunity:
     market_id: str
     topic: str

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -189,7 +189,7 @@ def _extract_list(payload: Any) -> list[dict[str, Any]]:
     if isinstance(payload, list):
         return [item for item in payload if isinstance(item, dict)]
     if isinstance(payload, dict):
-        for key in ("data", "markets", "trades"):
+        for key in ("data", "markets", "trades", "users", "leaderboard", "results"):
             value = payload.get(key)
             if isinstance(value, list):
                 return [item for item in value if isinstance(item, dict)]

--- a/src/predictcel/wallet_discovery.py
+++ b/src/predictcel/wallet_discovery.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+import json
+
+from .basket_assignment import BasketAssignmentEngine
+from .basket_manager import BasketManagerPlanner
+from .config import AppConfig
+from .models import BasketAssignment, BasketManagerAction, WalletDiscoveryCandidate
+from .polymarket import PolymarketPublicClient
+from .wallet_sources import DataApiWalletSource
+from .wallet_topics import classify_wallet_topics
+
+
+class WalletDiscoveryPipeline:
+    def __init__(self, config: AppConfig) -> None:
+        self.config = config
+        live_data = config.live_data
+        self.client = PolymarketPublicClient(
+            gamma_base_url=live_data.gamma_base_url if live_data else "https://gamma-api.polymarket.com",
+            data_base_url=live_data.data_base_url if live_data else "https://data-api.polymarket.com",
+            clob_base_url=live_data.clob_base_url if live_data else "https://clob.polymarket.com",
+            timeout_seconds=live_data.request_timeout_seconds if live_data else 15,
+        )
+        self.source = DataApiWalletSource(self.client)
+        self.assignment_engine = BasketAssignmentEngine(config.wallet_discovery)
+        self.manager = BasketManagerPlanner(config)
+
+    def run(self) -> tuple[list[WalletDiscoveryCandidate], list[BasketAssignment], list[BasketManagerAction]]:
+        raw_candidates = self.source.fetch_candidates(self.config.wallet_discovery.candidate_limit)
+        existing = self._existing_wallets()
+        candidates: list[WalletDiscoveryCandidate] = []
+
+        seen: set[str] = set()
+        for raw in raw_candidates:
+            address = raw["address"].lower()
+            if address in seen:
+                continue
+            seen.add(address)
+            if self.config.wallet_discovery.exclude_existing_wallets and address in existing:
+                continue
+            trades = self._safe_fetch_trades(address)
+            candidates.append(self._build_candidate(address, raw.get("source", "unknown"), trades))
+
+        accepted = [candidate for candidate in candidates if not candidate.rejected_reasons]
+        assignments = [self.assignment_engine.assign(candidate) for candidate in accepted]
+        actions = self.manager.plan(assignments)
+        return candidates, assignments, actions
+
+    def write_reports(self, output_dir: str | Path) -> dict[str, str]:
+        candidates, assignments, actions = self.run()
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        files = {
+            "wallet_discovery_report": output_path / "wallet_discovery_report.json",
+            "basket_assignments": output_path / "basket_assignments.json",
+            "basket_manager_plan": output_path / "basket_manager_plan.json",
+        }
+        self._write_json(files["wallet_discovery_report"], [asdict(item) for item in candidates])
+        self._write_json(files["basket_assignments"], [asdict(item) for item in assignments])
+        self._write_json(files["basket_manager_plan"], [asdict(item) for item in actions])
+        return {name: str(path) for name, path in files.items()}
+
+    def _build_candidate(self, address: str, source: str, trades: list[dict[str, Any]]) -> WalletDiscoveryCandidate:
+        profile = classify_wallet_topics(trades, self.config.wallet_discovery.topics)
+        total_trades = len(trades)
+        recent_trades = sum(1 for trade in trades if _age_seconds(trade) <= self.config.wallet_discovery.recent_window_seconds)
+        avg_size = _average_trade_size(trades)
+        rejected = []
+        if total_trades < self.config.wallet_discovery.min_trades:
+            rejected.append("not enough total trades")
+        if recent_trades < self.config.wallet_discovery.min_recent_trades:
+            rejected.append("not enough recent trades")
+        if avg_size < self.config.wallet_discovery.min_avg_trade_size_usd:
+            rejected.append("average trade size too small")
+
+        score = self._candidate_score(profile.specialization_score, total_trades, recent_trades, avg_size)
+        return WalletDiscoveryCandidate(
+            wallet_address=address,
+            source=source,
+            total_trades=total_trades,
+            recent_trades=recent_trades,
+            avg_trade_size_usd=round(avg_size, 4),
+            topic_profile=profile,
+            score=score,
+            confidence=_confidence(score),
+            rejected_reasons=rejected,
+        )
+
+    def _candidate_score(self, specialization: float, total_trades: int, recent_trades: int, avg_size: float) -> float:
+        sample_score = min(total_trades / max(self.config.wallet_discovery.min_trades * 3, 1), 1.0)
+        recent_score = min(recent_trades / max(self.config.wallet_discovery.min_recent_trades * 3, 1), 1.0)
+        size_score = min(avg_size / max(self.config.wallet_discovery.min_avg_trade_size_usd * 5, 1.0), 1.0)
+        score = (specialization * 0.35) + (sample_score * 0.25) + (recent_score * 0.25) + (size_score * 0.15)
+        return round(max(0.0, min(score, 1.0)), 4)
+
+    def _safe_fetch_trades(self, address: str) -> list[dict[str, Any]]:
+        try:
+            return self.source.fetch_wallet_trades(address, self.config.wallet_discovery.trade_limit_per_wallet)
+        except Exception:
+            return []
+
+    def _existing_wallets(self) -> set[str]:
+        return {wallet.lower() for basket in self.config.baskets for wallet in basket.wallets}
+
+    def _write_json(self, path: Path, payload: Any) -> None:
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _average_trade_size(trades: list[dict[str, Any]]) -> float:
+    sizes = [float(trade.get("size") or trade.get("sizeUsd") or trade.get("amount") or 0.0) for trade in trades]
+    return sum(sizes) / len(sizes) if sizes else 0.0
+
+
+def _age_seconds(trade: dict[str, Any]) -> int:
+    value = trade.get("timestamp") or trade.get("createdAt") or trade.get("created_at")
+    if value is None:
+        return 10**9
+    try:
+        if isinstance(value, (int, float)):
+            dt = datetime.fromtimestamp(float(value), tz=UTC)
+        else:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return 10**9
+    return max(int((datetime.now(UTC) - dt).total_seconds()), 0)
+
+
+def _confidence(score: float) -> str:
+    if score >= 0.70:
+        return "HIGH"
+    if score >= 0.50:
+        return "MEDIUM"
+    return "LOW"

--- a/src/predictcel/wallet_discovery.py
+++ b/src/predictcel/wallet_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -50,7 +51,12 @@ class WalletDiscoveryPipeline:
         actions = self.manager.plan(assignments)
         return candidates, assignments, actions
 
-    def write_reports(self, output_dir: str | Path) -> dict[str, str]:
+    def write_reports(
+        self,
+        output_dir: str | Path,
+        config_path: str | Path | None = None,
+        config_output_path: str | Path | None = None,
+    ) -> dict[str, str]:
         candidates, assignments, actions = self.run()
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -62,7 +68,56 @@ class WalletDiscoveryPipeline:
         self._write_json(files["wallet_discovery_report"], [asdict(item) for item in candidates])
         self._write_json(files["basket_assignments"], [asdict(item) for item in assignments])
         self._write_json(files["basket_manager_plan"], [asdict(item) for item in actions])
+
+        mutation_path = self._write_mutated_config_if_enabled(output_path, actions, config_path, config_output_path)
+        if mutation_path is not None:
+            key = "updated_config" if self.config.wallet_discovery.mode == "auto_update" else "config_proposal"
+            files[key] = mutation_path
         return {name: str(path) for name, path in files.items()}
+
+    def build_mutated_config(self, payload: dict[str, Any], actions: list[BasketManagerAction]) -> dict[str, Any]:
+        updated = deepcopy(payload)
+        baskets = updated.get("baskets")
+        if not isinstance(baskets, list):
+            return updated
+
+        baskets_by_topic = {str(item.get("topic")): item for item in baskets if isinstance(item, dict)}
+        for action in actions:
+            if action.action != "add":
+                continue
+            basket = baskets_by_topic.get(action.basket)
+            if not basket:
+                continue
+            wallets = basket.setdefault("wallets", [])
+            if not isinstance(wallets, list):
+                continue
+            existing = {str(wallet).lower() for wallet in wallets}
+            if action.wallet_address.lower() not in existing:
+                wallets.append(action.wallet_address)
+        return updated
+
+    def _write_mutated_config_if_enabled(
+        self,
+        output_dir: Path,
+        actions: list[BasketManagerAction],
+        config_path: str | Path | None,
+        config_output_path: str | Path | None,
+    ) -> Path | None:
+        mode = self.config.wallet_discovery.mode
+        if mode == "report_only":
+            return None
+        if config_path is None:
+            return None
+
+        source_path = Path(config_path)
+        payload = json.loads(source_path.read_text(encoding="utf-8"))
+        mutated = self.build_mutated_config(payload, actions)
+        if mode == "auto_update":
+            target_path = Path(config_output_path) if config_output_path else source_path
+        else:
+            target_path = Path(config_output_path) if config_output_path else output_dir / "predictcel.proposed.json"
+        self._write_json(target_path, mutated)
+        return target_path
 
     def _build_candidate(self, address: str, source: str, trades: list[dict[str, Any]]) -> WalletDiscoveryCandidate:
         profile = classify_wallet_topics(trades, self.config.wallet_discovery.topics)
@@ -107,6 +162,7 @@ class WalletDiscoveryPipeline:
         return {wallet.lower() for basket in self.config.baskets for wallet in basket.wallets}
 
     def _write_json(self, path: Path, payload: Any) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 

--- a/src/predictcel/wallet_sources.py
+++ b/src/predictcel/wallet_sources.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .polymarket import PolymarketPublicClient
+
+
+class DataApiWalletSource:
+    def __init__(self, client: PolymarketPublicClient) -> None:
+        self.client = client
+
+    def fetch_candidates(self, limit: int) -> list[dict[str, Any]]:
+        raw_items = self.client.fetch_leaderboard(limit)
+        candidates: list[dict[str, Any]] = []
+        for item in raw_items:
+            address = extract_wallet_address(item)
+            if not address:
+                continue
+            candidates.append({"address": address.lower(), "source": "polymarket_data_api", "raw": item})
+        return candidates
+
+    def fetch_wallet_trades(self, address: str, limit: int) -> list[dict[str, Any]]:
+        return self.client.fetch_wallet_trades(address, limit)
+
+
+def extract_wallet_address(item: dict[str, Any]) -> str:
+    for key in ("address", "wallet", "walletAddress", "user", "userAddress", "proxyWallet", "proxy_wallet"):
+        value = item.get(key)
+        if value:
+            return str(value).strip()
+    profile = item.get("profile")
+    if isinstance(profile, dict):
+        for key in ("address", "proxyWallet", "wallet"):
+            value = profile.get(key)
+            if value:
+                return str(value).strip()
+    return ""

--- a/src/predictcel/wallet_topics.py
+++ b/src/predictcel/wallet_topics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from .models import WalletTopicProfile
+
+UNKNOWN_TOPIC = "other"
+
+
+def classify_wallet_topics(trades: list[dict[str, Any]], topic_keywords: dict[str, list[str]]) -> WalletTopicProfile:
+    counts: Counter[str] = Counter()
+    for trade in trades:
+        topic = _explicit_topic(trade)
+        if not topic or topic == "unknown":
+            topic = classify_trade_topic(trade, topic_keywords)
+        counts[topic] += 1
+
+    total = sum(counts.values())
+    if total <= 0:
+        return WalletTopicProfile(topic_affinities={UNKNOWN_TOPIC: 1.0}, primary_topic=UNKNOWN_TOPIC, specialization_score=1.0)
+
+    affinities = {topic: round(count / total, 4) for topic, count in counts.items()}
+    primary_topic = max(affinities, key=affinities.get)
+    specialization = round(sum(value * value for value in affinities.values()), 4)
+    return WalletTopicProfile(
+        topic_affinities=dict(sorted(affinities.items(), key=lambda item: item[1], reverse=True)),
+        primary_topic=primary_topic,
+        specialization_score=specialization,
+    )
+
+
+def classify_trade_topic(trade: dict[str, Any], topic_keywords: dict[str, list[str]]) -> str:
+    text = _trade_text(trade)
+    for topic, keywords in topic_keywords.items():
+        if any(keyword.lower() in text for keyword in keywords):
+            return topic
+    return UNKNOWN_TOPIC
+
+
+def _explicit_topic(trade: dict[str, Any]) -> str:
+    for key in ("topic", "category", "tag", "seriesSlug", "eventSlug"):
+        value = trade.get(key)
+        if value:
+            return str(value).strip().lower()
+    return ""
+
+
+def _trade_text(trade: dict[str, Any]) -> str:
+    parts = []
+    for key in ("slug", "marketSlug", "title", "question", "market", "eventTitle", "description"):
+        value = trade.get(key)
+        if value:
+            parts.append(str(value))
+    return " ".join(parts).lower()

--- a/tests/test_basket_assignment.py
+++ b/tests/test_basket_assignment.py
@@ -1,0 +1,77 @@
+from predictcel.basket_assignment import BasketAssignmentEngine
+from predictcel.basket_manager import BasketManagerPlanner
+from predictcel.config import (
+    ArbitrageConfig,
+    AppConfig,
+    BasketRule,
+    ConsensusConfig,
+    ExecutionConfig,
+    ExposureConfig,
+    FilterConfig,
+    LiveDataConfig,
+    PositionConfig,
+    WalletDiscoveryConfig,
+)
+from predictcel.models import WalletDiscoveryCandidate, WalletTopicProfile
+
+
+def make_config() -> AppConfig:
+    discovery = WalletDiscoveryConfig(
+        min_assignment_score=0.5,
+        max_wallets_per_basket=3,
+        max_new_wallets_per_run=1,
+        topics={"sports": ["nba"], "crypto": ["btc"]},
+    )
+    return AppConfig(
+        baskets=[BasketRule(topic="sports", wallets=["0xexisting"], quorum_ratio=0.66)],
+        filters=FilterConfig(3600, 0.05, 5000, 60, 1440, 100),
+        arbitrage=ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000),
+        wallet_trades_path="",
+        market_snapshots_path="",
+        live_data=LiveDataConfig(False, "https://gamma-api.polymarket.com", "https://data-api.polymarket.com", "https://clob.polymarket.com", 10, 10, 15),
+        execution=ExecutionConfig(False, True, 0.7, 1, 10.0, 0.02, "FOK", 137, 0, PositionConfig(0.3, 0.1, 1440), ExposureConfig(100, 10), 3, 1.0),
+        consensus=ConsensusConfig(),
+        wallet_discovery=discovery,
+    )
+
+
+def make_candidate(score: float = 0.8) -> WalletDiscoveryCandidate:
+    return WalletDiscoveryCandidate(
+        wallet_address="0xabc",
+        source="test",
+        total_trades=30,
+        recent_trades=10,
+        avg_trade_size_usd=20.0,
+        topic_profile=WalletTopicProfile({"sports": 0.8, "crypto": 0.2}, "sports", 0.68),
+        score=score,
+        confidence="HIGH" if score >= 0.7 else "MEDIUM",
+        rejected_reasons=[],
+    )
+
+
+def test_assignment_recommends_matching_baskets() -> None:
+    assignment = BasketAssignmentEngine(make_config().wallet_discovery).assign(make_candidate())
+
+    assert assignment.primary_topic == "sports"
+    assert assignment.recommended_baskets == ["sports", "crypto"]
+    assert assignment.confidence == "HIGH"
+
+
+def test_manager_proposes_add_in_report_only_mode() -> None:
+    config = make_config()
+    assignment = BasketAssignmentEngine(config.wallet_discovery).assign(make_candidate())
+
+    actions = BasketManagerPlanner(config).plan([assignment])
+
+    assert actions[0].action == "add"
+    assert actions[0].basket == "sports"
+    assert "manual approval" in actions[0].reason
+
+
+def test_manager_observes_low_score_assignment() -> None:
+    config = make_config()
+    assignment = BasketAssignmentEngine(config.wallet_discovery).assign(make_candidate(score=0.4))
+
+    actions = BasketManagerPlanner(config).plan([assignment])
+
+    assert actions[0].action == "observe"

--- a/tests/test_basket_assignment.py
+++ b/tests/test_basket_assignment.py
@@ -57,7 +57,7 @@ def test_assignment_recommends_matching_baskets() -> None:
     assert assignment.confidence == "HIGH"
 
 
-def test_manager_proposes_add_in_report_only_mode() -> None:
+def test_manager_proposes_add_in_auto_update_mode() -> None:
     config = make_config()
     assignment = BasketAssignmentEngine(config.wallet_discovery).assign(make_candidate())
 
@@ -65,7 +65,7 @@ def test_manager_proposes_add_in_report_only_mode() -> None:
 
     assert actions[0].action == "add"
     assert actions[0].basket == "sports"
-    assert "manual approval" in actions[0].reason
+    assert "auto-update" in actions[0].reason
 
 
 def test_manager_observes_low_score_assignment() -> None:

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -102,6 +102,8 @@ def test_emits_candidate_when_quorum_and_drift_pass() -> None:
     assert candidates[0].recency_score > 0
     assert candidates[0].suggested_position_usd >= 0
     assert candidates[0].copyability_score > 0
+    assert candidates[0].market_regime in {"RANGE", "TRANSITION", "TREND", "UNSTABLE"}
+    assert candidates[0].regime_score > 0
 
 
 def test_skips_candidate_when_drift_is_too_large() -> None:
@@ -160,3 +162,20 @@ def test_suggested_position_size_is_capped() -> None:
     candidate = engine.evaluate(trades, {"m1": market}, make_qualities())[0]
 
     assert candidate.suggested_position_usd <= 12.0
+
+
+def test_market_regime_detects_trend_and_unstable_books() -> None:
+    engine = CopyEngine(make_config(ConsensusConfig(min_confidence_score=0.20)))
+    trades = [
+        WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.69, size_usd=300, age_seconds=60),
+        WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.70, size_usd=300, age_seconds=60),
+    ]
+    trend_market = replace(make_market(), yes_ask=0.70, yes_spread=0.02, yes_ask_size=200)
+    unstable_market = replace(make_market(), yes_ask=0.70, yes_spread=0.20, yes_ask_size=1)
+
+    trend = engine.evaluate(trades, {"m1": trend_market}, make_qualities())[0]
+    unstable = engine.evaluate(trades, {"m1": unstable_market}, make_qualities())[0]
+
+    assert trend.market_regime == "TREND"
+    assert unstable.market_regime == "UNSTABLE"
+    assert trend.regime_score > unstable.regime_score

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 from predictcel.polymarket import (
+    _extract_list,
     build_wallet_trades,
     enrich_market_snapshots_with_orderbooks,
     market_snapshot_from_gamma,
@@ -104,3 +105,10 @@ def test_build_wallet_trades_skips_wallets_without_topic_mapping() -> None:
 
     assert len(trades) == 1
     assert trades[0].wallet == "wallet_a"
+
+
+def test_extract_list_handles_leaderboard_shapes() -> None:
+    payload = {"leaderboard": [{"address": "0x1"}], "total": 1}
+
+    assert _extract_list(payload) == [{"address": "0x1"}]
+    assert _extract_list({"users": [{"address": "0x2"}]}) == [{"address": "0x2"}]

--- a/tests/test_wallet_discovery.py
+++ b/tests/test_wallet_discovery.py
@@ -1,3 +1,5 @@
+import json
+
 from predictcel.basket_assignment import BasketAssignmentEngine
 from predictcel.basket_manager import BasketManagerPlanner
 from predictcel.config import (
@@ -33,8 +35,9 @@ class FakeSource:
         return []
 
 
-def make_config() -> AppConfig:
+def make_config(mode: str = "auto_update") -> AppConfig:
     discovery = WalletDiscoveryConfig(
+        mode=mode,
         candidate_limit=10,
         trade_limit_per_wallet=10,
         min_trades=3,
@@ -56,11 +59,16 @@ def make_config() -> AppConfig:
     )
 
 
-def test_pipeline_filters_existing_wallets_and_assigns_new_candidate() -> None:
-    pipeline = WalletDiscoveryPipeline(make_config())
+def make_pipeline(mode: str = "auto_update") -> WalletDiscoveryPipeline:
+    pipeline = WalletDiscoveryPipeline(make_config(mode))
     pipeline.source = FakeSource()
     pipeline.assignment_engine = BasketAssignmentEngine(pipeline.config.wallet_discovery)
     pipeline.manager = BasketManagerPlanner(pipeline.config)
+    return pipeline
+
+
+def test_pipeline_filters_existing_wallets_and_assigns_new_candidate() -> None:
+    pipeline = make_pipeline()
 
     candidates, assignments, actions = pipeline.run()
 
@@ -69,3 +77,29 @@ def test_pipeline_filters_existing_wallets_and_assigns_new_candidate() -> None:
     assert candidates[0].rejected_reasons == []
     assert assignments[0].recommended_baskets == ["sports"]
     assert actions[0].action == "add"
+
+
+def test_auto_update_mutates_config_path_by_default(tmp_path) -> None:
+    config_path = tmp_path / "predictcel.json"
+    config_path.write_text(json.dumps({"baskets": [{"topic": "sports", "wallets": ["0xexisting"], "quorum_ratio": 0.66}]}), encoding="utf-8")
+    pipeline = make_pipeline("auto_update")
+
+    reports = pipeline.write_reports(tmp_path / "reports", config_path)
+    updated = json.loads(config_path.read_text(encoding="utf-8"))
+
+    assert reports["updated_config"] == str(config_path)
+    assert updated["baskets"][0]["wallets"] == ["0xexisting", "0xnew"]
+
+
+def test_propose_config_writes_separate_proposal(tmp_path) -> None:
+    config_path = tmp_path / "predictcel.json"
+    config_path.write_text(json.dumps({"baskets": [{"topic": "sports", "wallets": ["0xexisting"], "quorum_ratio": 0.66}]}), encoding="utf-8")
+    pipeline = make_pipeline("propose_config")
+
+    reports = pipeline.write_reports(tmp_path / "reports", config_path)
+    original = json.loads(config_path.read_text(encoding="utf-8"))
+    proposed = json.loads((tmp_path / "reports" / "predictcel.proposed.json").read_text(encoding="utf-8"))
+
+    assert reports["config_proposal"] == str(tmp_path / "reports" / "predictcel.proposed.json")
+    assert original["baskets"][0]["wallets"] == ["0xexisting"]
+    assert proposed["baskets"][0]["wallets"] == ["0xexisting", "0xnew"]

--- a/tests/test_wallet_discovery.py
+++ b/tests/test_wallet_discovery.py
@@ -1,0 +1,71 @@
+from predictcel.basket_assignment import BasketAssignmentEngine
+from predictcel.basket_manager import BasketManagerPlanner
+from predictcel.config import (
+    ArbitrageConfig,
+    AppConfig,
+    BasketRule,
+    ConsensusConfig,
+    ExecutionConfig,
+    ExposureConfig,
+    FilterConfig,
+    LiveDataConfig,
+    PositionConfig,
+    WalletDiscoveryConfig,
+)
+from predictcel.models import WalletDiscoveryCandidate
+from predictcel.wallet_discovery import WalletDiscoveryPipeline
+
+
+class FakeSource:
+    def fetch_candidates(self, limit: int):
+        return [
+            {"address": "0xnew", "source": "fake"},
+            {"address": "0xexisting", "source": "fake"},
+        ]
+
+    def fetch_wallet_trades(self, address: str, limit: int):
+        if address == "0xnew":
+            return [
+                {"question": "NBA finals winner", "size": "20", "createdAt": "2999-01-01T00:00:00Z"},
+                {"question": "NFL playoff winner", "size": "30", "createdAt": "2999-01-01T00:00:00Z"},
+                {"question": "NBA MVP", "size": "40", "createdAt": "2999-01-01T00:00:00Z"},
+            ]
+        return []
+
+
+def make_config() -> AppConfig:
+    discovery = WalletDiscoveryConfig(
+        candidate_limit=10,
+        trade_limit_per_wallet=10,
+        min_trades=3,
+        min_recent_trades=2,
+        min_avg_trade_size_usd=10,
+        exclude_existing_wallets=True,
+        topics={"sports": ["nba", "nfl"], "crypto": ["btc"]},
+    )
+    return AppConfig(
+        baskets=[BasketRule(topic="sports", wallets=["0xexisting"], quorum_ratio=0.66)],
+        filters=FilterConfig(3600, 0.05, 5000, 60, 1440, 100),
+        arbitrage=ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000),
+        wallet_trades_path="",
+        market_snapshots_path="",
+        live_data=LiveDataConfig(False, "https://gamma-api.polymarket.com", "https://data-api.polymarket.com", "https://clob.polymarket.com", 10, 10, 15),
+        execution=ExecutionConfig(False, True, 0.7, 1, 10.0, 0.02, "FOK", 137, 0, PositionConfig(0.3, 0.1, 1440), ExposureConfig(100, 10), 3, 1.0),
+        consensus=ConsensusConfig(),
+        wallet_discovery=discovery,
+    )
+
+
+def test_pipeline_filters_existing_wallets_and_assigns_new_candidate() -> None:
+    pipeline = WalletDiscoveryPipeline(make_config())
+    pipeline.source = FakeSource()
+    pipeline.assignment_engine = BasketAssignmentEngine(pipeline.config.wallet_discovery)
+    pipeline.manager = BasketManagerPlanner(pipeline.config)
+
+    candidates, assignments, actions = pipeline.run()
+
+    assert [candidate.wallet_address for candidate in candidates] == ["0xnew"]
+    assert isinstance(candidates[0], WalletDiscoveryCandidate)
+    assert candidates[0].rejected_reasons == []
+    assert assignments[0].recommended_baskets == ["sports"]
+    assert actions[0].action == "add"

--- a/tests/test_wallet_topics.py
+++ b/tests/test_wallet_topics.py
@@ -1,0 +1,29 @@
+from predictcel.wallet_topics import classify_wallet_topics, classify_trade_topic
+
+
+def topic_keywords():
+    return {
+        "sports": ["nba", "nfl", "soccer"],
+        "crypto": ["btc", "bitcoin", "eth"],
+        "geopolitics": ["election", "senate"],
+    }
+
+
+def test_classifies_trade_topic_from_keywords() -> None:
+    trade = {"question": "Will BTC close above 100k?"}
+
+    assert classify_trade_topic(trade, topic_keywords()) == "crypto"
+
+
+def test_builds_affinities_and_specialization() -> None:
+    trades = [
+        {"question": "NBA finals winner"},
+        {"question": "NFL playoff game"},
+        {"question": "Bitcoin above 100k"},
+    ]
+
+    profile = classify_wallet_topics(trades, topic_keywords())
+
+    assert profile.primary_topic == "sports"
+    assert profile.topic_affinities["sports"] == 0.6667
+    assert profile.specialization_score > 0


### PR DESCRIPTION
## Summary
- add wallet discovery configuration, candidate models, and topic classification heuristics
- add public Data API wallet source, discovery pipeline, wallet-to-basket assignment, and basket manager planning
- make wallet discovery `auto_update` the default mode so approved add actions can mutate the configured basket JSON
- keep `propose_config` and `report_only` modes available for safer review-only runs
- add `discover-wallets --config-output` for writing updated/proposed configs to a separate path
- add market regime config and copy-engine trend/range/transition/unstable classification
- include market regime score/reason in copy candidates and copyability scoring
- document usage and add focused tests for topic classification, assignment planning, discovery config mutation, leaderboard response parsing, and regime detection

## Safety
- live trading path is unchanged
- auto-update only appends wallets from planned `add` actions and de-duplicates existing wallet addresses
- basket capacity and max-new-wallets-per-run limits still apply before mutation
- `propose_config` can be used to inspect a separate config proposal without mutating source config

## Testing
- Not run locally; implementation was made directly on GitHub per request.
