### PR TITLE
fix: canonicalize aliased copy-engine market ids

### DIFF
--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -96,7 +96,8 @@ class CopyEngine:
         wallet_qualities = wallet_qualities or {}
         grouped: dict[str, list[WalletTrade]] = {}
         for trade in trades:
-            grouped.setdefault(trade.market_id, []).append(trade)
+            canonical_market_id = self._canonical_market_id(trade.market_id, markets)
+            grouped.setdefault(canonical_market_id, []).append(trade)
 
         if not grouped:
             self.last_diagnostics = {
@@ -162,6 +163,12 @@ class CopyEngine:
             **dict(sorted(rejection_counts.items())),
         }
         return candidates
+
+    def _canonical_market_id(self, market_id: str, markets: dict[str, MarketSnapshot]) -> str:
+        market = markets.get(market_id)
+        if market is None:
+            return market_id
+        return market.market_id
 
     def _resolve_topic(self, trades: list[WalletTrade]) -> str:
         counts: dict[str, int] = {}

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -124,6 +124,22 @@ def test_emits_candidate_when_quorum_and_drift_pass() -> None:
     assert engine.last_diagnostics["candidates_returned"] == 1
 
 
+def test_mixed_market_aliases_share_one_consensus_bucket() -> None:
+    engine = CopyEngine(make_config())
+    market = replace(make_market(), market_id="cond_1", yes_token_id="token_yes")
+    trades = [
+        WalletTrade(wallet="w1", topic="geopolitics", market_id="cond_1", side="YES", price=0.58, size_usd=200, age_seconds=600),
+        WalletTrade(wallet="w2", topic="geopolitics", market_id="token_yes", side="YES", price=0.6, size_usd=220, age_seconds=800),
+    ]
+
+    candidates = engine.evaluate(trades, {"cond_1": market, "token_yes": market}, make_qualities())
+
+    assert len(candidates) == 1
+    assert candidates[0].market_id == "cond_1"
+    assert engine.last_diagnostics["markets_evaluated"] == 1
+    assert engine.last_diagnostics["candidates_returned"] == 1
+
+
 def test_skips_candidate_when_drift_is_too_large() -> None:
     engine = CopyEngine(make_config())
     trades = [


### PR DESCRIPTION
## Summary
- normalize trade market identifiers through the loaded market alias map before grouping copy-engine votes
- add a regression test covering mixed condition-id and token-id trades for the same market

## Why
Live input loading aliases Polymarket markets under condition ids, slugs, and token ids, but `CopyEngine.evaluate()` was still grouping on raw `WalletTrade.market_id`. That could split one real market into multiple buckets, reducing quorum and inflating `no_valid_trades` / other rejections even when the market cross-reference rate was 100%.

## Notes
- this is a surgical fix and leaves the rest of the candidate filters unchanged
- CI should confirm whether candidate starvation improves or if there are still config-side constraints after this logic fix
