### PR TITLE
Fix Gamma supplemental market lookup

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -201,7 +201,7 @@ def _load_live_inputs(config):
     active_market_rows = client.fetch_active_markets(config.live_data.market_limit)
     markets = build_market_snapshots(active_market_rows)
     missing_trade_market_ids = [market_id for market_id in trade_market_ids if market_id not in markets]
-    supplemental_rows = client.fetch_markets_by_condition_ids(missing_trade_market_ids)
+    supplemental_rows = client.fetch_markets_by_identifiers(missing_trade_market_ids)
     if supplemental_rows:
         markets.update(build_market_snapshots(supplemental_rows))
 

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -37,15 +37,24 @@ class PolymarketPublicClient:
         return _extract_list(payload)
 
     def fetch_markets_by_condition_ids(self, condition_ids: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
+        return self._fetch_markets_by_array_filter("condition_ids", condition_ids, chunk_size)
+
+    def fetch_markets_by_clob_token_ids(self, token_ids: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
+        return self._fetch_markets_by_array_filter("clob_token_ids", token_ids, chunk_size)
+
+    def fetch_markets_by_identifiers(self, identifiers: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
-        unique_ids = sorted({market_id.strip() for market_id in condition_ids if market_id and market_id.strip()})
-        for chunk in _chunks(unique_ids, max(chunk_size, 1)):
-            query = urlencode({"condition_ids": ",".join(chunk), "limit": len(chunk)})
-            try:
-                payload = self._get_json(f"{self.gamma_base_url}/markets?{query}")
-            except Exception:
-                continue
-            results.extend(_extract_list(payload))
+        seen_market_keys: set[str] = set()
+        for rows in (
+            self.fetch_markets_by_condition_ids(identifiers, chunk_size),
+            self.fetch_markets_by_clob_token_ids(identifiers, chunk_size),
+        ):
+            for row in rows:
+                key = str(row.get("conditionId") or row.get("condition_id") or row.get("id") or row).strip()
+                if key in seen_market_keys:
+                    continue
+                seen_market_keys.add(key)
+                results.append(row)
         return results
 
     def fetch_leaderboard(self, limit: int) -> list[dict[str, Any]]:
@@ -62,6 +71,18 @@ class PolymarketPublicClient:
         query = urlencode({"token_id": token_id})
         payload = self._get_json(f"{self.clob_base_url}/book?{query}")
         return payload if isinstance(payload, dict) else {}
+
+    def _fetch_markets_by_array_filter(self, filter_name: str, values: list[str], chunk_size: int) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        unique_values = sorted({value.strip() for value in values if value and value.strip()})
+        for chunk in _chunks(unique_values, max(chunk_size, 1)):
+            query = urlencode({filter_name: chunk, "limit": len(chunk)}, doseq=True)
+            try:
+                payload = self._get_json(f"{self.gamma_base_url}/markets?{query}")
+            except Exception:
+                continue
+            results.extend(_extract_list(payload))
+        return results
 
     def _get_json(self, url: str) -> Any:
         request = Request(url, headers={"User-Agent": "PredictCel/0.1"})

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -19,6 +19,15 @@ class FakeClient:
         return self.books.get(token_id, {})
 
 
+class FakeGammaClient:
+    def __init__(self):
+        self.urls = []
+
+    def _get_json(self, url: str):
+        self.urls.append(url)
+        return {"markets": [{"conditionId": "cond_1", "outcomePrices": "[0.61, 0.35]"}]}
+
+
 def test_market_snapshot_from_gamma_parses_string_prices_and_token_ids() -> None:
     item = {
         "conditionId": "cond_1",
@@ -125,6 +134,16 @@ def test_extract_trade_market_ids_deduplicates_common_shapes() -> None:
     }
 
     assert extract_trade_market_ids(payloads) == ["cond_1", "market_2"]
+
+
+def test_gamma_market_array_filter_uses_repeated_query_params() -> None:
+    client = FakeGammaClient()
+
+    rows = client._fetch_markets_by_array_filter("clob_token_ids", ["token_a", "token_b"], 25)
+
+    assert rows == [{"conditionId": "cond_1", "outcomePrices": "[0.61, 0.35]"}]
+    assert "clob_token_ids=token_a" in client.urls[0]
+    assert "clob_token_ids=token_b" in client.urls[0]
 
 
 def test_build_wallet_trades_skips_wallets_without_topic_mapping() -> None:

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 from predictcel.polymarket import (
+    PolymarketPublicClient,
     _extract_list,
     build_market_snapshots,
     build_wallet_trades,
@@ -19,8 +20,9 @@ class FakeClient:
         return self.books.get(token_id, {})
 
 
-class FakeGammaClient:
+class FakeGammaClient(PolymarketPublicClient):
     def __init__(self):
+        super().__init__()
         self.urls = []
 
     def _get_json(self, url: str):


### PR DESCRIPTION
## Summary
- sends Gamma array filters as repeated query params instead of comma-joined strings
- resolves missing live trade markets through both `condition_ids` and `clob_token_ids`
- keeps the Railway live-input diagnostics while making `supplemental_market_rows_loaded` meaningful for token-backed trade IDs

## Testing
- Not run locally; changes were applied directly on GitHub per request.
