### PR TITLE
fix exports, Discord alerts, and CI type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+      - run: python -m mypy
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -37,7 +47,7 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, typecheck, test]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Celmaro" }]
 dependencies = ["numpy>=1.24.0", "aiohttp>=3.9.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-benchmark>=4.0.0", "pytest-mock>=3.12.0"]
+dev = ["mypy>=1.11.0", "pytest>=8.0", "pytest-benchmark>=4.0.0", "pytest-mock>=3.12.0"]
 trade = ["py-clob-client>=0.34.6"]
 cache = ["redis>=4.5.0"]
 ml = ["scikit-learn>=1.3.0", "pandas>=2.0.0", "statsmodels>=0.14.0"]
@@ -22,3 +22,13 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.mypy]
+python_version = "3.11"
+files = [
+    "src/predictcel/alerting.py",
+    "src/predictcel/discovery.py",
+    "src/predictcel/markets.py",
+    "src/predictcel/wallet_topics.py",
+    "src/predictcel/wallets.py",
+]

--- a/src/predictcel/alerting.py
+++ b/src/predictcel/alerting.py
@@ -66,6 +66,35 @@ class SlackFormatter:
         return {"attachments": [{"color": color, "blocks": blocks}]}
 
 
+class DiscordFormatter:
+    """Formats alerts as Discord webhook messages."""
+
+    SEVERITY_COLORS = {"critical": 0xFF0000, "warning": 0xFFA500, "info": 0x36A64F}
+
+    @classmethod
+    def format(cls, payload: AlertPayload) -> dict[str, Any]:
+        fields = [{"name": "Severity", "value": payload.severity.upper(), "inline": True}]
+        if payload.cycle_id:
+            fields.append({"name": "Cycle ID", "value": payload.cycle_id, "inline": True})
+        if payload.metadata:
+            fields.extend(
+                {"name": str(key), "value": str(value), "inline": True}
+                for key, value in list(payload.metadata.items())[:5]
+            )
+        return {
+            "content": f"**{payload.title}**\n{payload.message}",
+            "embeds": [
+                {
+                    "title": payload.title,
+                    "description": payload.message,
+                    "color": cls.SEVERITY_COLORS.get(payload.severity, 0x808080),
+                    "timestamp": payload.timestamp,
+                    "fields": fields,
+                }
+            ],
+        }
+
+
 class AlertManager:
     """Centralized alerting manager for PredictCel."""
 
@@ -123,6 +152,12 @@ class AlertManager:
             slack_data = SlackFormatter.format(payload)
             if self._send_webhook(self.slack_url, slack_data):
                 logger.info(f"Slack alert sent: {title}")
+                sent = True
+
+        if self.discord_url:
+            discord_data = DiscordFormatter.format(payload)
+            if self._send_webhook(self.discord_url, discord_data):
+                logger.info(f"Discord alert sent: {title}")
                 sent = True
 
         if self.generic_url:
@@ -187,4 +222,4 @@ def get_alert_manager() -> AlertManager:
     return _alert_manager
 
 
-__all__ = ["AlertManager", "AlertPayload", "get_alert_manager", "SlackFormatter"]
+__all__ = ["AlertManager", "AlertPayload", "DiscordFormatter", "SlackFormatter", "get_alert_manager"]

--- a/src/predictcel/basket_manager.py
+++ b/src/predictcel/basket_manager.py
@@ -11,7 +11,7 @@ import logging
 from .config import AppConfig
 from .models import BasketAssignment, BasketManagerAction
 
-__all__ = ["BasketManager", "load_baskets", "save_baskets"]
+__all__ = ["BasketManagerPlanner"]
 
 
 logger = logging.getLogger(__name__)

--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -17,7 +17,7 @@ from .config import AppConfig, BasketRule
 from .models import CopyCandidate, MarketRegime, MarketSnapshot, WalletQuality, WalletTrade
 from .scoring import compute_copyability_score
 
-__all__ = ["CopyEngine", "evaluate_markets"]
+__all__ = ["CopyEngine"]
 
 
 logger = logging.getLogger(__name__)

--- a/src/predictcel/discovery.py
+++ b/src/predictcel/discovery.py
@@ -10,7 +10,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass
 from typing import Any
 
