### PR TITLE
chore: tagged basket structure - 268 wallets, 22 baskets

### DIFF
--- a/config/predictcel.example.json
+++ b/config/predictcel.example.json
@@ -166,9 +166,9 @@
         "0xe542afd3881c4c330ba0ebbb603bb470b2ba0a37",
         "0x47ab026767cc320ac6e62f6ec747d59cf4d795df",
         "0xd5ccdf772f795547e299de57f47966e24de8dea4",
-        "0x8d8A6BF269646a9F72E8d9E03C53415D153b715d",
-        "0x21a31Ee1afc59152d32CF38a2a2952d2aECa921a",
-        "0xBE0eB53F46cd790Cd13851d5EFf43D12404d33E8",
+        "0x8d8a6bf269646a9f72e8d9e03c53415d153b715d",
+        "0x21a31ee1afc59152d32cf38a2a2952d2aeca921a",
+        "0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",
         "0x81e0d0c6817669629a58ea8b08d2eb1b93492c3b",
         "0xfba277382e9f1c8dc2f93ba4eafacfd5d37297c1",
         "0x19a1277f9eda4e5078b8aec978ad81c85ec0472c",
@@ -198,10 +198,12 @@
         "0xd38b71f3e8ed1af71983e5c309eac3dfa9b35029",
         "0x9d84ce0306f8551e02efef1680475fc0f1dc1344",
         "0x37c1874a60d348903594a96703e0507c518fc53a",
-        "0x07bdcabf60da99be8fad11092bf4e8412cffe993"
+        "0x07bdcabf60da99be8fad11092bf4e8412cffe993",
+        "0xf524bfb554fc488324dafe01ce36178156c38178",
+        "0x632378d502d023faa01dfd94997c529e516329ed"
       ],
       "quorum_ratio": 0.2,
-      "note": "War, Ukraine, Russia, Iran, Israel, NATO, Taiwan"
+      "note": "War, Ukraine, Russia, Iran, Israel, Taiwan, China relations"
     },
     {
       "topic": "trump",
@@ -238,7 +240,7 @@
         "0xc8075693f48668a264b9fa313b47f52712fcc12b"
       ],
       "quorum_ratio": 0.2,
-      "note": "Trump approval, impeachment, pardon, admin decisions"
+      "note": "Trump admin, approval, impeachment, pardon"
     },
     {
       "topic": "us_election",
@@ -264,7 +266,8 @@
         "0xe8b7023153d625f8d111d3b1b93a672f2418c4db",
         "0x1c17f1d806926fbb900c59fb3c385fd75c013653",
         "0x31864feb9d25dee93728c6225ba891530967e9ca",
-        "0x5bffcf561bcae83af680ad600cb99f1184d6ffbe"
+        "0x5bffcf561bcae83af680ad600cb99f1184d6ffbe",
+        "0xf524bfb554fc488324dafe01ce36178156c38178"
       ],
       "quorum_ratio": 0.2,
       "note": "US elections, Senate, Congress, Biden, polls"
