### PR TITLE
docs(copy_engine): Add module docstring and __all__

### DIFF
--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -1,3 +1,9 @@
+"""Copy trading engine.
+
+Evaluates markets and generates copy trading signals based on
+wallet baskets and market conditions.
+"""
+
 from __future__ import annotations
 
 from collections import Counter, defaultdict
@@ -10,6 +16,9 @@ import os
 from .config import AppConfig, BasketRule
 from .models import CopyCandidate, MarketRegime, MarketSnapshot, WalletQuality, WalletTrade
 from .scoring import compute_copyability_score
+
+__all__ = ["CopyEngine", "evaluate_markets"]
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
Adds proper module documentation and explicit exports to copy_engine.py

## Changes
- Added comprehensive module docstring
- Added `__all__` declaration for explicit public API

## Benefits
- Better IDE support with clear module documentation
- Explicit control over public API surface
- Clearer code organization for contributors

## Backward Compatibility
No functional changes - all existing code continues to work.