### PR TITLE
Add scoring diagnostics and expand basket limits

### DIFF
--- a/config/predictcel.example.json
+++ b/config/predictcel.example.json
@@ -6,7 +6,7 @@
     "gamma_base_url": "https://gamma-api.polymarket.com",
     "data_base_url": "https://data-api.polymarket.com",
     "clob_base_url": "https://clob.polymarket.com",
-    "market_limit": 50,
+    "market_limit": 250,
     "trade_limit": 25,
     "request_timeout_seconds": 15
   },
@@ -55,7 +55,7 @@
   "wallet_discovery": {
     "enabled": true,
     "mode": "auto_update",
-    "candidate_limit": 100,
+    "candidate_limit": 250,
     "trade_limit_per_wallet": 100,
     "min_trades": 20,
     "min_recent_trades": 5,
@@ -63,8 +63,8 @@
     "min_avg_trade_size_usd": 10.0,
     "min_assignment_score": 0.50,
     "exclude_existing_wallets": true,
-    "max_wallets_per_basket": 20,
-    "max_new_wallets_per_run": 3,
+    "max_wallets_per_basket": 50,
+    "max_new_wallets_per_run": 10,
     "topics": {
       "geopolitics": ["election", "trump", "biden", "war", "federal", "senate", "president"],
       "sports": ["nba", "nfl", "mlb", "nhl", "ufc", "soccer", "football", "tennis"],

--- a/src/predictcel/config.py
+++ b/src/predictcel/config.py
@@ -60,7 +60,7 @@ class MarketRegimeConfig:
 class WalletDiscoveryConfig:
     enabled: bool = False
     mode: str = "auto_update"
-    candidate_limit: int = 100
+    candidate_limit: int = 250
     trade_limit_per_wallet: int = 100
     min_trades: int = 20
     min_recent_trades: int = 5
@@ -68,8 +68,8 @@ class WalletDiscoveryConfig:
     min_avg_trade_size_usd: float = 10.0
     min_assignment_score: float = 0.50
     exclude_existing_wallets: bool = True
-    max_wallets_per_basket: int = 20
-    max_new_wallets_per_run: int = 3
+    max_wallets_per_basket: int = 50
+    max_new_wallets_per_run: int = 10
     topics: dict[str, list[str]] = field(default_factory=_default_topic_keywords)
 
 

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -56,7 +56,12 @@ def main() -> None:
     timings["input_load_ms"] = _elapsed_ms(started)
 
     started = time.perf_counter()
-    wallet_qualities = WalletQualityScorer(config.filters, config.consensus.recency_half_life_seconds).score(trades, markets)
+    scorer = WalletQualityScorer(config.filters, config.consensus.recency_half_life_seconds)
+    wallet_qualities = scorer.score(trades, markets)
+    scoring_diagnostics = {
+        "rejection_counts": scorer.last_rejection_counts,
+        "wallet_rejection_counts": scorer.last_wallet_rejection_counts,
+    }
     timings["wallet_scoring_ms"] = _elapsed_ms(started)
 
     started = time.perf_counter()
@@ -119,6 +124,7 @@ def main() -> None:
         "mode": "live" if use_live_data else "file",
         "summary": summary,
         "latency_ms": timings,
+        "scoring_diagnostics": scoring_diagnostics,
         "portfolio_summary": _portfolio_summary(store, config),
         "wallet_qualities": {wallet: quality.__dict__ for wallet, quality in wallet_qualities.items()},
         "copy_candidates": [candidate.__dict__ for candidate in copy_candidates],
@@ -129,7 +135,7 @@ def main() -> None:
         "close_results": [result.__dict__ for result in close_results],
         "open_positions": [pos.__dict__ for pos in open_positions],
     }
-    _log_event("predictcel_cycle_latency", {"mode": output["mode"], "latency_ms": timings, "summary": summary})
+    _log_event("predictcel_cycle_latency", {"mode": output["mode"], "latency_ms": timings, "summary": summary, "scoring_diagnostics": scoring_diagnostics})
     print(json.dumps(output, indent=2, default=str))
 
 

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 from .config import FilterConfig
 from .models import MarketSnapshot, WalletQuality, WalletTrade
@@ -11,15 +11,26 @@ class WalletQualityScorer:
     def __init__(self, filters: FilterConfig, recency_half_life_seconds: int | None = None) -> None:
         self.filters = filters
         self.recency_half_life_seconds = recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1)
+        self.last_rejection_counts: dict[str, int] = {}
+        self.last_wallet_rejection_counts: dict[str, dict[str, int]] = {}
 
     def score(self, trades: list[WalletTrade], markets: dict[str, MarketSnapshot]) -> dict[str, WalletQuality]:
         grouped: dict[str, list[WalletTrade]] = defaultdict(list)
