### PR TITLE
Fix live market matching for wallet scoring

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -14,13 +14,20 @@ from .copy_engine import CopyEngine
 from .execution import ExecutionPlanner, ExitRunner, LiveOrderExecutor, intents_as_dicts
 from .markets import load_market_snapshots
 from .models import Position
-from .polymarket import PolymarketPublicClient, build_market_snapshots, build_wallet_trades, enrich_market_snapshots_with_orderbooks
+from .polymarket import (
+    PolymarketPublicClient,
+    build_market_snapshots,
+    build_wallet_trades,
+    enrich_market_snapshots_with_orderbooks,
+    extract_trade_market_ids,
+)
 from .scoring import WalletQualityScorer
 from .storage import SignalStore
 from .wallet_discovery import WalletDiscoveryPipeline
 from .wallets import load_wallet_trades
 
 TRUSTED_POSITION_STATUSES = {"filled", "matched", "success", "submitted"}
+HEX_CHARS = set("0123456789abcdefABCDEF")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -52,7 +59,11 @@ def main() -> None:
     use_live_data = bool(args.live_data or (config.live_data and config.live_data.enabled))
 
     started = time.perf_counter()
-    trades, markets = _load_live_inputs(config) if use_live_data else (load_wallet_trades(config.wallet_trades_path), load_market_snapshots(config.market_snapshots_path))
+    live_input_diagnostics: dict[str, Any] = {}
+    if use_live_data:
+        trades, markets, live_input_diagnostics = _load_live_inputs(config)
+    else:
+        trades, markets = load_wallet_trades(config.wallet_trades_path), load_market_snapshots(config.market_snapshots_path)
     timings["input_load_ms"] = _elapsed_ms(started)
 
     started = time.perf_counter()
@@ -61,6 +72,7 @@ def main() -> None:
     scoring_diagnostics = {
         "rejection_counts": scorer.last_rejection_counts,
         "wallet_rejection_counts": scorer.last_wallet_rejection_counts,
+        "missing_market_samples": scorer.last_missing_market_samples,
     }
     timings["wallet_scoring_ms"] = _elapsed_ms(started)
 
@@ -124,6 +136,7 @@ def main() -> None:
         "mode": "live" if use_live_data else "file",
         "summary": summary,
         "latency_ms": timings,
+        "live_input_diagnostics": live_input_diagnostics,
         "scoring_diagnostics": scoring_diagnostics,
         "portfolio_summary": _portfolio_summary(store, config),
         "wallet_qualities": {wallet: quality.__dict__ for wallet, quality in wallet_qualities.items()},
@@ -135,7 +148,16 @@ def main() -> None:
         "close_results": [result.__dict__ for result in close_results],
         "open_positions": [pos.__dict__ for pos in open_positions],
     }
-    _log_event("predictcel_cycle_latency", {"mode": output["mode"], "latency_ms": timings, "summary": summary, "scoring_diagnostics": scoring_diagnostics})
+    _log_event(
+        "predictcel_cycle_latency",
+        {
+            "mode": output["mode"],
+            "latency_ms": timings,
+            "summary": summary,
+            "live_input_diagnostics": live_input_diagnostics,
+            "scoring_diagnostics": scoring_diagnostics,
+        },
+    )
     print(json.dumps(output, indent=2, default=str))
 
 
@@ -168,11 +190,34 @@ def _load_live_inputs(config):
     if config.live_data is None:
         raise ValueError("--live-data was requested but live_data is not configured.")
     client = PolymarketPublicClient(config.live_data.gamma_base_url, config.live_data.data_base_url, config.live_data.clob_base_url, config.live_data.request_timeout_seconds)
-    topic_by_wallet = {wallet: basket.topic for basket in config.baskets for wallet in basket.wallets}
+    raw_topic_by_wallet = {wallet: basket.topic for basket in config.baskets for wallet in basket.wallets}
+    topic_by_wallet = {wallet: topic for wallet, topic in raw_topic_by_wallet.items() if _is_evm_address(wallet)}
+    skipped_wallets = [wallet for wallet in raw_topic_by_wallet if wallet not in topic_by_wallet]
+
     wallet_payloads = _fetch_wallet_payloads(client, list(topic_by_wallet), config.live_data.trade_limit)
     trades = build_wallet_trades(wallet_payloads, topic_by_wallet)