@@ -272,6 +275,7 @@
     {
       "topic": "crypto",
       "wallets": [
+        "0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b",
         "0xeebde7a0e019a63e6b476eb425505b7b3e6eba30",
         "0x674887d1ac838099a48b629dff53f25b7b87ee08",
         "0x665b25ede9866b456432b3fcccdc7ce6b42de773",
@@ -321,14 +325,69 @@
         "0x5b69fe7048a533847b4e3abe1b9eea261a91a6af",
         "0xa67d00591c8f609e69d39dcd1503a771fb3c85c6",
         "0x3f3b427368f7cc3f9560c57cdedce6fa18fe3a4c",
-        "0x5bc331ff6a2f3a679f0c98cca0d92cdda5c47a59"
+        "0x5bc331ff6a2f3a679f0c98cca0d92cdda5c47a59",
+        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
       ],
       "quorum_ratio": 0.2,
-      "note": "BTC/ETH/SOL short-term up-or-down"
+      "note": "BTC/ETH/SOL short-term price prediction markets"
     },
     {
       "topic": "longterm_crypto",
       "wallets": [
+        "0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b",
+        "0xeebde7a0e019a63e6b476eb425505b7b3e6eba30",
+        "0x674887d1ac838099a48b629dff53f25b7b87ee08",
+        "0x665b25ede9866b456432b3fcccdc7ce6b42de773",
+        "0x20d2309cd92b797ae7ca175ed828ed8a27fbe29d",
+        "0x0e16ae2082d82bf1c727038952b61db5a3bd1207",
+        "0xd7c626093f28383612363889ad811fc736d3706f",
+        "0x4d40c3f3627f64591eac428cd4248c651a9c398d",
+        "0x75cc3b63a2f2423085e10706c78b494017b93ce1",
+        "0x32e4abe3e97aaf3c95c315ba3ffbe7b2a313beed",
+        "0x968553298d1cc1c343d11398cb42db76d533aed0",
+        "0x218f36c313d6c012636b21cc6b5a043d9fef17bc",
+        "0x3a847382ad6fff9be1db4e073fd9b869f6884d44",
+        "0xf3531b23b504cf0aed4ff21325232b2a2d496685",
+        "0x7347d3291b321d2ee8d43d24aff244e7fb8c3d35",
+        "0x43f1949de1964deb6f7ec5865964d476cc5d06e5",
+        "0x5d3cc45e538130b02c8f3c821638ec9cd350c298",
+        "0x6c6aefbdb3fe1a0a7ee3d07277f9e58b76064fd2",
+        "0x60889af507ec3f9da136f38b1c58080bec32f361",
+        "0xe1d6b51521bd4365769199f392f9818661bd907c",
+        "0x1f19c48aee80ec95396d91f0d21ac249b8a7f57a",
+        "0x6bab41a0dc40d6dd4c1a915b8c01969479fd1292",
+        "0x7177a7f5c216809c577c50c77b12aae81f81ddef",
+        "0xcd71fd5370880f3d92bb941e628c05840fe0d127",
+        "0xe9ad918c7678cd38b12603a762e638a5d1ee7091",
+        "0x23786fdad0073692157c6d7dc81f281843a35fcb",
+        "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e",
+        "0x006cc834cc092684f1b56626e23bedb3835c16ea",
+        "0x7fb7ad0d194d7123e711e7db6c9d418fac14e33d",
+        "0xc6474ca778dde50b2f2d8074b8ea914a54b75e87",
+        "0x11dc2b4145b0497fcbdd70599dd61513efa51502",
+        "0x9b95638015b4adaa7f4f7435b0f5816b687f6c4a",
+        "0x6e9443babf02148408bbd05413f9ea6aba2b9b29",
+        "0x2d3a2efa0516f700165b10561d90fa5a77287d4a",
+        "0xbf289b9f2b78a6f83d222fec98209339f5d78f93",
+        "0xf613d20d8ede6f4705a1288e6d2f668b1c78b2d4",
+        "0xae94949d4778af469e631a92383fd2eac615af2c",
+        "0x4705408c791455edffc66782d4cea30c17afd03e",
+        "0x8e64bf9ddbe4f0a98693f64c6c826761a4c317e4",
+        "0x65a7e6303e0a625b15a6001524c334d31dec8060",
+        "0x3e6d998a25793c1d0ca5b59d7d7ac7f8d0132671",
+        "0xdb7e93cd4668dda1b73abb2acd1687a88173b4c7",
+        "0x01a9160c6a2aa8591a11a88badbc505e824575dd",
+        "0x71bf7564bdae113a21e2116d471cbcb5619495de",
+        "0xd9d65d9b4d41c9bbd77b332009a6d849b886b245",
+        "0xcdf79098337926ce014ac680d98cc9728439824e",
+        "0x27f041f8786c43281c853623dade7fdbf7ffe9e6",
+        "0x5b69fe7048a533847b4e3abe1b9eea261a91a6af",
+        "0xa67d00591c8f609e69d39dcd1503a771fb3c85c6",
+        "0x3f3b427368f7cc3f9560c57cdedce6fa18fe3a4c",
+        "0x5bc331ff6a2f3a679f0c98cca0d92cdda5c47a59",
         "0xd768776321066958f7a032652acb5344a26a8e1f",
         "0xf705fa045201391d9632b7f3cde06a5e24453ca7",
         "0xe5f85d076f0b1edd4ec89bfb95e123a9036a8d75",
@@ -340,14 +399,58 @@
         "0x50733d0627e4763d7d7e81a69abc345edf6416a7",
         "0xd634c33f7de4aa342c3136ac8b5b36ef390f77ad",
         "0x1643038efde95846b92b008e2efedca553296ec8",
-        "0xee767b98e3c9d59a612135a091ea8c8f00ec8fed"
+        "0xee767b98e3c9d59a612135a091ea8c8f00ec8fed",
+        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
       ],
       "quorum_ratio": 0.2,
-      "note": "BTC above targets, long-term crypto"
+      "note": "BTC long-term targets and crypto fundamentals"
+    },
+    {
+      "topic": "nba",
+      "wallets": [
+        "0xefbc5fec8d7b0acdc8911bdd9a98d6964308f9a2",
+        "0x019782cab5d844f02bafb71f512758be78579f3c",
+        "0x02227b8f5a9636e895607edd3185ed6ee5598ff7",
+        "0x37c1874a60d348903594a96703e0507c518fc53a",
+        "0x07bdcabf60da99be8fad11092bf4e8412cffe993",
+        "0xc8075693f48668a264b9fa313b47f52712fcc12b",
+        "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e",
+        "0xc2e7800b5af46e6093872b177b7a5e7f0563be51",
+        "0x50b1db131a24a9d9450bbd0372a95d32ea88f076",
+        "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb",
+        "0x777d9f00c2b4f7b829c9de0049ca3e707db05143",
+        "0xf195721ad850377c96cd634457c70cd9e8308057",
+        "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09",
+        "0x9f2fe025f84839ca81dd8e0338892605702d2ca8",
+        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a",
+        "0x3f084183bd7135768605c7525ea3d94a39a6e919",
+        "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5",
+        "0xbddf61af533ff524d27154e589d2d7a81510c684",
+        "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x93abbc022ce98d6f45d4444b594791cc4b7a9723",
+        "0xdc876e6873772d38716fda7f2452a78d426d7ab6",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "NBA - team games, playoffs, MVP, championships"
     },
     {
       "topic": "sports",
       "wallets": [
+        "0xead152b855effa6b5b5837f53b24c0756830c76a",
+        "0xefbc5fec8d7b0acdc8911bdd9a98d6964308f9a2",
+        "0x019782cab5d844f02bafb71f512758be78579f3c",
+        "0x02227b8f5a9636e895607edd3185ed6ee5598ff7",
+        "0x37c1874a60d348903594a96703e0507c518fc53a",
+        "0x07bdcabf60da99be8fad11092bf4e8412cffe993",
+        "0xee613b3fc183ee44f9da9c05f53e2da107e3debf",
+        "0xc8075693f48668a264b9fa313b47f52712fcc12b",
+        "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e",
         "0x232db46657c1f711aa275d324bd42eddf609de8e",
         "0xc7b84afab9e144a258b98a1cb45e05df7aab0d21",
         "0x1fa1bbcc1cd75b0d04eb5590ad4a812eb2b0e73a",
@@ -377,14 +480,140 @@
         "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb",
         "0x777d9f00c2b4f7b829c9de0049ca3e707db05143",
         "0xf195721ad850377c96cd634457c70cd9e8308057",
-        "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09"
+        "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09",
+        "0x9f2fe025f84839ca81dd8e0338892605702d2ca8",
+        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a",
+        "0x3f084183bd7135768605c7525ea3d94a39a6e919",
+        "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5",
+        "0xbddf61af533ff524d27154e589d2d7a81510c684",
+        "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x93abbc022ce98d6f45d4444b594791cc4b7a9723",
+        "0xdc876e6873772d38716fda7f2452a78d426d7ab6",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
       ],
       "quorum_ratio": 0.2,
-      "note": "NBA, NFL, MLB, UFC, Super Bowl"
+      "note": "General sports - catch-all for all sports-tagged wallets"
+    },
+    {
+      "topic": "nfl",
+      "wallets": [],
+      "quorum_ratio": 0.2,
+      "note": "NFL - games, playoffs, Super Bowl"
+    },
+    {
+      "topic": "soccer",
+      "wallets": [
+        "0xefbc5fec8d7b0acdc8911bdd9a98d6964308f9a2",
+        "0x019782cab5d844f02bafb71f512758be78579f3c",
+        "0x02227b8f5a9636e895607edd3185ed6ee5598ff7",
+        "0x37c1874a60d348903594a96703e0507c518fc53a",
+        "0x07bdcabf60da99be8fad11092bf4e8412cffe993",
+        "0xee613b3fc183ee44f9da9c05f53e2da107e3debf",
+        "0xc8075693f48668a264b9fa313b47f52712fcc12b",
+        "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e",
+        "0xc2e7800b5af46e6093872b177b7a5e7f0563be51",
+        "0x50b1db131a24a9d9450bbd0372a95d32ea88f076",
+        "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb",
+        "0x777d9f00c2b4f7b829c9de0049ca3e707db05143",
+        "0xf195721ad850377c96cd634457c70cd9e8308057",
+        "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09",
+        "0x9f2fe025f84839ca81dd8e0338892605702d2ca8",
+        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a",
+        "0x3f084183bd7135768605c7525ea3d94a39a6e919",
+        "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5",
+        "0xbddf61af533ff524d27154e589d2d7a81510c684",
+        "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x93abbc022ce98d6f45d4444b594791cc4b7a9723",
+        "0xdc876e6873772d38716fda7f2452a78d426d7ab6",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "Premier League, La Liga, Serie A, Bundesliga, Champions League, World Cup"
+    },
+    {
+      "topic": "ufc_boxing",
+      "wallets": [],
+      "quorum_ratio": 0.2,
+      "note": "UFC, MMA, Boxing - fight outcomes, method of victory"
+    },
+    {
+      "topic": "mlb",
+      "wallets": [
+        "0xefbc5fec8d7b0acdc8911bdd9a98d6964308f9a2",
+        "0x019782cab5d844f02bafb71f512758be78579f3c",
+        "0x02227b8f5a9636e895607edd3185ed6ee5598ff7",
+        "0x37c1874a60d348903594a96703e0507c518fc53a",
+        "0x07bdcabf60da99be8fad11092bf4e8412cffe993",
+        "0xc8075693f48668a264b9fa313b47f52712fcc12b",
+        "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e",
+        "0xc2e7800b5af46e6093872b177b7a5e7f0563be51",
+        "0x50b1db131a24a9d9450bbd0372a95d32ea88f076",
+        "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb",
+        "0x777d9f00c2b4f7b829c9de0049ca3e707db05143",
+        "0xf195721ad850377c96cd634457c70cd9e8308057",
+        "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09",
+        "0x9f2fe025f84839ca81dd8e0338892605702d2ca8",
+        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a",
+        "0x3f084183bd7135768605c7525ea3d94a39a6e919",
+        "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5",
+        "0xbddf61af533ff524d27154e589d2d7a81510c684",
+        "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x93abbc022ce98d6f45d4444b594791cc4b7a9723",
+        "0xdc876e6873772d38716fda7f2452a78d426d7ab6",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "MLB baseball - games, World Series, player props"
+    },
+    {
+      "topic": "f1",
+      "wallets": [],
+      "quorum_ratio": 0.2,
+      "note": "F1 - race winners, podiums, championships"
+    },
+    {
+      "topic": "tennis",
+      "wallets": [
+        "0xefbc5fec8d7b0acdc8911bdd9a98d6964308f9a2",
+        "0x019782cab5d844f02bafb71f512758be78579f3c",
+        "0x02227b8f5a9636e895607edd3185ed6ee5598ff7",
+        "0x37c1874a60d348903594a96703e0507c518fc53a",
+        "0x07bdcabf60da99be8fad11092bf4e8412cffe993",
+        "0xc8075693f48668a264b9fa313b47f52712fcc12b",
+        "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e",
+        "0xc2e7800b5af46e6093872b177b7a5e7f0563be51",
+        "0x50b1db131a24a9d9450bbd0372a95d32ea88f076",
+        "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb",
+        "0x777d9f00c2b4f7b829c9de0049ca3e707db05143",
+        "0xf195721ad850377c96cd634457c70cd9e8308057",
+        "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09",
+        "0x9f2fe025f84839ca81dd8e0338892605702d2ca8",
+        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a",
+        "0x3f084183bd7135768605c7525ea3d94a39a6e919",
+        "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5",
+        "0xbddf61af533ff524d27154e589d2d7a81510c684",
+        "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15",
+        "0x2005d16a84ceefa912d4e380cd32e7ff827875ea",
+        "0x93abbc022ce98d6f45d4444b594791cc4b7a9723",
+        "0xdc876e6873772d38716fda7f2452a78d426d7ab6",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "Tennis - Grand Slams, ATP, WTA, match outcomes"
     },
     {
       "topic": "esports",
       "wallets": [
+        "0x019782cab5d844f02bafb71f512758be78579f3c",
+        "0x37c1874a60d348903594a96703e0507c518fc53a",
+        "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb",
         "0xdc5aa14975f4cbb19169554723ffa5e89570bf71",
         "0x7e0be260bf431c091d7218e2d7960fc940944dd5",
         "0x5471604e05accad637155999bbf90d9fad76a236",
@@ -407,10 +636,15 @@
         "0x1b8cad78a3b8e59f6dc24f57eabef2c5de49f73a",
         "0x3b5c629f114098b0dee345fb78b7a3a013c7126e",
         "0x9f2fe025f84839ca81dd8e0338892605702d2ca8",
-        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a"
+        "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a",
+        "0x3f084183bd7135768605c7525ea3d94a39a6e919",
+        "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5",
+        "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15",
+        "0x492442eab586f242b53bda933fd5de859c8a3782",
+        "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1"
       ],
       "quorum_ratio": 0.2,
-      "note": "CS2, Valorant, Dota, League of Legends, F1"
+      "note": "CS2, Valorant, League of Legends, Dota 2"
     },
     {
       "topic": "weather",
@@ -438,7 +672,7 @@
         "0x6dad6e29c1879058181b9e0cfd2797d7939f5c37"
       ],
       "quorum_ratio": 0.2,
-      "note": "Temperature, weather events"
+      "note": "Temperature forecasts, weather events"
     },
     {
       "topic": "economy",
@@ -448,7 +682,54 @@
         "0x5aa4ab516dbdc8657362466132cb620be3562cfb"
       ],
       "quorum_ratio": 0.2,
-      "note": "Inflation, Fed rates, GDP, unemployment"
+      "note": "Inflation, Fed rates, GDP, economic indicators"
+    },
+    {
+      "topic": "ai_science",
+      "wallets": [
+        "0xead152b855effa6b5b5837f53b24c0756830c76a",
+        "0xcd91a549956854fdc38efad7e80ff5da8f5432b8",
+        "0x99c97ff0da44d5aab0d3bd59d5ea0c524fb24c22",
+        "0x36901eb0f21519cc9055662a6d2483e96da1e16f",
+        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
+        "0xffd87246e85ec478d221ade469c3c19ed3be1a4d"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "AI model race - OpenAI, DeepSeek, Anthropic capabilities"
+    },
+    {
+      "topic": "medical",
+      "wallets": [
+        "0xead152b855effa6b5b5837f53b24c0756830c76a",
+        "0xcd91a549956854fdc38efad7e80ff5da8f5432b8",
+        "0x99c97ff0da44d5aab0d3bd59d5ea0c524fb24c22",
+        "0x36901eb0f21519cc9055662a6d2483e96da1e16f",
+        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
+        "0xffd87246e85ec478d221ade469c3c19ed3be1a4d"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "Medical research, FDA decisions, drug approvals"
+    },
+    {
+      "topic": "space",
+      "wallets": [
+        "0xead152b855effa6b5b5837f53b24c0756830c76a",
+        "0xcd91a549956854fdc38efad7e80ff5da8f5432b8",
+        "0x99c97ff0da44d5aab0d3bd59d5ea0c524fb24c22",
+        "0x36901eb0f21519cc9055662a6d2483e96da1e16f",
+        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
+        "0xffd87246e85ec478d221ade469c3c19ed3be1a4d"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "Space missions, NASA, SpaceX, satellite launches"
+    },
+    {
+      "topic": "elon_musk",
+      "wallets": [
+        "0xbc13c7d56f6144af394335ab837d28167b1b5578"
+      ],
+      "quorum_ratio": 0.2,
+      "note": "Elon Musk - tweets, Tesla, SpaceX, DOGE, xAI"
     },
     {
       "topic": "tech",
@@ -467,10 +748,15 @@
         "0xad5353afe30c2da57709e2704ef3ccdcf67eef24",
         "0x707ae3c159dca22b4e375cbdd10023b76d49a170",
         "0x0979bad57d7a1403db89cbcd9c52bf43f2138d9b",
-        "0x7ac83882979ccb5665cea83cb269e558b55077cd"
+        "0x7ac83882979ccb5665cea83cb269e558b55077cd",
+        "0xcd91a549956854fdc38efad7e80ff5da8f5432b8",
+        "0x99c97ff0da44d5aab0d3bd59d5ea0c524fb24c22",
+        "0x36901eb0f21519cc9055662a6d2483e96da1e16f",
+        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
+        "0xffd87246e85ec478d221ade469c3c19ed3be1a4d"
       ],
       "quorum_ratio": 0.2,
-      "note": "OpenAI, Nvidia, Meta, Apple, AI stocks"
+      "note": "Tech stocks - OpenAI, Nvidia, Meta, Apple, AI companies"
     },
     {
       "topic": "entertainment",
@@ -479,30 +765,20 @@
         "0xf524bfb554fc488324dafe01ce36178156c38178"
       ],
       "quorum_ratio": 0.2,
-      "note": "Oscars, Grammy, Emmy, celebrity events, pop culture, viral moments"
-    },
-    {
-      "topic": "science",
-      "wallets": [
-        "0xcd91a549956854fdc38efad7e80ff5da8f5432b8",
-        "0x99c97ff0da44d5aab0d3bd59d5ea0c524fb24c22",
-        "0x36901eb0f21519cc9055662a6d2483e96da1e16f",
-        "0x91aa4d41bf886e073d9cf772fee77c8367d90209",
-        "0xffd87246e85ec478d221ade469c3c19ed3be1a4d"
-      ],
-      "quorum_ratio": 0.2,
-      "note": "AI model races, space missions, medical breakthroughs, climate tech"
+      "note": "Pop culture, celebrity events, viral moments, movies, music"
     },
     {
       "topic": "degen",
       "wallets": [
+        "0x192f5dada45fead2cf48cccea130a52b8d31639c",
+        "0xf524bfb554fc488324dafe01ce36178156c38178",
         "0xbc13c7d56f6144af394335ab837d28167b1b5578",
         "0x632378d502d023faa01dfd94997c529e516329ed",
         "0x3f084183bd7135768605c7525ea3d94a39a6e919",
         "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5"
       ],
       "quorum_ratio": 0.2,
-      "note": "Short-term volatile markets, meme/trending topics, obscure events"
+      "note": "High-leverage, obscure trending topics, viral bets, hot takes"
     }
   ],
   "filters": {
@@ -526,5 +802,1019 @@
     "liquidity_weight": 0.25,
     "speed_weight": 0.2,
     "confidence_weight": 0.2
+  },
+  "wallet_tags": {
+    "0xa91edabae0eae478c830a6d5dfd3acc0571709e0": [
+      "geopolitics",
+      "war",
+      "ukraine",
+      "politics"
+    ],
+    "0xead152b855effa6b5b5837f53b24c0756830c76a": [
+      "geopolitics",
+      "war",
+      "science",
+      "ai",
+      "sports"
+    ],
+    "0x5ccf62ac8155e49bc7d021a1a66e9ef18f5579d7": [
+      "geopolitics",
+      "war",
+      "ukraine"
+    ],
+    "0x69b3b4d53b702d75c6827a1d7a33663b5eb214f8": [
+      "geopolitics",
+      "war",
+      "ukraine"
+    ],
+    "0x166a49699aba5d7a9ce3142450062deedf83d7ed": [
+      "geopolitics",
+      "war"
+    ],
+    "0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b": [
+      "geopolitics",
+      "war",
+      "crypto"
+    ],
+    "0x24c8cf69a0e0a17eee21f69d29752bfa32e823e1": [
+      "geopolitics",
+      "war"
+    ],
+    "0x4e25605fd905e9972efc0f4d8814530c655cd7a7": [
+      "geopolitics",
+      "war"
+    ],
+    "0xe542afd3881c4c330ba0ebbb603bb470b2ba0a37": [
+      "geopolitics",
+      "war"
+    ],
+    "0x47ab026767cc320ac6e62f6ec747d59cf4d795df": [
+      "geopolitics",
+      "war"
+    ],
+    "0xd5ccdf772f795547e299de57f47966e24de8dea4": [
+      "geopolitics",
+      "war"
+    ],
+    "0x8d8a6bf269646a9f72e8d9e03c53415d153b715d": [
+      "geopolitics"
+    ],
+    "0x21a31ee1afc59152d32cf38a2a2952d2aeca921a": [
+      "geopolitics"
+    ],
+    "0xbe0eb53f46cd790cd13851d5eff43d12404d33e8": [
+      "geopolitics"
+    ],
+    "0x81e0d0c6817669629a58ea8b08d2eb1b93492c3b": [
+      "geopolitics"
+    ],
+    "0xfba277382e9f1c8dc2f93ba4eafacfd5d37297c1": [
+      "geopolitics"
+    ],
+    "0x19a1277f9eda4e5078b8aec978ad81c85ec0472c": [
+      "geopolitics"
+    ],
+    "0xcb9d7b65381f3f601b47ffbaf213d69d892c6e15": [
+      "geopolitics"
+    ],
+    "0x72b2a84fa6831988effa5338b1fde3cf534a0104": [
+      "geopolitics"
+    ],
+    "0xa7a1c3b19b7d7e4c8089f7dac76c2423a3b8a85e": [
+      "geopolitics"
+    ],
+    "0xf37ffd153d173406b367dcc8c5f5ebbc5328d631": [
+      "geopolitics"
+    ],
+    "0x84ad9c5c547a82ec9a08547b94bd922446e5bfb7": [
+      "geopolitics"
+    ],
+    "0x93b755e98087635368872bb190bc7eaf7d61bfcd": [
+      "geopolitics"
+    ],
+    "0xc40681969b90c1e54527775fa48273a06bef07d9": [
+      "geopolitics"
+    ],
+    "0x12ac61f06b37bca05d491bbf35f83481af2c0ca4": [
+      "geopolitics"
+    ],
+    "0x17db3fcd93ba12d38382a0cade24b200185c5f6d": [
+      "geopolitics"
+    ],
+    "0xd25c72ac0928385610611c8148803dc717334d20": [
+      "geopolitics"
+    ],
+    "0x000d257d2dc7616feaef4ae0f14600fdf50a758e": [
+      "geopolitics"
+    ],
+    "0x7f3c8979d0afa00007bae4747d5347122af05613": [
+      "geopolitics"
+    ],
+    "0x1986a3e555dd2a334c33c34b0168170cff54ef06": [
+      "geopolitics"
+    ],
+    "0x56687bf447db6ffa42ffe2204a05edaa20f55839": [
+      "geopolitics"
+    ],
+    "0x1f2dd6d473f3e824cd2f8a89d9c69fb96f6ad0cf": [
+      "geopolitics"
+    ],
+    "0x6a72f61820b26b1fe4d956e17b6dc2a1ea3033ee": [
+      "geopolitics"
+    ],
+    "0x78b9ac44a6d7d7a076c14e0ad518b301b63c6b76": [
+      "geopolitics"
+    ],
+    "0xd235973291b2b75ff4070e9c0b01728c520b0f29": [
+      "geopolitics"
+    ],
+    "0x16f91db2592924cfed6e03b7e5cb5bb1e32299e3": [
+      "geopolitics"
+    ],
+    "0xefbc5fec8d7b0acdc8911bdd9a98d6964308f9a2": [
+      "geopolitics",
+      "sports",
+      "soccer",
+      "war",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x019782cab5d844f02bafb71f512758be78579f3c": [
+      "geopolitics",
+      "sports",
+      "soccer",
+      "esports",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x16b29c50f2439faf627209b2ac0c7bbddaa8a881": [
+      "geopolitics"
+    ],
+    "0x02227b8f5a9636e895607edd3185ed6ee5598ff7": [
+      "geopolitics",
+      "sports",
+      "soccer",
+      "war",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0xd38b71f3e8ed1af71983e5c309eac3dfa9b35029": [
+      "geopolitics"
+    ],
+    "0x9d84ce0306f8551e02efef1680475fc0f1dc1344": [
+      "geopolitics"
+    ],
+    "0x37c1874a60d348903594a96703e0507c518fc53a": [
+      "geopolitics",
+      "sports",
+      "nba",
+      "magic",
+      "celtics",
+      "soccer",
+      "bundesliga",
+      "mlb",
+      "tennis",
+      "esports"
+    ],
+    "0x07bdcabf60da99be8fad11092bf4e8412cffe993": [
+      "geopolitics",
+      "sports",
+      "soccer",
+      "real_madrid",
+      "la_liga",
+      "serie_a",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x12d6cccfc7470a3f4bafc53599a4779cbf2cf2a8": [
+      "trump"
+    ],
+    "0xf1f9a438f2697381b4ac8eb283d6f4dd772d1245": [
+      "trump"
+    ],
+    "0x21064fd320bfd5a86f8c92a94d3209edf4154dea": [
+      "trump"
+    ],
+    "0x27abdfc3e9d1a8f4b6c2e0d9a7f3b5c8e1d0f2a4": [
+      "trump"
+    ],
+    "0xd1a63a5c8e2f0b4a6d9c1e3f5a7b9d2f4e6a8b0": [
+      "trump"
+    ],
+    "0x84c386331355f47057afca0c06c7211f4dbe35d4": [
+      "trump"
+    ],
+    "0x5c898593e6745d475faa40ccbb9dd1b913dbc8ff": [
+      "trump"
+    ],
+    "0xe3726a1b9c6ba2f06585d1c9e01d00afaedaeb38": [
+      "trump"
+    ],
+    "0xb69a4501852c60a12c48643057bece21cdd17c05": [
+      "trump"
+    ],
+    "0x1a3d83418c5fa02a0478e4f769649fda5e12fea1": [
+      "trump"
+    ],
+    "0x2d5241f89b392ccf3c440c78af049f50d0b1df50": [
+      "trump"
+    ],
+    "0x6e507746a76b863a749e9b2d7c60fb3a08176a26": [
+      "trump"
+    ],
+    "0x122d9ce327d1d40ded62b8782aea3d1c32af95fe": [
+      "trump"
+    ],
+    "0xc935a3b3742358a323c6777c51e7cc56f38b74cf": [
+      "trump"
+    ],
+    "0xd8b2f329027edff5db191b4f010fd8db0b86fe5b": [
+      "trump"
+    ],
+    "0x5782a0de3dcd8e1928c789e00025ef41e63274e4": [
+      "trump"
+    ],
+    "0x8b4410e877fa826c7e986dfb30a5be73d72163fb": [
+      "trump"
+    ],
+    "0xe777ae99c36fb16206afdeb96f92c3afa96c2cda": [
+      "trump"
+    ],
+    "0x14eb1b504c6d28103b7f10a0509b06b50dc2910b": [
+      "trump",
+      "us_politics"
+    ],
+    "0x6cb6e442305e583b8fe0aeddd7a95f971c66ec83": [
+      "trump",
+      "us_politics"
+    ],
+    "0x44c1dfe43260c94ed4f1d00de2e1f80fb113ebc1": [
+      "trump"
+    ],
+    "0xee50a31c3f5a7c77824b12a941a54388a2827ed6": [
+      "trump"
+    ],
+    "0xa9878e59934ab507f9039bcb917c1bae0451141d": [
+      "trump"
+    ],
+    "0x0b9cae2b0dfe7a71c413e0604eaac1c352f87e44": [
+      "trump"
+    ],
+    "0x863134d00841b2e200492805a01e1e2f5defaa53": [
+      "trump"
+    ],
+    "0x8119010a6e589062aa03583bb3f39ca632d9f887": [
+      "trump"
+    ],
+    "0xee613b3fc183ee44f9da9c05f53e2da107e3debf": [
+      "trump",
+      "us_politics",
+      "sports",
+      "soccer"
+    ],
+    "0x94a428cfa4f84b264e01f70d93d02bc96cb36356": [
+      "trump"
+    ],
+    "0x2bf64b86b64c315d879571b07a3b76629e467cd0": [
+      "trump"
+    ],
+    "0xc8075693f48668a264b9fa313b47f52712fcc12b": [
+      "trump",
+      "sports",
+      "soccer",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x30a0c0554c1f86675123d2a09be36e999585a458": [
+      "us_election"
+    ],
+    "0x6bc9eeeee5ccfdee503899376858ff0adbf87356": [
+      "us_election"
+    ],
+    "0xcdbfdac42aeac5837d105e255c1131e7bf751926": [
+      "us_election"
+    ],
+    "0x7139e528784be79aad23386835dd2e3d705a3750": [
+      "us_election"
+    ],
+    "0xe165b8a84c8095933f7f850ef1164b378f3a8076": [
+      "us_election"
+    ],
+    "0x0ad3532973e23c37ce9d5c6a580df1daa2d121fc": [
+      "us_election"
+    ],
+    "0x26323dc834e645f9f9d46f88027d3a3c2d5a6475": [
+      "us_election"
+    ],
+    "0xac13e6c65f547bc47fca2679fc30364ef6104182": [
+      "us_election"
+    ],
+    "0x9c5fa8b5e0f111c5b3fc9bc322ad7d95074d7ea6": [
+      "us_election"
+    ],
+    "0xd5243dc06a3dbdfcb8a3b5acf455d4382e050f5a": [
+      "us_election"
+    ],
+    "0xfa2ffce46639aa89adf97f61a995094e73e90e59": [
+      "us_election"
+    ],
+    "0x07c37a244ecd4e33e688a1708fcfad27a9058a5d": [
+      "us_election"
+    ],
+    "0xc8ceccaf0177ddd8092f62dd56336cf9662aebc8": [
+      "us_election"
+    ],
+    "0xd634812db459fe38441c14f228086422c34368fd": [
+      "us_election"
+    ],
+    "0x4f4412913d3ac69991517864e6aa132bac586d1e": [
+      "us_election"
+    ],
+    "0x7c7b045a871dc224a74bc11c38a1c330ddffe357": [
+      "us_election"
+    ],
+    "0x7e68a0fb4135b31ace54b56d9979e35ec325f49f": [
+      "us_election"
+    ],
+    "0xf6714cd65f19a944fde191ec4ad9effbc2693d1f": [
+      "us_election"
+    ],
+    "0xe8b7023153d625f8d111d3b1b93a672f2418c4db": [
+      "us_election"
+    ],
+    "0x1c17f1d806926fbb900c59fb3c385fd75c013653": [
+      "us_election"
+    ],
+    "0x31864feb9d25dee93728c6225ba891530967e9ca": [
+      "us_election"
+    ],
+    "0x5bffcf561bcae83af680ad600cb99f1184d6ffbe": [
+      "us_election"
+    ],
+    "0xeebde7a0e019a63e6b476eb425505b7b3e6eba30": [
+      "crypto"
+    ],
+    "0x674887d1ac838099a48b629dff53f25b7b87ee08": [
+      "crypto"
+    ],
+    "0x665b25ede9866b456432b3fcccdc7ce6b42de773": [
+      "crypto"
+    ],
+    "0x20d2309cd92b797ae7ca175ed828ed8a27fbe29d": [
+      "crypto"
+    ],
+    "0x0e16ae2082d82bf1c727038952b61db5a3bd1207": [
+      "crypto"
+    ],
+    "0xd7c626093f28383612363889ad811fc736d3706f": [
+      "crypto"
+    ],
+    "0x4d40c3f3627f64591eac428cd4248c651a9c398d": [
+      "crypto"
+    ],
+    "0x75cc3b63a2f2423085e10706c78b494017b93ce1": [
+      "crypto"
+    ],
+    "0x32e4abe3e97aaf3c95c315ba3ffbe7b2a313beed": [
+      "crypto"
+    ],
+    "0x968553298d1cc1c343d11398cb42db76d533aed0": [
+      "crypto"
+    ],
+    "0x218f36c313d6c012636b21cc6b5a043d9fef17bc": [
+      "crypto"
+    ],
+    "0x3a847382ad6fff9be1db4e073fd9b869f6884d44": [
+      "crypto"
+    ],
+    "0xf3531b23b504cf0aed4ff21325232b2a2d496685": [
+      "crypto"
+    ],
+    "0x7347d3291b321d2ee8d43d24aff244e7fb8c3d35": [
+      "crypto"
+    ],
+    "0x43f1949de1964deb6f7ec5865964d476cc5d06e5": [
+      "crypto"
+    ],
+    "0x5d3cc45e538130b02c8f3c821638ec9cd350c298": [
+      "crypto"
+    ],
+    "0x6c6aefbdb3fe1a0a7ee3d07277f9e58b76064fd2": [
+      "crypto"
+    ],
+    "0x60889af507ec3f9da136f38b1c58080bec32f361": [
+      "crypto"
+    ],
+    "0xe1d6b51521bd4365769199f392f9818661bd907c": [
+      "crypto"
+    ],
+    "0x1f19c48aee80ec95396d91f0d21ac249b8a7f57a": [
+      "crypto"
+    ],
+    "0x6bab41a0dc40d6dd4c1a915b8c01969479fd1292": [
+      "crypto"
+    ],
+    "0x7177a7f5c216809c577c50c77b12aae81f81ddef": [
+      "crypto"
+    ],
+    "0xcd71fd5370880f3d92bb941e628c05840fe0d127": [
+      "crypto"
+    ],
+    "0xe9ad918c7678cd38b12603a762e638a5d1ee7091": [
+      "crypto"
+    ],
+    "0x23786fdad0073692157c6d7dc81f281843a35fcb": [
+      "crypto"
+    ],
+    "0xdb27bf2ac5d428a9c63dbc914611036855a6c56e": [
+      "crypto",
+      "sports",
+      "nba",
+      "magic",
+      "celtics",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0x006cc834cc092684f1b56626e23bedb3835c16ea": [
+      "crypto"
+    ],
+    "0x7fb7ad0d194d7123e711e7db6c9d418fac14e33d": [
+      "crypto"
+    ],
+    "0xc6474ca778dde50b2f2d8074b8ea914a54b75e87": [
+      "crypto"
+    ],
+    "0x11dc2b4145b0497fcbdd70599dd61513efa51502": [
+      "crypto"
+    ],
+    "0x9b95638015b4adaa7f4f7435b0f5816b687f6c4a": [
+      "crypto"
+    ],
+    "0x6e9443babf02148408bbd05413f9ea6aba2b9b29": [
+      "crypto"
+    ],
+    "0x2d3a2efa0516f700165b10561d90fa5a77287d4a": [
+      "crypto"
+    ],
+    "0xbf289b9f2b78a6f83d222fec98209339f5d78f93": [
+      "crypto"
+    ],
+    "0xf613d20d8ede6f4705a1288e6d2f668b1c78b2d4": [
+      "crypto"
+    ],
+    "0xae94949d4778af469e631a92383fd2eac615af2c": [
+      "crypto"
+    ],
+    "0x4705408c791455edffc66782d4cea30c17afd03e": [
+      "crypto"
+    ],
+    "0x8e64bf9ddbe4f0a98693f64c6c826761a4c317e4": [
+      "crypto"
+    ],
+    "0x65a7e6303e0a625b15a6001524c334d31dec8060": [
+      "crypto"
+    ],
+    "0x3e6d998a25793c1d0ca5b59d7d7ac7f8d0132671": [
+      "crypto"
+    ],
+    "0xdb7e93cd4668dda1b73abb2acd1687a88173b4c7": [
+      "crypto"
+    ],
+    "0x01a9160c6a2aa8591a11a88badbc505e824575dd": [
+      "crypto"
+    ],
+    "0x71bf7564bdae113a21e2116d471cbcb5619495de": [
+      "crypto"
+    ],
+    "0xd9d65d9b4d41c9bbd77b332009a6d849b886b245": [
+      "crypto"
+    ],
+    "0xcdf79098337926ce014ac680d98cc9728439824e": [
+      "crypto"
+    ],
+    "0x27f041f8786c43281c853623dade7fdbf7ffe9e6": [
+      "crypto"
+    ],
+    "0x5b69fe7048a533847b4e3abe1b9eea261a91a6af": [
+      "crypto"
+    ],
+    "0xa67d00591c8f609e69d39dcd1503a771fb3c85c6": [
+      "crypto"
+    ],
+    "0x3f3b427368f7cc3f9560c57cdedce6fa18fe3a4c": [
+      "crypto"
+    ],
+    "0x5bc331ff6a2f3a679f0c98cca0d92cdda5c47a59": [
+      "crypto"
+    ],
+    "0xd768776321066958f7a032652acb5344a26a8e1f": [
+      "longterm_crypto"
+    ],
+    "0xf705fa045201391d9632b7f3cde06a5e24453ca7": [
+      "longterm_crypto"
+    ],
+    "0xe5f85d076f0b1edd4ec89bfb95e123a9036a8d75": [
+      "longterm_crypto"
+    ],
+    "0x991f81e6344646ed7f419d79ddf9e6a9dea6d3c2": [
+      "longterm_crypto"
+    ],
+    "0x388537259dc9e693c1c9b96fdf07a63f6b7aca77": [
+      "longterm_crypto"
+    ],
+    "0x6e1d5040d0ac73709b0621f620d2a60b80d2d0fa": [
+      "longterm_crypto"
+    ],
+    "0x434f15599b49b65cd63e2aa3f140dc605e934d09": [
+      "longterm_crypto"
+    ],
+    "0x17559efac103ac7f361be37ec0b93888d4c55aac": [
+      "longterm_crypto"
+    ],
+    "0x50733d0627e4763d7d7e81a69abc345edf6416a7": [
+      "longterm_crypto"
+    ],
+    "0xd634c33f7de4aa342c3136ac8b5b36ef390f77ad": [
+      "longterm_crypto"
+    ],
+    "0x1643038efde95846b92b008e2efedca553296ec8": [
+      "longterm_crypto"
+    ],
+    "0xee767b98e3c9d59a612135a091ea8c8f00ec8fed": [
+      "longterm_crypto"
+    ],
+    "0x232db46657c1f711aa275d324bd42eddf609de8e": [
+      "sports"
+    ],
+    "0xc7b84afab9e144a258b98a1cb45e05df7aab0d21": [
+      "sports"
+    ],
+    "0x1fa1bbcc1cd75b0d04eb5590ad4a812eb2b0e73a": [
+      "sports"
+    ],
+    "0xdae37ea4238f43fc3f25c1ef6c83be1aa5270863": [
+      "sports"
+    ],
+    "0x5921cd907f42e39a419bf9b8b8daa6e897bcced6": [
+      "sports"
+    ],
+    "0xb677f9146fb98985a8f60c2e7d8d44330b10e745": [
+      "sports"
+    ],
+    "0xdd2afdf73cd2a32439875c65433a688b327c315e": [
+      "sports"
+    ],
+    "0x861ae65ad67b06b5cdabe24ba6de052269221f15": [
+      "sports"
+    ],
+    "0x5ae14dc9e0cf9df72de8d873dcea05aacb799fad": [
+      "sports"
+    ],
+    "0x6211f97a76ed5c4b1d658f637041ac5f293db89e": [
+      "sports"
+    ],
+    "0xa8e089ade142c95538e06196e09c85681112ad50": [
+      "sports"
+    ],
+    "0x6ade597c0e2b43c0bf3542cada8a5e330d73f5b0": [
+      "sports"
+    ],
+    "0x5eeb2911bf927d7ded5fccf150293105ef7e01b2": [
+      "sports"
+    ],
+    "0x204f72f35326db932158cba6adff0b9a1da95e14": [
+      "sports"
+    ],
+    "0xb52ab5ae6718ee723e912371dbf391f447ed48a7": [
+      "sports"
+    ],
+    "0x09e55a590666492a5d09197928e6350cda122b07": [
+      "sports"
+    ],
+    "0x041dd543dac781c204da5ac440c5a95c87c022f8": [
+      "sports"
+    ],
+    "0x9bd573e9c9d2815bee1a226e1a0ec8377a1a0cd2": [
+      "sports"
+    ],
+    "0x15885559b62df5bca5df930ca3bc2a5504842529": [
+      "sports"
+    ],
+    "0xfe3e63ff74085583791df5145ccc822abb1c70b4": [
+      "sports"
+    ],
+    "0x507e52ef684ca2dd91f90a9d26d149dd3288beae": [
+      "sports"
+    ],
+    "0xdbade4c82fb72780a0db9a38f821d8671aba9c95": [
+      "sports"
+    ],
+    "0xf5fe759cece500f58a431ef8dacea321f6e3e23d": [
+      "sports"
+    ],
+    "0x0562c423912e325f83fa79df55085979e1f5594f": [
+      "sports"
+    ],
+    "0xc2e7800b5af46e6093872b177b7a5e7f0563be51": [
+      "sports",
+      "soccer",
+      "premier_league",
+      "nba",
+      "kings",
+      "warriors",
+      "mlb",
+      "tennis"
+    ],
+    "0x50b1db131a24a9d9450bbd0372a95d32ea88f076": [
+      "sports",
+      "soccer",
+      "atlético_madrid",
+      "la_liga",
+      "real_madrid",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x36a3f17401e395ef4cb1b7f42bcdb8ab8e15fafb": [
+      "sports",
+      "soccer",
+      "liverpool",
+      "premier_league",
+      "tennis",
+      "alcaraz",
+      "nba",
+      "mlb",
+      "esports"
+    ],
+    "0x777d9f00c2b4f7b829c9de0049ca3e707db05143": [
+      "sports",
+      "soccer",
+      "premier_league",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0xf195721ad850377c96cd634457c70cd9e8308057": [
+      "sports",
+      "soccer",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x59a0744db1f39ff3afccd175f80e6e8dfc239a09": [
+      "sports",
+      "soccer",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0xdc5aa14975f4cbb19169554723ffa5e89570bf71": [
+      "esports"
+    ],
+    "0x7e0be260bf431c091d7218e2d7960fc940944dd5": [
+      "esports"
+    ],
+    "0x5471604e05accad637155999bbf90d9fad76a236": [
+      "esports"
+    ],
+    "0x58879b12fb0ff9e7e048db7cfe901142134d994e": [
+      "esports"
+    ],
+    "0x775d9de0c72c76a459fadfbb4cd79d5715236beb": [
+      "esports"
+    ],
+    "0x629da223adfc9957329e02de95ae3d263f92756c": [
+      "esports"
+    ],
+    "0x14ed2f5669e37b1ae7313456116b78ad935e6584": [
+      "esports"
+    ],
+    "0x29245f582c2cba3c230124729901ea1761440f31": [
+      "esports"
+    ],
+    "0x83a0c368715beb4897ea19c9810ac03274ca4f9b": [
+      "esports"
+    ],
+    "0x5835f5a34218c9e879f574c1d25199bd2d1b8745": [
+      "esports"
+    ],
+    "0x0740c8b8a88b5a040d4592c41617c6a085121ad4": [
+      "esports"
+    ],
+    "0x0b868bee6405dbd480f3dc1cf5381d85e3c080ba": [
+      "esports"
+    ],
+    "0xe91171f655be1568e4c63f29663c0028649e3d4e": [
+      "esports"
+    ],
+    "0xf3ef6ac0510c9eabc42fbb146b5c3c64edc1ca6b": [
+      "esports"
+    ],
+    "0xe8e1b119302ae410e77b2af7d7456809007549dd": [
+      "esports"
+    ],
+    "0x29a5082998f18e7f90dd1a7fe6ad4dd9a665a3c4": [
+      "esports"
+    ],
+    "0x47138dcab06fa1f3e02cf4bb4f1d0c6bf6bb9b72": [
+      "esports"
+    ],
+    "0x7e0be268f8b4f39e8a12c57daff3b0ef5dc92f74": [
+      "esports"
+    ],
+    "0x267336b05a82e14dc5f2b1ae94ac38ad9f93e5d8": [
+      "esports"
+    ],
+    "0x1b8cad78a3b8e59f6dc24f57eabef2c5de49f73a": [
+      "esports"
+    ],
+    "0x3b5c629f114098b0dee345fb78b7a3a013c7126e": [
+      "esports"
+    ],
+    "0x9f2fe025f84839ca81dd8e0338892605702d2ca8": [
+      "esports",
+      "sports",
+      "nba",
+      "philadelphia_76ers",
+      "celtics",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0xa5ea13a81d2b7e8e424b182bdc1db08e756bd96a": [
+      "esports",
+      "sports",
+      "soccer",
+      "premier_league",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x7595191ed7c6e8ec98df3fc14328015ad73b872e": [
+      "weather"
+    ],
+    "0xeb1d1cd1b31070fb34b1d1de20d700f59c9959b0": [
+      "weather"
+    ],
+    "0x66a17b44f6187745c4f273622a702e2f1b423de8": [
+      "weather"
+    ],
+    "0x2a25f7cbf3fc823e315c31602d2eccab85788055": [
+      "weather"
+    ],
+    "0xf84dc12754f16b5c3d72df540ceb2d1f2907c613": [
+      "weather"
+    ],
+    "0xe6c85f9d531bc274dc4aaf9f8baf8ad175acb8c0": [
+      "weather"
+    ],
+    "0xd89fa4879f2ad7c53763eaec8e0434763f9c535e": [
+      "weather"
+    ],
+    "0x0bf7e9407469e51e598368fea8dc4edd02f1d384": [
+      "weather"
+    ],
+    "0xef2e2fd7a18f409f703f036df91e23e9dfab10c3": [
+      "weather"
+    ],
+    "0xb40e89677d59665d5188541ad860450a6e2a7cc9": [
+      "weather"
+    ],
+    "0x42545c3f429161c35198ef40719f635268011d02": [
+      "weather"
+    ],
+    "0xf7c8ebd09e715ce1e95c89f5a4b60782fc7dbd6b": [
+      "weather"
+    ],
+    "0xf1ec1d6c33c74335a5698b2f4d22915d77fb5d14": [
+      "weather"
+    ],
+    "0x83f7aacb9d9abbf4f43a669b0f320a55d8c91907": [
+      "weather"
+    ],
+    "0x6e35ed31aa3d64164ef7c7f46f5f6041fc28ddce": [
+      "weather"
+    ],
+    "0xa426a46a1fe75d34700433d79dac9fbac60dcf3d": [
+      "weather"
+    ],
+    "0xaae1444fc0a0fab93e4825e85b98143cf0854edf": [
+      "weather"
+    ],
+    "0x50b1e35022933ae620665ce55dbd9785c5e30793": [
+      "weather"
+    ],
+    "0xe5b29f5da62141c6e20e6a6a99a16585893b21f4": [
+      "weather"
+    ],
+    "0xf4c599f3794a3e70019af975807355c8530d36d1": [
+      "weather"
+    ],
+    "0x6dad6e29c1879058181b9e0cfd2797d7939f5c37": [
+      "weather"
+    ],
+    "0xb026df322e1445da8fe74d4029c966dfd9d3bbfd": [
+      "economy"
+    ],
+    "0x4789be68ec6615a660b162ff5bfe99cd2b705ef7": [
+      "economy"
+    ],
+    "0x5aa4ab516dbdc8657362466132cb620be3562cfb": [
+      "economy"
+    ],
+    "0xb89f5425341719d298dc2f5b9a92374f5fde1c44": [
+      "tech"
+    ],
+    "0x65df5f2f2c0ab949def496ad49f41615cf348555": [
+      "tech"
+    ],
+    "0x5aec01932a51836bc151b5aa515ccea15a7d904b": [
+      "tech"
+    ],
+    "0x42c99f38d2b951b0dc8e8bd5371fa80c9dd19623": [
+      "tech"
+    ],
+    "0x6c0a40489cfd646e1b4b225c7a15b70db620f6bd": [
+      "tech"
+    ],
+    "0xa3282d3e882501229c75d0caf134e62e3afb4977": [
+      "tech"
+    ],
+    "0x162e2778f4cd82a11d6fcc2db4a61c61d8ef6bbb": [
+      "tech"
+    ],
+    "0x3468375cbce77260779805706a06a5d326163965": [
+      "tech"
+    ],
+    "0x45f03fdb9aa6d4503501c94b138eee3e6ef65e0d": [
+      "tech"
+    ],
+    "0x1c0227bc2f91f70f0982db198d00ad3345e5e658": [
+      "tech"
+    ],
+    "0x09a5d3b75f908d780f2070ac270eabd6cf83caaa": [
+      "tech"
+    ],
+    "0xad5353afe30c2da57709e2704ef3ccdcf67eef24": [
+      "tech"
+    ],
+    "0x707ae3c159dca22b4e375cbdd10023b76d49a170": [
+      "tech"
+    ],
+    "0x0979bad57d7a1403db89cbcd9c52bf43f2138d9b": [
+      "tech"
+    ],
+    "0x7ac83882979ccb5665cea83cb269e558b55077cd": [
+      "tech"
+    ],
+    "0x192f5dada45fead2cf48cccea130a52b8d31639c": [
+      "entertainment",
+      "eurovision",
+      "music",
+      "viral"
+    ],
+    "0xf524bfb554fc488324dafe01ce36178156c38178": [
+      "entertainment",
+      "geopolitics",
+      "latam",
+      "elections",
+      "degen"
+    ],
+    "0xcd91a549956854fdc38efad7e80ff5da8f5432b8": [
+      "science",
+      "ai",
+      "deepseek",
+      "anthropic",
+      "tech"
+    ],
+    "0x99c97ff0da44d5aab0d3bd59d5ea0c524fb24c22": [
+      "science",
+      "ai",
+      "openai"
+    ],
+    "0x36901eb0f21519cc9055662a6d2483e96da1e16f": [
+      "science",
+      "ai",
+      "deepseek",
+      "baidu",
+      "tech"
+    ],
+    "0x91aa4d41bf886e073d9cf772fee77c8367d90209": [
+      "science",
+      "tech",
+      "crypto",
+      "btc"
+    ],
+    "0xffd87246e85ec478d221ade469c3c19ed3be1a4d": [
+      "science",
+      "ai",
+      "openai",
+      "tech",
+      "coding"
+    ],
+    "0xbc13c7d56f6144af394335ab837d28167b1b5578": [
+      "degen",
+      "elon_musk",
+      "twitter",
+      "social_media"
+    ],
+    "0x632378d502d023faa01dfd94997c529e516329ed": [
+      "degen",
+      "geopolitics",
+      "china",
+      "taiwan"
+    ],
+    "0x3f084183bd7135768605c7525ea3d94a39a6e919": [
+      "degen",
+      "sports",
+      "esports",
+      "lol",
+      "nba",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0x0f15bca68d73e79fda8ad13794861c6644ce0ce5": [
+      "degen",
+      "sports",
+      "esports",
+      "lol",
+      "nba",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0xbddf61af533ff524d27154e589d2d7a81510c684": [
+      "sports",
+      "nba",
+      "magic",
+      "celtics",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0x5d58e38cd0a7e6f5fa67b7f9c2f70dd70df09a15": [
+      "sports",
+      "esports",
+      "cs2",
+      "valorant",
+      "nba",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0x2005d16a84ceefa912d4e380cd32e7ff827875ea": [
+      "sports",
+      "crypto",
+      "nba",
+      "mlb",
+      "soccer",
+      "tennis"
+    ],
+    "0x93abbc022ce98d6f45d4444b594791cc4b7a9723": [
+      "sports",
+      "soccer",
+      "premier_league",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0xdc876e6873772d38716fda7f2452a78d426d7ab6": [
+      "sports",
+      "soccer",
+      "nba",
+      "mlb",
+      "tennis"
+    ],
+    "0x492442eab586f242b53bda933fd5de859c8a3782": [
+      "sports",
+      "nba",
+      "philadelphia_76ers",
+      "wizards",
+      "crypto",
+      "soccer",
+      "mlb",
+      "tennis",
+      "esports"
+    ],
+    "0x2a2c53bd278c04da9962fcf96490e17f3dfb9bc1": [
+      "sports",
+      "soccer",
+      "crypto",
+      "nba",
+      "mlb",
+      "tennis",
+      "esports"
+    ]
+  },
+  "wallet_metadata": {
+    "description": "Tags per wallet address. A wallet can appear in multiple baskets if it has matching tags.",
+    "_note": "wallet_metadata field reserved for future per-wallet annotations (name, specialty, source)"
   }
 }


### PR DESCRIPTION
## Summary
**268 unique wallets** across **23 baskets**
**470 total tag instances** (wallets counted per basket)
**39 wallets** in 3+ baskets (cross-category specialists)

- **geopolitics**: 46
- **trump**: 30
- **us_election**: 23
- **crypto**: 55
- **longterm_crypto**: 67
- **nba**: 24
- **sports**: 50
- **nfl**: 0
- **soccer**: 25
- **ufc_boxing**: 0
- **mlb**: 24
- **f1**: 0
- **tennis**: 24
- **esports**: 31
- **weather**: 21
- **economy**: 3
- **ai_science**: 6
- **medical**: 6
- **space**: 6
- **elon_musk**: 1
- **tech**: 20
- **entertainment**: 2
- **degen**: 6

### New Structure
Cross-basket wallet support with `wallet_tags` metadata:
- Same wallet can appear in multiple baskets via tag matching
- 39 wallets trade across 3+ categories
- Example: CemeterySun -> [geopolitics, sports, nba, magic, celtics, soccer, bundesliga, mlb, tennis, esports]

### Specialized Baskets
- **nba**: NBA teams, playoffs, MVP
- **soccer**: Premier League, La Liga, Bundesliga, Champions League
- **mlb**: MLB, World Series
- **tennis**: ATP, WTA, Grand Slams
- **ai_science**: AI model race (OpenAI, DeepSeek, Anthropic)
- **elon_musk**: Musk tweets, Tesla, SpaceX, DOGE

### Sources
polymarket.com leaderboard, data-api.polymarket.com, polydata.pro, polymarket-portfolio.shop, predicts.guru, polymarketscan.org

> Auto-generated by PredictCel wallet discovery pipeline