### PR TITLE
ci: Add GitHub-native CI/CD, scheduled cycles, Codespaces, and issue templates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "PredictCel Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {},
+  "extensions": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "github.vscode-github-actions"
+  ],
+  "postCreateCommand": "pip install -e '.[dev]'",
+  "settings": {
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+---
+
+**Description**
+A clear description of the bug.
+
+**Steps to Reproduce**
+1. 
+2. 
+3. 
+
+**Expected Behavior**
+What you expected to happen.
+
+**Actual Behavior**
+What actually happened.
+
+**Environment**
+- OS:
+- Python version:
+- PredictCel version:
+- Config used:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: enhancement
+---
+
+**Problem Statement**
+A clear description of the problem this feature would solve.
+
+**Proposed Solution**
+A clear description of what you want to happen.
+
+**Alternatives Considered**
+A description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: Question
+about: Ask a question about PredictCel
+title: "[Question] "
+labels: question
+---
+
+**Context**
+What are you trying to accomplish? Provide any relevant configuration or environment details.
+
+**Question**
+Your question here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Description
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor / cleanup
+- [ ] Documentation
+
+## Testing
+- [ ] Unit tests pass (`pytest`)
+- [ ] Lint clean (`ruff check`)
+
+## Safety Gates
+- [ ] No live-trading changes without explicit config review
+- [ ] No new dependencies without version pins

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - run: pytest --tb=short -q
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e "."
+      - run: python -m predictcel.main --config config/predictcel.example.json --db /tmp/predictcel-ci.db

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,53 @@
+name: Scheduled Cycle
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Cycle mode"
+        required: false
+        default: "paper"
+        type: choice
+        options:
+          - paper
+          - live-data
+          - dry-run-trading
+
+jobs:
+  cycle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Restore DB cache
+        uses: actions/cache@v4
+        with:
+          path: predictcel.db
+          key: predictcel-db-${{ github.run_id }}
+          restore-keys: |
+            predictcel-db-
+      - run: pip install -e "."
+      - name: Run cycle
+        env:
+          MODE: ${{ github.event.inputs.mode || 'paper' }}
+        run: |
+          ARGS="--config config/predictcel.example.json --db predictcel.db"
+          if [ "$MODE" = "live-data" ]; then
+            ARGS="$ARGS --live-data"
+          fi
+          if [ "$MODE" = "dry-run-trading" ]; then
+            ARGS="$ARGS --live-data --live-trading"
+          fi
+          python -m predictcel.main $ARGS
+      - name: Upload cycle output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cycle-output-${{ github.run_number }}
+          path: predictcel.db
+          retention-days: 7


### PR DESCRIPTION
## GitHub-Native Infrastructure for PredictCel

This PR adds all the tooling needed to run PredictCel exclusively on GitHub's cloud infrastructure — no local setup required.

### Deliverables

1. **CI Pipeline** (`.github/workflows/ci.yml`)
   - Lint with `ruff check` + `ruff format --check`
   - Test matrix on Python 3.11 & 3.12
   - Integration smoke test running a full cycle
   - Concurrency control cancels in-progress runs

2. **Scheduled Cycle** (`.github/workflows/schedule.yml`)
   - Cron every 30 minutes
   - `workflow_dispatch` with mode selector (paper / live-data / dry-run-trading)
   - DB cache persistence via `actions/cache`
   - Cycle output artifacts via `actions/upload-artifact`
   - 10-minute timeout

3. **Codespace** (`.devcontainer/devcontainer.json`)
   - Python 3.11 image
   - Extensions: Python, Pylance, Ruff, GitHub Actions
   - Format-on-save enabled
   - `pip install -e '.[dev]'` on create

4. **Dependabot** (`.github/dependabot.yml`)
   - Weekly pip updates (max 5 PRs)
   - Weekly GitHub Actions updates (max 3 PRs)

5. **Issue Templates** (`.github/ISSUE_TEMPLATE/`)
   - Bug report
   - Feature request
   - Question

6. **PR Template** (`.github/PULL_REQUEST_TEMPLATE.md`)
   - Change type checklist
   - Testing checklist
   - Safety gates for live-trading and dependency changes

### How to use

- **Develop**: Open a Codespace from the repo — everything is pre-configured.
- **CI**: Every push/PR to `main` triggers lint + test + integration.
- **Scheduled runs**: Enable the workflow in Actions tab, then use `workflow_dispatch` to run on demand or let the cron handle it.
- **Dependabot**: Merges arrive automatically as PRs.
- **Issues/PRs**: Templates guide contributors.