-    markets = build_market_snapshots(client.fetch_active_markets(config.live_data.market_limit))
-    return trades, enrich_market_snapshots_with_orderbooks(markets, client)
+    trade_market_ids = extract_trade_market_ids(wallet_payloads)
+
+    active_market_rows = client.fetch_active_markets(config.live_data.market_limit)
+    markets = build_market_snapshots(active_market_rows)
+    missing_trade_market_ids = [market_id for market_id in trade_market_ids if market_id not in markets]
+    supplemental_rows = client.fetch_markets_by_condition_ids(missing_trade_market_ids)
+    if supplemental_rows:
+        markets.update(build_market_snapshots(supplemental_rows))
+
+    diagnostics = {
+        "requested_wallets": len(raw_topic_by_wallet),
+        "valid_wallets": len(topic_by_wallet),
+        "skipped_invalid_wallets": len(skipped_wallets),
+        "sample_skipped_invalid_wallets": skipped_wallets[:5],
+        "wallet_payloads_loaded": sum(len(items) for items in wallet_payloads.values()),
+        "active_market_rows_loaded": len(active_market_rows),
+        "trade_market_ids_seen": len(trade_market_ids),
+        "supplemental_market_ids_requested": len(missing_trade_market_ids),
+        "supplemental_market_rows_loaded": len(supplemental_rows),
+        "market_cache_entries": len(markets),
+    }
+    return trades, enrich_market_snapshots_with_orderbooks(markets, client), diagnostics
 
 
 def _fetch_wallet_payloads(client: PolymarketPublicClient, wallets: list[str], limit: int) -> dict[str, list[dict[str, Any]]]:
