### PR TITLE
Add latency quick wins and timing instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Instead, V1 focuses on the alpha layer we actually want to test:
 - scans for simple YES/NO underpricing opportunities
 - can plan live copy orders from top-ranked signals
 - stores signals, duplicate-signal fingerprints, positions, and execution results into SQLite
+- emits per-cycle latency timings for the load, scoring, copy, arbitrage, execution, and storage stages
 
 ## What V1 does not do
 
@@ -72,7 +73,7 @@ It reads:
 - recent wallet trades from the Data API
 - public order books from the CLOB API
 
-It still does not place trades.
+It still does not place trades. Wallet and orderbook reads are fetched with bounded parallelism, and public API retries include jittered exponential backoff.
 
 ```bash
 python -m predictcel.main --config config/predictcel.example.json --db predictcel.db --live-data
@@ -135,7 +136,7 @@ Recommended worker variables:
 - `PREDICTCEL_MODE=live-data` for public Polymarket reads without trading
 - `PREDICTCEL_MODE=dry-run-trading` for live data plus execution planning while `execution.dry_run` remains true
 - `PREDICTCEL_MODE=live-trading` only after credentials, config, and jurisdictional eligibility are verified
-- `PREDICTCEL_RUN_INTERVAL_SECONDS=300`
+- `PREDICTCEL_RUN_INTERVAL_SECONDS=300` for paper mode; omit it for live modes to use the 60 second live default
 - `PREDICTCEL_RUN_ONCE=false`
 - `PREDICTCEL_CONFIG=config/predictcel.example.json`
 - `PREDICTCEL_DB=/data/predictcel.db`
@@ -149,7 +150,7 @@ Live trading variables:
 - `PREDICTCEL_POLY_FUNDER`
 - optional: `PREDICTCEL_POLY_HOST`
 
-The Railway worker catches per-cycle exceptions, logs JSON events, waits for the next interval, and continues. Each normal run prints a compact `summary` object with counts for markets, wallet trades, copy candidates, duplicate skips, execution intents, and open positions.
+The Railway worker catches per-cycle exceptions, logs JSON events, waits for the next interval, and continues. Each normal run prints a compact `summary` object with counts for markets, wallet trades, copy candidates, duplicate skips, execution intents, and open positions, plus a `latency_ms` object for stage-level timing.
 
 ## Project layout
 
@@ -174,14 +175,14 @@ The Railway worker catches per-cycle exceptions, logs JSON events, waits for the
 ## Notes on scoring
 
 Wallet quality is currently based on:
-- freshness of recent trades
+- exponential freshness decay using `consensus.recency_half_life_seconds`
 - drift discipline versus current market pricing proxy
 - sample size of eligible recent trades
 
 Copyability score is currently based on:
 - basket consensus ratio
 - average source wallet quality
-- freshness of aligned trades
+- exponential freshness decay using `consensus.recency_half_life_seconds`
 - drift from reference entry
 - available market liquidity
 - side-specific spread from the public order book

--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -121,6 +121,7 @@ class CopyEngine:
             side_spread=side_spread,
             side_depth_usd=side_depth_usd,
             filters=self.config.filters,
+            recency_half_life_seconds=self.config.consensus.recency_half_life_seconds,
         )
         copyability_score = round(max(0.0, min(1.0, (base_score * 0.70) + (confidence_score * 0.15) + (recency_score * 0.10) + (regime.score * 0.05) - conflict_penalty)), 4)
         suggested_position_usd = self._suggested_position_size(current_price, confidence_score, copyability_score)

--- a/src/predictcel/execution.py
+++ b/src/predictcel/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import random
 import time
 from dataclasses import asdict, replace
 from datetime import UTC, datetime
@@ -179,8 +180,7 @@ class LiveOrderExecutor:
                     or "504" in error_msg
                 )
                 if is_retryable and attempt < max_retries - 1:
-                    delay = base_delay * (2 ** attempt)
-                    time.sleep(delay)
+                    time.sleep(retry_delay(base_delay, attempt))
                     continue
                 return ExecutionResult(
                     market_id=intent.market_id,
@@ -275,6 +275,10 @@ class ExitRunner:
             updated_positions.append(updated_pos)
 
         return close_intents, updated_positions
+
+
+def retry_delay(base_delay: float, attempt: int) -> float:
+    return base_delay * (2 ** attempt) * random.uniform(0.5, 1.5)
 
 
 def intents_as_dicts(intents: list[ExecutionIntent]) -> list[dict[str, Any]]:

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from typing import Any
 
@@ -43,14 +45,27 @@ def main() -> None:
         _run_wallet_discovery(sys.argv[2:])
         return
 
+    cycle_started = time.perf_counter()
+    timings: dict[str, int] = {}
     args = build_parser().parse_args()
     config = load_config(args.config)
     use_live_data = bool(args.live_data or (config.live_data and config.live_data.enabled))
-    trades, markets = _load_live_inputs(config) if use_live_data else (load_wallet_trades(config.wallet_trades_path), load_market_snapshots(config.market_snapshots_path))
 
-    wallet_qualities = WalletQualityScorer(config.filters).score(trades, markets)
+    started = time.perf_counter()
+    trades, markets = _load_live_inputs(config) if use_live_data else (load_wallet_trades(config.wallet_trades_path), load_market_snapshots(config.market_snapshots_path))
+    timings["input_load_ms"] = _elapsed_ms(started)
+
+    started = time.perf_counter()
+    wallet_qualities = WalletQualityScorer(config.filters, config.consensus.recency_half_life_seconds).score(trades, markets)
+    timings["wallet_scoring_ms"] = _elapsed_ms(started)
+
+    started = time.perf_counter()
     copy_candidates = CopyEngine(config).evaluate(trades, markets, wallet_qualities)
+    timings["copy_engine_ms"] = _elapsed_ms(started)
+
+    started = time.perf_counter()
     arbitrage_opportunities = ArbitrageSidecar(config.arbitrage).scan(markets)
+    timings["arbitrage_scan_ms"] = _elapsed_ms(started)
 
     execution_intents: list = []
     execution_results: list = []
@@ -59,6 +74,7 @@ def main() -> None:
     skipped_duplicate_signals = 0
     store = SignalStore(args.db)
 
+    started = time.perf_counter()
     if args.live_trading:
         if config.execution is None or not config.execution.enabled:
             raise ValueError("--live-trading was requested but execution is not enabled in config.")
@@ -76,11 +92,16 @@ def main() -> None:
         execution_intents = ExecutionPlanner(config.execution, config.execution.position).plan(fresh_candidates, markets, store.get_held_market_ids(), current_exposure_usd)
         execution_results = LiveOrderExecutor(config.execution, config.live_data).execute(execution_intents)
         _persist_execution_side_effects(store, config, execution_results)
+    timings["execution_ms"] = _elapsed_ms(started)
 
+    started = time.perf_counter()
     store.save_copy_candidates(copy_candidates)
     store.save_arbitrage_opportunities(arbitrage_opportunities)
     store.save_execution_results(execution_results + close_results)
     open_positions = store.get_open_positions()
+    timings["storage_ms"] = _elapsed_ms(started)
+    timings["total_cycle_ms"] = _elapsed_ms(cycle_started)
+
     summary = {
         "markets_loaded": len(markets),
         "wallet_trades_loaded": len(trades),
@@ -94,9 +115,10 @@ def main() -> None:
         "close_results": len(close_results),
         "open_positions": len(open_positions),
     }
-    print(json.dumps({
+    output = {
         "mode": "live" if use_live_data else "file",
         "summary": summary,
+        "latency_ms": timings,
         "portfolio_summary": _portfolio_summary(store, config),
         "wallet_qualities": {wallet: quality.__dict__ for wallet, quality in wallet_qualities.items()},
         "copy_candidates": [candidate.__dict__ for candidate in copy_candidates],
@@ -106,14 +128,17 @@ def main() -> None:
         "close_intents": intents_as_dicts(close_intents),
         "close_results": [result.__dict__ for result in close_results],
         "open_positions": [pos.__dict__ for pos in open_positions],
-    }, indent=2, default=str))
+    }
+    _log_event("predictcel_cycle_latency", {"mode": output["mode"], "latency_ms": timings, "summary": summary})
+    print(json.dumps(output, indent=2, default=str))
 
 
 def _run_wallet_discovery(argv: list[str]) -> None:
+    started = time.perf_counter()
     args = build_discovery_parser().parse_args(argv)
     config = load_config(args.config)
     files = WalletDiscoveryPipeline(config).write_reports(args.output_dir, args.config, args.config_output)
-    print(json.dumps({"mode": "wallet_discovery", "reports": files}, indent=2))
+    print(json.dumps({"mode": "wallet_discovery", "reports": files, "latency_ms": {"total_cycle_ms": _elapsed_ms(started)}}, indent=2))
 
 
 def _persist_execution_side_effects(store: SignalStore, config: Any, execution_results: list) -> None:
@@ -138,15 +163,26 @@ def _load_live_inputs(config):
         raise ValueError("--live-data was requested but live_data is not configured.")
     client = PolymarketPublicClient(config.live_data.gamma_base_url, config.live_data.data_base_url, config.live_data.clob_base_url, config.live_data.request_timeout_seconds)
     topic_by_wallet = {wallet: basket.topic for basket in config.baskets for wallet in basket.wallets}
-    wallet_payloads = {}
-    for wallet in topic_by_wallet:
-        try:
-            wallet_payloads[wallet] = client.fetch_wallet_trades(wallet, config.live_data.trade_limit)
-        except Exception:
-            wallet_payloads[wallet] = []
+    wallet_payloads = _fetch_wallet_payloads(client, list(topic_by_wallet), config.live_data.trade_limit)
     trades = build_wallet_trades(wallet_payloads, topic_by_wallet)
     markets = build_market_snapshots(client.fetch_active_markets(config.live_data.market_limit))
     return trades, enrich_market_snapshots_with_orderbooks(markets, client)
+
+
+def _fetch_wallet_payloads(client: PolymarketPublicClient, wallets: list[str], limit: int) -> dict[str, list[dict[str, Any]]]:
+    if not wallets:
+        return {}
+    payloads: dict[str, list[dict[str, Any]]] = {}
+    workers = max(1, min(8, len(wallets)))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(client.fetch_wallet_trades, wallet, limit): wallet for wallet in wallets}
+        for future in as_completed(futures):
+            wallet = futures[future]
+            try:
+                payloads[wallet] = future.result()
+            except Exception:
+                payloads[wallet] = []
+    return payloads
 
 
 def _filter_duplicate_candidates(store: SignalStore, candidates: list) -> tuple[list, int]:
@@ -156,6 +192,14 @@ def _filter_duplicate_candidates(store: SignalStore, candidates: list) -> tuple[
 
 def _is_trusted_execution_result(result) -> bool:
     return str(result.status).strip().lower() in TRUSTED_POSITION_STATUSES and bool(str(result.order_id).strip())
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.perf_counter() - started) * 1000)
+
+
+def _log_event(event: str, payload: dict[str, Any]) -> None:
+    print(json.dumps({"event": event, "ts": datetime.now(UTC).isoformat(), **payload}, sort_keys=True, default=str), flush=True)
 
 
 if __name__ == "__main__":

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import random
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
@@ -58,7 +60,7 @@ class PolymarketPublicClient:
             except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
                 if attempt >= self.max_retries - 1:
                     raise
-                time.sleep(self.retry_base_delay_seconds * (2 ** attempt))
+                time.sleep(_retry_delay(self.retry_base_delay_seconds, attempt))
         return None
 
 
@@ -74,39 +76,50 @@ def build_market_snapshots(items: list[dict[str, Any]]) -> dict[str, MarketSnaps
 def enrich_market_snapshots_with_orderbooks(
     snapshots: dict[str, MarketSnapshot],
     client: PolymarketPublicClient,
+    max_workers: int = 8,
 ) -> dict[str, MarketSnapshot]:
+    if not snapshots:
+        return {}
+
     enriched: dict[str, MarketSnapshot] = {}
-    for market_id, snapshot in snapshots.items():
-        try:
-            yes_book = client.fetch_order_book(snapshot.yes_token_id) if snapshot.yes_token_id else {}
-            no_book = client.fetch_order_book(snapshot.no_token_id) if snapshot.no_token_id else {}
-        except Exception:
-            enriched[market_id] = snapshot
-            continue
-
-        yes_bid = _book_best_price(yes_book, "bids")
-        no_bid = _book_best_price(no_book, "bids")
-        yes_ask = _book_best_price(yes_book, "asks") or snapshot.yes_ask
-        no_ask = _book_best_price(no_book, "asks") or snapshot.no_ask
-        yes_ask_size = _book_best_size(yes_book, "asks")
-        no_ask_size = _book_best_size(no_book, "asks")
-        yes_spread = round(max(yes_ask - yes_bid, 0.0), 4) if yes_ask and yes_bid else 0.0
-        no_spread = round(max(no_ask - no_bid, 0.0), 4) if no_ask and no_bid else 0.0
-
-        enriched[market_id] = replace(
-            snapshot,
-            yes_ask=yes_ask,
-            no_ask=no_ask,
-            best_bid=max(yes_bid, no_bid, snapshot.best_bid),
-            yes_bid=yes_bid,
-            no_bid=no_bid,
-            yes_ask_size=yes_ask_size,
-            no_ask_size=no_ask_size,
-            yes_spread=yes_spread,
-            no_spread=no_spread,
-            orderbook_ready=bool(yes_book or no_book),
-        )
+    workers = max(1, min(max_workers, len(snapshots)))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_enrich_one_snapshot, snapshot, client): market_id for market_id, snapshot in snapshots.items()}
+        for future in as_completed(futures):
+            market_id = futures[future]
+            try:
+                enriched[market_id] = future.result()
+            except Exception:
+                enriched[market_id] = snapshots[market_id]
     return enriched
+
+
+def _enrich_one_snapshot(snapshot: MarketSnapshot, client: PolymarketPublicClient) -> MarketSnapshot:
+    yes_book = client.fetch_order_book(snapshot.yes_token_id) if snapshot.yes_token_id else {}
+    no_book = client.fetch_order_book(snapshot.no_token_id) if snapshot.no_token_id else {}
+
+    yes_bid = _book_best_price(yes_book, "bids")
+    no_bid = _book_best_price(no_book, "bids")
+    yes_ask = _book_best_price(yes_book, "asks") or snapshot.yes_ask
+    no_ask = _book_best_price(no_book, "asks") or snapshot.no_ask
+    yes_ask_size = _book_best_size(yes_book, "asks")
+    no_ask_size = _book_best_size(no_book, "asks")
+    yes_spread = round(max(yes_ask - yes_bid, 0.0), 4) if yes_ask and yes_bid else 0.0
+    no_spread = round(max(no_ask - no_bid, 0.0), 4) if no_ask and no_bid else 0.0
+
+    return replace(
+        snapshot,
+        yes_ask=yes_ask,
+        no_ask=no_ask,
+        best_bid=max(yes_bid, no_bid, snapshot.best_bid),
+        yes_bid=yes_bid,
+        no_bid=no_bid,
+        yes_ask_size=yes_ask_size,
+        no_ask_size=no_ask_size,
+        yes_spread=yes_spread,
+        no_spread=no_spread,
+        orderbook_ready=bool(yes_book or no_book),
+    )
 
 
 def build_wallet_trades(
@@ -292,3 +305,7 @@ def _parse_datetime(value: Any) -> datetime:
         normalized = value.replace("Z", "+00:00")
         return datetime.fromisoformat(normalized).astimezone(UTC)
     raise ValueError("Unsupported datetime value")
+
+
+def _retry_delay(base_delay: float, attempt: int) -> float:
+    return base_delay * (2 ** attempt) * random.uniform(0.5, 1.5)

--- a/src/predictcel/railway.py
+++ b/src/predictcel/railway.py
@@ -10,26 +10,31 @@ from datetime import UTC, datetime
 from .main import main as run_cli
 
 VALID_MODES = {"paper", "live-data", "dry-run-trading", "live-trading"}
+LIVE_MODES = {"live-data", "dry-run-trading", "live-trading"}
 
 
 def main() -> None:
-    interval_seconds = int(os.getenv("PREDICTCEL_RUN_INTERVAL_SECONDS", "300"))
+    interval_seconds = int(os.getenv("PREDICTCEL_RUN_INTERVAL_SECONDS", str(_default_interval_seconds())))
     run_once = _env_enabled("PREDICTCEL_RUN_ONCE", default=False)
+    interval = max(interval_seconds, 30)
 
     while True:
+        started = time.perf_counter()
         try:
             _run_once_from_env()
+            _log_event("predictcel_run_complete", {"duration_ms": _elapsed_ms(started), "next_interval_seconds": 0 if run_once else interval})
         except Exception as exc:  # pragma: no cover - defensive worker boundary
             _log_event(
                 "predictcel_run_error",
                 {
+                    "duration_ms": _elapsed_ms(started),
                     "error": str(exc),
                     "traceback": traceback.format_exc(),
                 },
             )
         if run_once:
             return
-        time.sleep(max(interval_seconds, 30))
+        time.sleep(interval)
 
 
 def _run_once_from_env() -> None:
@@ -41,7 +46,7 @@ def _run_once_from_env() -> None:
     if mode:
         if mode not in VALID_MODES:
             raise ValueError(f"Invalid PREDICTCEL_MODE={mode!r}. Expected one of {sorted(VALID_MODES)}.")
-        if mode in {"live-data", "dry-run-trading", "live-trading"}:
+        if mode in LIVE_MODES:
             argv.append("--live-data")
         if mode in {"dry-run-trading", "live-trading"}:
             argv.append("--live-trading")
@@ -60,11 +65,21 @@ def _run_once_from_env() -> None:
         sys.argv = previous_argv
 
 
+def _default_interval_seconds() -> int:
+    mode = os.getenv("PREDICTCEL_MODE", "").strip().lower()
+    legacy_live = _env_enabled("PREDICTCEL_LIVE_DATA", default=False) or _env_enabled("PREDICTCEL_LIVE_TRADING", default=False)
+    return 60 if mode in LIVE_MODES or legacy_live else 300
+
+
 def _env_enabled(name: str, default: bool) -> bool:
     raw = os.getenv(name)
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.perf_counter() - started) * 1000)
 
 
 def _log_event(event: str, payload: dict) -> None:

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections import defaultdict
 
 from .config import FilterConfig
@@ -7,8 +8,9 @@ from .models import MarketSnapshot, WalletQuality, WalletTrade
 
 
 class WalletQualityScorer:
-    def __init__(self, filters: FilterConfig) -> None:
+    def __init__(self, filters: FilterConfig, recency_half_life_seconds: int | None = None) -> None:
         self.filters = filters
+        self.recency_half_life_seconds = recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1)
 
     def score(self, trades: list[WalletTrade], markets: dict[str, MarketSnapshot]) -> dict[str, WalletQuality]:
         grouped: dict[str, list[WalletTrade]] = defaultdict(list)
@@ -26,7 +28,7 @@ class WalletQualityScorer:
             drifts = [self._trade_drift(trade, markets[trade.market_id]) for trade in eligible if trade.market_id in markets]
             average_drift = sum(drifts) / len(drifts) if drifts else self.filters.max_price_drift
 
-            freshness_score = max(0.0, 1.0 - (average_age / self.filters.max_trade_age_seconds))
+            freshness_score = freshness_decay(average_age, self.recency_half_life_seconds)
             drift_score = max(0.0, 1.0 - (average_drift / self.filters.max_price_drift)) if self.filters.max_price_drift else 0.0
             sample_score = min(len(eligible) / 5.0, 1.0)
             quality_score = round((freshness_score * 0.35) + (drift_score * 0.4) + (sample_score * 0.25), 4)
@@ -38,7 +40,7 @@ class WalletQualityScorer:
                 eligible_trade_count=len(eligible),
                 average_age_seconds=average_age,
                 average_drift=average_drift,
-                reason="freshness, drift discipline, and sample size",
+                reason="exponential freshness, drift discipline, and sample size",
             )
         return scores
 
@@ -63,6 +65,12 @@ class WalletQualityScorer:
         return abs(current_price - trade.price)
 
 
+def freshness_decay(age_seconds: float, half_life_seconds: int | float) -> float:
+    if half_life_seconds <= 0:
+        return 0.0
+    return max(0.0, min(1.0, math.exp(-math.log(2) * max(age_seconds, 0.0) / half_life_seconds)))
+
+
 def compute_copyability_score(
     consensus_ratio: float,
     wallet_quality_score: float,
@@ -72,8 +80,9 @@ def compute_copyability_score(
     side_spread: float,
     side_depth_usd: float,
     filters: FilterConfig,
+    recency_half_life_seconds: int | None = None,
 ) -> float:
-    freshness_score = max(0.0, 1.0 - (average_age_seconds / filters.max_trade_age_seconds))
+    freshness_score = freshness_decay(average_age_seconds, recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1))
     drift_score = max(0.0, 1.0 - (drift / filters.max_price_drift)) if filters.max_price_drift else 0.0
     liquidity_score = min(liquidity_usd / (filters.min_liquidity_usd * 3), 1.0) if filters.min_liquidity_usd else 0.0
     spread_score = max(0.0, 1.0 - (side_spread / 0.1))

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 from predictcel.config import ExecutionConfig, ExposureConfig, LiveDataConfig, PositionConfig
-from predictcel.execution import ExecutionPlanner, ExitRunner, LiveOrderExecutor
+from predictcel.execution import ExecutionPlanner, ExitRunner, LiveOrderExecutor, retry_delay
 from predictcel.models import CopyCandidate, ExecutionIntent, MarketSnapshot, Position
 
 
@@ -310,3 +310,9 @@ def test_live_executor_dry_run_preserves_close_side() -> None:
 
     assert results[0].side == "CLOSE"
     assert results[0].status == "dry_run"
+
+
+def test_retry_delay_adds_bounded_jitter() -> None:
+    for _ in range(20):
+        delay = retry_delay(1.0, 2)
+        assert 2.0 <= delay <= 6.0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,6 @@
 from predictcel.config import FilterConfig
 from predictcel.models import MarketSnapshot, WalletTrade
-from predictcel.scoring import WalletQualityScorer, compute_copyability_score
+from predictcel.scoring import WalletQualityScorer, compute_copyability_score, freshness_decay
 
 
 def make_filters() -> FilterConfig:
@@ -38,6 +38,7 @@ def test_wallet_quality_scores_eligible_wallet() -> None:
     assert "w1" in scores
     assert scores["w1"].score > 0
     assert scores["w1"].eligible_trade_count == 2
+    assert "exponential freshness" in scores["w1"].reason
 
 
 def test_compute_copyability_score_rewards_better_inputs() -> None:
@@ -64,3 +65,9 @@ def test_compute_copyability_score_rewards_better_inputs() -> None:
     )
 
     assert strong > weak
+
+
+def test_freshness_decay_uses_true_half_life() -> None:
+    assert freshness_decay(0, 1800) == 1.0
+    assert round(freshness_decay(1800, 1800), 4) == 0.5
+    assert round(freshness_decay(3600, 1800), 4) == 0.25


### PR DESCRIPTION
## Summary
- add per-cycle latency timings to main CLI output and Railway JSON events
- use 60s default Railway cadence for live modes while keeping 300s for paper mode
- parallelize public wallet polling and orderbook enrichment with bounded `ThreadPoolExecutor` workers
- add jitter to public API and live order retry backoff
- replace linear freshness scoring with true exponential half-life decay using `consensus.recency_half_life_seconds`
- pass half-life freshness into copyability scoring
- document the latency behavior and add tests for half-life decay and retry jitter bounds

## Testing
- Not run locally; implementation was made directly on GitHub per request.
