### PR TITLE
fix: defer signal marking until execution intents exist

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -183,8 +183,14 @@ def main() -> None:
                 store.update_position(pos.market_id, pos.current_price, pos.unrealized_pnl, status, token_id=pos.token_id)
             current_exposure_usd = store.get_total_exposure()
 
-        fresh_candidates, skipped_duplicate_signals = store.filter_and_mark_candidates_atomically(copy_candidates)
-        execution_intents = ExecutionPlanner(config.execution, config.execution.position).plan(fresh_candidates, markets, store.get_held_market_ids(), current_exposure_usd)
+        fresh_candidates, skipped_duplicate_signals = _filter_duplicate_candidates(store, copy_candidates)
+        execution_intents = ExecutionPlanner(config.execution, config.execution.position).plan(
+            fresh_candidates,
+            markets,
+            store.get_held_market_ids(),
+            current_exposure_usd,
+        )
+        _mark_execution_intents_seen(store, execution_intents)
         execution_results = LiveOrderExecutor(config.execution, config.live_data).execute(execution_intents)
         _persist_execution_side_effects(store, config, execution_results)
     timings["execution_ms"] = _elapsed_ms(started)
@@ -252,14 +258,17 @@ def _run_wallet_discovery(argv: list[str]) -> None:
     print(json.dumps({"mode": "wallet_discovery", "reports": files, "latency_ms": {"total_cycle_ms": _elapsed_ms(started)}}, indent=2))
 
 
+def _mark_execution_intents_seen(store: SignalStore, execution_intents: list) -> None:
+    if execution_intents:
+        store.mark_signals_seen((intent.market_id, intent.topic, intent.side) for intent in execution_intents)
+
+
 def _persist_execution_side_effects(store: SignalStore, config: Any, execution_results: list) -> None:
     now = datetime.now(UTC)
     position_config = config.execution.position
-    signals: list[tuple[str, str, str]] = []
     positions: list[Position] = []
     for result in execution_results:
         if _creates_or_updates_paper_position(result):