+        rejection_counts: Counter[str] = Counter()
+        wallet_rejections: dict[str, Counter[str]] = defaultdict(Counter)
         for trade in trades:
             grouped[trade.wallet].append(trade)
 
         scores: dict[str, WalletQuality] = {}
         for wallet, wallet_trades in grouped.items():
-            eligible = [trade for trade in wallet_trades if self._is_eligible_trade(trade, markets)]
+            eligible = []
+            for trade in wallet_trades:
+                reason = self.rejection_reason(trade, markets)
+                if reason is None:
+                    eligible.append(trade)
+                else:
+                    rejection_counts[reason] += 1
+                    wallet_rejections[wallet][reason] += 1
             if not eligible:
                 continue
 
@@ -42,23 +53,29 @@ class WalletQualityScorer:
                 average_drift=average_drift,
                 reason="exponential freshness, drift discipline, and sample size",
             )
+
+        self.last_rejection_counts = dict(sorted(rejection_counts.items()))
+        self.last_wallet_rejection_counts = {wallet: dict(sorted(counts.items())) for wallet, counts in sorted(wallet_rejections.items())}
         return scores
 
-    def _is_eligible_trade(self, trade: WalletTrade, markets: dict[str, MarketSnapshot]) -> bool:
+    def rejection_reason(self, trade: WalletTrade, markets: dict[str, MarketSnapshot]) -> str | None:
         market = markets.get(trade.market_id)
         if market is None:
-            return False
+            return "missing_market"
         if trade.age_seconds > self.filters.max_trade_age_seconds:
-            return False
+            return "too_old"
         if trade.size_usd < self.filters.min_position_size_usd:
-            return False
+            return "too_small"
         if market.liquidity_usd < self.filters.min_liquidity_usd:
-            return False
+            return "low_liquidity"
         if market.minutes_to_resolution < self.filters.min_minutes_to_resolution:
-            return False
+            return "too_close_to_resolution"
         if market.minutes_to_resolution > self.filters.max_minutes_to_resolution:
-            return False
-        return True
+            return "too_far_from_resolution"
+        return None
+
+    def _is_eligible_trade(self, trade: WalletTrade, markets: dict[str, MarketSnapshot]) -> bool:
+        return self.rejection_reason(trade, markets) is None
 
     def _trade_drift(self, trade: WalletTrade, market: MarketSnapshot) -> float:
         current_price = market.yes_ask if trade.side.upper() == "YES" else market.no_ask

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -39,6 +39,26 @@ def test_wallet_quality_scores_eligible_wallet() -> None:
     assert scores["w1"].score > 0
     assert scores["w1"].eligible_trade_count == 2
     assert "exponential freshness" in scores["w1"].reason
+    assert scorer.last_rejection_counts == {}
+
+
+def test_scoring_diagnostics_count_rejection_reasons() -> None:
+    scorer = WalletQualityScorer(make_filters())
+    trades = [
+        WalletTrade(wallet="w1", topic="sports", market_id="missing", side="YES", price=0.55, size_usd=200, age_seconds=300),
+        WalletTrade(wallet="w1", topic="sports", market_id="m1", side="YES", price=0.56, size_usd=20, age_seconds=300),
+        WalletTrade(wallet="w2", topic="sports", market_id="m1", side="YES", price=0.56, size_usd=200, age_seconds=7200),
+    ]
+    markets = {
+        "m1": MarketSnapshot("m1", "sports", "Example", 0.57, 0.4, 0.55, 9000, 180)
+    }
+
+    scores = scorer.score(trades, markets)
+
+    assert scores == {}
+    assert scorer.last_rejection_counts == {"missing_market": 1, "too_old": 1, "too_small": 1}
+    assert scorer.last_wallet_rejection_counts["w1"] == {"missing_market": 1, "too_small": 1}
+    assert scorer.last_wallet_rejection_counts["w2"] == {"too_old": 1}
 
 
 def test_compute_copyability_score_rewards_better_inputs() -> None:


### PR DESCRIPTION
## Summary
- emit wallet scoring rejection diagnostics in CLI output and Railway latency events
- track aggregate and per-wallet rejection reasons such as `missing_market`, `too_old`, `too_small`, and resolution-window failures
- increase default live market scan limit from 50 to 250 to improve overlap with tracked wallet trades
- increase wallet discovery defaults to 250 candidates, 50 wallets per basket, and 10 new wallets per run
- add tests for rejection diagnostics

## Why
Recent Railway logs showed `wallet_trades_loaded: 200` but `wallets_scored: 0`. These diagnostics make the next Railway cycle explain exactly which eligibility gate is dropping trades, while the larger market scan/basket defaults reduce the likely `missing_market` case.

## Testing
- Not run locally; implementation was made directly on GitHub per request.