-__all__ = ["DiscoveryRunner", "discover_wallets"]
+__all__ = ["WalletCandidate", "score_wallet_candidates", "candidates_as_dicts"]
 
 
 

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -35,7 +35,7 @@ from .storage import SignalStore
 from .wallet_discovery import WalletDiscoveryPipeline
 from .wallets import load_wallet_trades
 
-__all__ = ["main", "run_cycle"]
+__all__ = ["main"]
 
 
 TRUSTED_POSITION_STATUSES = {"filled", "matched", "success"}

--- a/src/predictcel/markets.py
+++ b/src/predictcel/markets.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from .models import MarketSnapshot
 
-__all__ = ["MarketCache", "fetch_markets", "get_market"]
+__all__ = ["load_market_snapshots"]
 
 
 
@@ -80,9 +80,10 @@ def _parse_outcome(item: dict[str, object]) -> str | None:
 
 
 def _parse_resolution_price(item: dict[str, object]) -> float | None:
-    if item.get("resolution_price") is not None:
+    value = item.get("resolution_price")
+    if isinstance(value, (int, float, str)):
         try:
-            return float(item["resolution_price"])
+            return float(value)
         except (TypeError, ValueError):
             return None
     outcome = _parse_outcome(item)

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -347,7 +347,7 @@ class PolymarketPublicClient:
                         self._validate_response(payload, url)
                         self._set_cached(url, payload)
                         return payload
-                except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError) as e:
+                except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
                     metrics["errors"] += 1
                     if attempt >= self.max_retries - 1:
                         raise

--- a/src/predictcel/wallet_discovery.py
+++ b/src/predictcel/wallet_discovery.py
@@ -21,7 +21,7 @@ from .polymarket import PolymarketPublicClient
 from .wallet_sources import DataApiWalletSource
 from .wallet_topics import classify_wallet_topics
 
-__all__ = ["discover_from_leaderboard", "discover_from_sources"]
+__all__ = ["WalletDiscoveryPipeline"]
 
 
 

--- a/src/predictcel/wallet_sources.py
+++ b/src/predictcel/wallet_sources.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .polymarket import PolymarketPublicClient
 
-__all__ = ["WALLET_SOURCES", "get_source_config"]
+__all__ = ["DataApiWalletSource", "extract_wallet_address"]
 
 
 

--- a/src/predictcel/wallet_topics.py
+++ b/src/predictcel/wallet_topics.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from .models import WalletTopicProfile
 
-__all__ = ["analyze_wallet_topics", "get_topic_preferences"]
+__all__ = ["classify_wallet_topics", "classify_trade_topic"]
 
 
 UNKNOWN_TOPIC = "other"