@@ -198,6 +243,11 @@ def _filter_duplicate_candidates(store: SignalStore, candidates: list) -> tuple[
 
 def _is_trusted_execution_result(result) -> bool:
     return str(result.status).strip().lower() in TRUSTED_POSITION_STATUSES and bool(str(result.order_id).strip())
+
+
+def _is_evm_address(value: str) -> bool:
+    value = str(value).strip()
+    return len(value) == 42 and value.startswith("0x") and all(char in HEX_CHARS for char in value[2:])
 
 
 def _elapsed_ms(started: float) -> int:

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -36,6 +36,18 @@ class PolymarketPublicClient:
         payload = self._get_json(f"{self.gamma_base_url}/markets?{query}")
         return _extract_list(payload)
 
+    def fetch_markets_by_condition_ids(self, condition_ids: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        unique_ids = sorted({market_id.strip() for market_id in condition_ids if market_id and market_id.strip()})
+        for chunk in _chunks(unique_ids, max(chunk_size, 1)):
+            query = urlencode({"condition_ids": ",".join(chunk), "limit": len(chunk)})
+            try:
+                payload = self._get_json(f"{self.gamma_base_url}/markets?{query}")
+            except Exception:
+                continue
+            results.extend(_extract_list(payload))
+        return results
+
     def fetch_leaderboard(self, limit: int) -> list[dict[str, Any]]:
         query = urlencode({"limit": limit})
         payload = self._get_json(f"{self.data_base_url}/v1/leaderboard?{query}")
@@ -68,8 +80,10 @@ def build_market_snapshots(items: list[dict[str, Any]]) -> dict[str, MarketSnaps
     snapshots: dict[str, MarketSnapshot] = {}
     for item in items:
         snapshot = market_snapshot_from_gamma(item)
-        if snapshot is not None:
-            snapshots[snapshot.market_id] = snapshot
+        if snapshot is None:
+            continue
+        for market_id in _market_snapshot_aliases(item, snapshot):
+            snapshots.setdefault(market_id, snapshot)
     return snapshots
 
 
@@ -81,16 +95,28 @@ def enrich_market_snapshots_with_orderbooks(
     if not snapshots:
         return {}
 
-    enriched: dict[str, MarketSnapshot] = {}
-    workers = max(1, min(max_workers, len(snapshots)))
+    unique_snapshots: dict[str, MarketSnapshot] = {}
+    aliases_by_canonical: dict[str, list[str]] = {}
+    for alias, snapshot in snapshots.items():
+        unique_snapshots.setdefault(snapshot.market_id, snapshot)
+        aliases_by_canonical.setdefault(snapshot.market_id, []).append(alias)
+
+    enriched_unique: dict[str, MarketSnapshot] = {}
+    workers = max(1, min(max_workers, len(unique_snapshots)))
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {executor.submit(_enrich_one_snapshot, snapshot, client): market_id for market_id, snapshot in snapshots.items()}
+        futures = {executor.submit(_enrich_one_snapshot, snapshot, client): market_id for market_id, snapshot in unique_snapshots.items()}
         for future in as_completed(futures):
             market_id = futures[future]
             try:
-                enriched[market_id] = future.result()
+                enriched_unique[market_id] = future.result()
             except Exception:
-                enriched[market_id] = snapshots[market_id]
+                enriched_unique[market_id] = unique_snapshots[market_id]
+
+    enriched: dict[str, MarketSnapshot] = {}
+    for canonical_id, aliases in aliases_by_canonical.items():
+        snapshot = enriched_unique.get(canonical_id, unique_snapshots[canonical_id])
+        for alias in aliases:
+            enriched[alias] = snapshot
     return enriched
 
 
@@ -140,8 +166,18 @@ def build_wallet_trades(
     return trades
 
 
+def extract_trade_market_ids(wallet_payloads: dict[str, list[dict[str, Any]]]) -> list[str]:
+    market_ids: set[str] = set()
+    for items in wallet_payloads.values():
+        for item in items:
+            market_id = _trade_market_id(item)
+            if market_id:
+                market_ids.add(market_id)
+    return sorted(market_ids)
+
+
 def market_snapshot_from_gamma(item: dict[str, Any]) -> MarketSnapshot | None:
-    market_id = str(item.get("conditionId") or item.get("id") or "").strip()
+    market_id = str(item.get("conditionId") or item.get("condition_id") or item.get("id") or "").strip()
     if not market_id:
         return None
 
@@ -176,7 +212,7 @@ def wallet_trade_from_data(
     item: dict[str, Any],
     now: datetime,
 ) -> WalletTrade | None:
-    market_id = str(item.get("conditionId") or item.get("market_id") or item.get("marketId") or item.get("market") or "").strip()
+    market_id = _trade_market_id(item)
     side = _trade_side(item)
     if not market_id or side not in {"YES", "NO"}:
         return None
@@ -207,6 +243,24 @@ def _extract_list(payload: Any) -> list[dict[str, Any]]:
             if isinstance(value, list):
                 return [item for item in value if isinstance(item, dict)]
     return []
+
+
+def _trade_market_id(item: dict[str, Any]) -> str:
+    for key in ("conditionId", "condition_id", "conditionID", "condition", "market_id", "marketId", "market"):
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _market_snapshot_aliases(item: dict[str, Any], snapshot: MarketSnapshot) -> list[str]:
+    aliases = [snapshot.market_id]
+    for key in ("conditionId", "condition_id", "conditionID", "condition", "id", "market_id", "marketId", "market", "slug", "marketSlug"):
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            aliases.append(str(value).strip())
+    aliases.extend(token_id for token_id in (snapshot.yes_token_id, snapshot.no_token_id) if token_id)
+    return list(dict.fromkeys(aliases))
 
 
 def _trade_side(item: dict[str, Any]) -> str:
@@ -305,6 +359,10 @@ def _parse_datetime(value: Any) -> datetime:
         normalized = value.replace("Z", "+00:00")
         return datetime.fromisoformat(normalized).astimezone(UTC)
     raise ValueError("Unsupported datetime value")
+
+
+def _chunks(items: list[str], size: int) -> list[list[str]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
 
 
 def _retry_delay(base_delay: float, attempt: int) -> float:

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -13,11 +13,13 @@ class WalletQualityScorer:
         self.recency_half_life_seconds = recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1)
         self.last_rejection_counts: dict[str, int] = {}
         self.last_wallet_rejection_counts: dict[str, dict[str, int]] = {}
+        self.last_missing_market_samples: list[str] = []
 
     def score(self, trades: list[WalletTrade], markets: dict[str, MarketSnapshot]) -> dict[str, WalletQuality]:
         grouped: dict[str, list[WalletTrade]] = defaultdict(list)
         rejection_counts: Counter[str] = Counter()
         wallet_rejections: dict[str, Counter[str]] = defaultdict(Counter)
+        missing_market_samples: list[str] = []
         for trade in trades:
             grouped[trade.wallet].append(trade)
 
@@ -31,6 +33,8 @@ class WalletQualityScorer:
                 else:
                     rejection_counts[reason] += 1
                     wallet_rejections[wallet][reason] += 1
+                    if reason == "missing_market" and trade.market_id not in missing_market_samples and len(missing_market_samples) < 10:
+                        missing_market_samples.append(trade.market_id)
             if not eligible:
                 continue
 
@@ -56,6 +60,7 @@ class WalletQualityScorer:
 
         self.last_rejection_counts = dict(sorted(rejection_counts.items()))
         self.last_wallet_rejection_counts = {wallet: dict(sorted(counts.items())) for wallet, counts in sorted(wallet_rejections.items())}
+        self.last_missing_market_samples = missing_market_samples
         return scores
 
     def rejection_reason(self, trade: WalletTrade, markets: dict[str, MarketSnapshot]) -> str | None:

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -2,8 +2,10 @@ from datetime import UTC, datetime
 
 from predictcel.polymarket import (
     _extract_list,
+    build_market_snapshots,
     build_wallet_trades,
     enrich_market_snapshots_with_orderbooks,
+    extract_trade_market_ids,
     market_snapshot_from_gamma,
     wallet_trade_from_data,
 )
@@ -40,6 +42,23 @@ def test_market_snapshot_from_gamma_parses_string_prices_and_token_ids() -> None
     assert snapshot.no_token_id == "no_token"
 
 
+def test_build_market_snapshots_indexes_common_aliases() -> None:
+    snapshots = build_market_snapshots(
+        [
+            {
+                "conditionId": "cond_1",
+                "slug": "will-event-x-happen",
+                "outcomePrices": "[0.61, 0.35]",
+                "clobTokenIds": "[\"yes_token\", \"no_token\"]",
+            }
+        ]
+    )
+
+    assert snapshots["cond_1"].market_id == "cond_1"
+    assert snapshots["will-event-x-happen"].market_id == "cond_1"
+    assert snapshots["yes_token"].market_id == "cond_1"
+
+
 def test_enrich_market_snapshots_with_orderbooks_adds_spread_and_depth() -> None:
     item = {
         "conditionId": "cond_1",
@@ -61,7 +80,7 @@ def test_enrich_market_snapshots_with_orderbooks_adds_spread_and_depth() -> None
         }
     )
 
-    enriched = enrich_market_snapshots_with_orderbooks({"cond_1": snapshot}, client)
+    enriched = enrich_market_snapshots_with_orderbooks({"cond_1": snapshot, "yes_token": snapshot}, client)
 
     assert enriched["cond_1"].yes_bid == 0.59
     assert enriched["cond_1"].no_bid == 0.33
@@ -72,12 +91,13 @@ def test_enrich_market_snapshots_with_orderbooks_adds_spread_and_depth() -> None
     assert enriched["cond_1"].yes_spread == 0.03
     assert enriched["cond_1"].no_spread == 0.03
     assert enriched["cond_1"].orderbook_ready is True
+    assert enriched["yes_token"].orderbook_ready is True
 
 
 def test_wallet_trade_from_data_uses_outcome_and_timestamp() -> None:
     now = datetime(2026, 1, 1, tzinfo=UTC)
     item = {
-        "conditionId": "cond_1",
+        "condition_id": "cond_1",
         "outcome": "YES",
         "price": "0.54",
         "size": "250",
@@ -92,6 +112,19 @@ def test_wallet_trade_from_data_uses_outcome_and_timestamp() -> None:
     assert trade.side == "YES"
     assert trade.market_id == "cond_1"
     assert trade.age_seconds == 600
+
+
+def test_extract_trade_market_ids_deduplicates_common_shapes() -> None:
+    payloads = {
+        "wallet_a": [
+            {"conditionId": "cond_1"},
+            {"condition_id": "cond_1"},
+            {"marketSlug": "ignored"},
+            {"market": "market_2"},
+        ]
+    }
+
+    assert extract_trade_market_ids(payloads) == ["cond_1", "market_2"]
 
 
 def test_build_wallet_trades_skips_wallets_without_topic_mapping() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -40,6 +40,7 @@ def test_wallet_quality_scores_eligible_wallet() -> None:
     assert scores["w1"].eligible_trade_count == 2
     assert "exponential freshness" in scores["w1"].reason
     assert scorer.last_rejection_counts == {}
+    assert scorer.last_missing_market_samples == []
 
 
 def test_scoring_diagnostics_count_rejection_reasons() -> None:
@@ -59,6 +60,7 @@ def test_scoring_diagnostics_count_rejection_reasons() -> None:
     assert scorer.last_rejection_counts == {"missing_market": 1, "too_old": 1, "too_small": 1}
     assert scorer.last_wallet_rejection_counts["w1"] == {"missing_market": 1, "too_small": 1}
     assert scorer.last_wallet_rejection_counts["w2"] == {"too_old": 1}
+    assert scorer.last_missing_market_samples == ["missing"]
 
 
 def test_compute_copyability_score_rewards_better_inputs() -> None:


### PR DESCRIPTION
## Summary
- filters configured baskets to real EVM wallet addresses before polling live Data API trades
- hydrates the market cache with supplemental Gamma market rows based on trade market identifiers
- indexes Gamma market snapshots by common aliases while deduplicating orderbook enrichment calls
- adds live input diagnostics and missing market samples to Railway JSON output

## Testing
- Not run locally; changes were applied directly on GitHub per request.