-            signals.append((result.market_id, result.topic, result.side))
             positions.append(
                 Position(
                     result.market_id,
@@ -279,8 +288,6 @@ def _persist_execution_side_effects(store: SignalStore, config: Any, execution_r
                     result.market_title,
                 )
             )
-    if signals:
-        store.mark_signals_seen(signals)
     if positions:
         store.save_positions(positions)
 
@@ -378,9 +385,20 @@ def _fetch_wallet_payloads(client: PolymarketPublicClient, wallets: list[str], l
 
 
 def _filter_duplicate_candidates(store: SignalStore, candidates: list) -> tuple[list, int]:
-    fingerprints = [store.make_signal_fingerprint(candidate.market_id, candidate.topic, candidate.side) for candidate in candidates]
-    recent_fingerprints = store.has_recent_signals([(candidate.market_id, candidate.topic, candidate.side) for candidate in candidates])
-    fresh = [candidate for candidate, fingerprint in zip(candidates, fingerprints) if fingerprint not in recent_fingerprints]
+    fingerprints = [
+        store.make_signal_fingerprint(candidate.market_id, candidate.topic, candidate.side)
+        for candidate in candidates
+    ]
+    recent_fingerprints = store.has_recent_signals(
+        [(candidate.market_id, candidate.topic, candidate.side) for candidate in candidates]
+    )
+    fresh = []
+    seen_in_batch: set[str] = set()
+    for candidate, fingerprint in zip(candidates, fingerprints):
+        if fingerprint in recent_fingerprints or fingerprint in seen_in_batch:
+            continue
+        fresh.append(candidate)
+        seen_in_batch.add(fingerprint)
     return fresh, len(candidates) - len(fresh)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,32 @@
 import sys
+from types import SimpleNamespace
 
 from predictcel import discover_wallets
-from predictcel.main import _creates_or_updates_paper_position
-from predictcel.models import ExecutionResult
+from predictcel.main import (
+    _creates_or_updates_paper_position,
+    _filter_duplicate_candidates,
+    _mark_execution_intents_seen,
+)
+from predictcel.models import CopyCandidate, ExecutionIntent, ExecutionResult
+
+
+class FakeStore:
+    def __init__(self, recent_fingerprints: set[str] | None = None) -> None:
+        self.recent_fingerprints = recent_fingerprints or set()
+        self.marked_signals = []
+
+    def make_signal_fingerprint(self, market_id: str, topic: str, side: str) -> str:
+        return f"{topic}:{market_id}:{side}"
+
+    def has_recent_signals(self, signals, ttl_minutes: int = 1440):
+        return {
+            self.make_signal_fingerprint(market_id, topic, side)
+            for market_id, topic, side in signals
+            if self.make_signal_fingerprint(market_id, topic, side) in self.recent_fingerprints
+        }
+
+    def mark_signals_seen(self, signals) -> None:
+        self.marked_signals.extend(list(signals))
 
 
 def make_result(status: str, order_id: str = "order_123") -> ExecutionResult:
@@ -22,6 +46,36 @@ def make_result(status: str, order_id: str = "order_123") -> ExecutionResult:
     )
 
 
+def make_candidate(market_id: str, side: str = "YES") -> CopyCandidate:
+    return CopyCandidate(
+        topic="geopolitics",
+        market_id=market_id,
+        side=side,
+        consensus_ratio=0.8,
+        reference_price=0.5,
+        current_price=0.5,
+        liquidity_usd=10000,
+        source_wallets=["w1"],
+        wallet_quality_score=0.8,
+        copyability_score=0.8,
+        reason="test",
+    )
+
+
+def make_intent(market_id: str, side: str = "YES") -> ExecutionIntent:
+    return ExecutionIntent(
+        market_id=market_id,
+        topic="geopolitics",
+        side=side,
+        token_id=f"token_{market_id}",
+        amount_usd=25.0,
+        worst_price=0.52,
+        copyability_score=0.9,
+        order_type="FOK",
+        reason="test",
+    )
+
+
 def test_submitted_order_does_not_create_position() -> None:
     assert _creates_or_updates_paper_position(make_result("submitted")) is False
 
@@ -29,6 +83,34 @@ def test_submitted_order_does_not_create_position() -> None:
 def test_filled_and_dry_run_results_create_positions() -> None:
     assert _creates_or_updates_paper_position(make_result("filled")) is True
     assert _creates_or_updates_paper_position(make_result("dry_run", order_id="")) is True
+
+
+def test_filter_duplicate_candidates_skips_recent_and_same_batch_duplicates() -> None:
+    store = FakeStore({"geopolitics:m1:YES"})
+
+    fresh, skipped = _filter_duplicate_candidates(
+        store,
+        [
+            make_candidate("m1", "YES"),
+            make_candidate("m2", "YES"),
+            make_candidate("m2", "YES"),
+            make_candidate("m3", "NO"),
+        ],
+    )
+
+    assert [(candidate.market_id, candidate.side) for candidate in fresh] == [("m2", "YES"), ("m3", "NO")]
+    assert skipped == 2
+
+
+def test_mark_execution_intents_seen_only_marks_planned_intents() -> None:
+    store = FakeStore()
+
+    _mark_execution_intents_seen(store, [make_intent("m2", "YES"), make_intent("m3", "NO")])
+
+    assert store.marked_signals == [
+        ("m2", "geopolitics", "YES"),
+        ("m3", "geopolitics", "NO"),
+    ]
 
 
 def test_discover_wallets_delegates_to_main(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- stop marking copy candidates as seen before execution planning
- keep duplicate filtering read-only until the planner produces execution intents
- preserve same-batch duplicate filtering with a regression test

## Why
The live cycle was producing non-zero `copy_candidates` but also reporting `skipped_duplicate_signals` equal to the candidate count with `execution_intents: 0`. The previous flow called `filter_and_mark_candidates_atomically()` before planning, which could burn a signal for the full TTL even when it never became an order.

## Change
- use `_filter_duplicate_candidates()` before planning
- mark signals only for planned execution intents
- keep execution-result persistence focused on positions only