@@ -30,7 +30,7 @@ def classify_wallet_topics(trades: list[dict[str, Any]], topic_keywords: dict[st
         return WalletTopicProfile(topic_affinities={UNKNOWN_TOPIC: 1.0}, primary_topic=UNKNOWN_TOPIC, specialization_score=1.0)
 
     affinities = {topic: round(count / total, 4) for topic, count in counts.items()}
-    primary_topic = max(affinities, key=affinities.get)
+    primary_topic = max(affinities.items(), key=lambda item: item[1])[0]
     specialization = round(sum(value * value for value in affinities.values()), 4)
     return WalletTopicProfile(
         topic_affinities=dict(sorted(affinities.items(), key=lambda item: item[1], reverse=True)),

--- a/src/predictcel/wallets.py
+++ b/src/predictcel/wallets.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from .models import WalletTrade
 
-__all__ = ["Wallet", "WalletStats", "filter_wallets"]
+__all__ = ["load_wallet_trades", "bucket_trades_by_market"]
 
 
 

--- a/tests/integration/test_discovery_pipeline.py
+++ b/tests/integration/test_discovery_pipeline.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 from predictcel.discovery import score_wallet_candidates
 from predictcel.polymarket import build_wallet_trades
@@ -123,7 +120,7 @@ class TestMarketSnapshotPipeline:
 
     def test_market_snapshot_creation_from_gamma(self):
         """Verify MarketSnapshot creation from Gamma API data."""
-        from predictcel.polymarket import build_market_snapshots, market_snapshot_from_gamma
+        from predictcel.polymarket import build_market_snapshots
 
         gamma_data = [
             {
@@ -153,7 +150,6 @@ class TestMarketSnapshotPipeline:
         from predictcel.polymarket import (
             build_market_snapshots,
             enrich_market_snapshots_with_orderbooks,
-            market_snapshot_from_gamma,
         )
 
         gamma_data = [

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -1,0 +1,43 @@
+from predictcel.alerting import AlertManager
+
+
+def test_send_posts_discord_alert(monkeypatch) -> None:
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK", raising=False)
+    monkeypatch.delenv("ALERT_WEBHOOK_URL", raising=False)
+
+    manager = AlertManager()
+    observed_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_send_webhook(url: str, payload: dict[str, object]) -> bool:
+        observed_calls.append((url, payload))
+        return True
+
+    monkeypatch.setattr(manager, "_send_webhook", fake_send_webhook)
+
+    sent = manager.send(
+        "warning",
+        "Cycle Warning",
+        "Something drifted",
+        cycle_id="cycle-123",
+        metadata={"stage": "evaluate"},
+    )
+
+    assert sent is True
+    assert len(observed_calls) == 1
+
+    url, payload = observed_calls[0]
+
+    assert url == "https://discord.example/webhook"
+    assert payload["content"] == "**Cycle Warning**\nSomething drifted"
+
+    embeds = payload["embeds"]
+    assert isinstance(embeds, list)
+    assert embeds[0]["title"] == "Cycle Warning"
+    assert embeds[0]["description"] == "Something drifted"
+    assert embeds[0]["fields"] == [
+        {"name": "Severity", "value": "WARNING", "inline": True},
+        {"name": "Cycle ID", "value": "cycle-123", "inline": True},
+        {"name": "stage", "value": "evaluate", "inline": True},
+    ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
 import sys
-from types import SimpleNamespace
 
 from predictcel import discover_wallets
 from predictcel.main import (

--- a/tests/test_module_exports.py
+++ b/tests/test_module_exports.py
@@ -1,0 +1,19 @@
+from importlib import import_module
+
+
+def test_public_module_exports_match_defined_symbols() -> None:
+    expected_exports = {
+        "predictcel.basket_manager": ["BasketManagerPlanner"],
+        "predictcel.copy_engine": ["CopyEngine"],
+        "predictcel.discovery": ["WalletCandidate", "score_wallet_candidates", "candidates_as_dicts"],
+        "predictcel.markets": ["load_market_snapshots"],
+        "predictcel.wallet_discovery": ["WalletDiscoveryPipeline"],
+        "predictcel.wallet_topics": ["classify_wallet_topics", "classify_trade_topic"],
+        "predictcel.wallets": ["load_wallet_trades", "bucket_trades_by_market"],
+    }
+
+    for module_name, exported_names in expected_exports.items():
+        module = import_module(module_name)
+
+        assert module.__all__ == exported_names
+        assert all(hasattr(module, name) for name in exported_names)

--- a/tests/test_module_exports.py
+++ b/tests/test_module_exports.py
@@ -6,8 +6,10 @@ def test_public_module_exports_match_defined_symbols() -> None:
         "predictcel.basket_manager": ["BasketManagerPlanner"],
         "predictcel.copy_engine": ["CopyEngine"],
         "predictcel.discovery": ["WalletCandidate", "score_wallet_candidates", "candidates_as_dicts"],
+        "predictcel.main": ["main"],
         "predictcel.markets": ["load_market_snapshots"],
         "predictcel.wallet_discovery": ["WalletDiscoveryPipeline"],
+        "predictcel.wallet_sources": ["DataApiWalletSource", "extract_wallet_address"],
         "predictcel.wallet_topics": ["classify_wallet_topics", "classify_trade_topic"],
         "predictcel.wallets": ["load_wallet_trades", "bucket_trades_by_market"],
     }


### PR DESCRIPTION
## Summary
- correct broken __all__ exports in modules that advertised undefined public names
- add Discord webhook formatting and dispatch coverage for AlertManager
- add a narrow mypy CI job plus tests for exports and Discord alerting

## Verification
- python -m pytest tests/test_alerting.py tests/test_module_exports.py -p no:cacheprovider
- python -m mypy
- python -m pytest -p no:cacheprovider --ignore-glob=pytest-cache-files-* (Windows-local run showed one pre-existing Railway path separator failure and temp-dir permission issues unrelated to this patch)