### PR TITLE
add execution diagnostics to cycle output

### DIFF
--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -278,7 +278,7 @@ class CopyEngine:
             source_wallets=aligned_wallets,
             wallet_quality_score=wallet_quality_score,
             copyability_score=copyability_score,
-            reason="weighted basket consensus, market regime, confidence, recency, liquidity, drift, and orderbook filters passed",
+            reason="weighted basket consensus, market regime, confidence, recency, liquidity, drift, and scored orderbook inputs passed",
             market_title=market.title,
             weighted_consensus=weighted_consensus,
             confidence_score=confidence_score,

--- a/src/predictcel/execution.py
+++ b/src/predictcel/execution.py
@@ -24,6 +24,7 @@ class ExecutionPlanner:
     def __init__(self, config: ExecutionConfig, position_config: PositionConfig) -> None:
         self.config = config
         self.position_config = position_config
+        self.last_diagnostics: dict[str, int] = {}
 
     def plan(
         self,
@@ -35,29 +36,51 @@ class ExecutionPlanner:
         ranked = sorted(candidates, key=lambda item: item.copyability_score, reverse=True)
         intents: list[ExecutionIntent] = []
         planned_exposure_usd = current_exposure_usd
+        diagnostics = {
+            "candidates_seen": len(ranked),
+            "below_copyability_threshold": 0,
+            "already_held": 0,
+            "orderbook_not_ready": 0,
+            "too_close_to_resolution": 0,
+            "zero_amount": 0,
+            "price_too_high": 0,
+            "missing_token_id": 0,
+            "insufficient_side_depth": 0,
+            "candidates_planned": 0,
+        }
         for candidate in ranked:
             if candidate.copyability_score < self.config.min_copyability_score:
+                diagnostics["below_copyability_threshold"] += 1
                 continue
             if candidate.market_id in held_market_ids:
+                diagnostics["already_held"] += 1
                 continue
 
             market = markets.get(candidate.market_id)
             if market is None or not market.orderbook_ready:
+                diagnostics["orderbook_not_ready"] += 1
                 continue
             if market.minutes_to_resolution < MIN_ENTRY_MINUTES_TO_RESOLUTION:
+                diagnostics["too_close_to_resolution"] += 1
                 continue
 
             amount_usd = self._planned_amount_usd(candidate, planned_exposure_usd)
             if amount_usd <= 0:
+                diagnostics["zero_amount"] += 1
                 continue
 
             token_id = market.yes_token_id if candidate.side == "YES" else market.no_token_id
             current_price = market.yes_ask if candidate.side == "YES" else market.no_ask
             if current_price >= MAX_ENTRY_PRICE:
+                diagnostics["price_too_high"] += 1
                 continue
             side_depth_shares = market.yes_ask_size if candidate.side == "YES" else market.no_ask_size
             side_depth_usd = side_depth_shares * current_price
-            if not token_id or side_depth_usd < amount_usd:
+            if not token_id:
+                diagnostics["missing_token_id"] += 1
+                continue
+            if side_depth_usd < amount_usd:
+                diagnostics["insufficient_side_depth"] += 1
                 continue
 
             worst_price = min(round(current_price + self.config.worst_price_buffer, 4), 0.99)
@@ -75,9 +98,11 @@ class ExecutionPlanner:
                     market_title=market.title,
                 )
             )
+            diagnostics["candidates_planned"] += 1
             planned_exposure_usd += amount_usd
             if len(intents) >= self.config.max_orders_per_run:
                 break
+        self.last_diagnostics = diagnostics
         return intents
 
     def _planned_amount_usd(self, candidate: CopyCandidate, planned_exposure_usd: float) -> float:

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -167,6 +167,8 @@ def main() -> None:
     close_intents: list = []
     close_results: list = []
     skipped_duplicate_signals = 0
+    execution_diagnostics: dict[str, int] = {}
+    planner_ran = False
 
     started = time.perf_counter()
     if args.live_trading:
@@ -184,12 +186,15 @@ def main() -> None:
             current_exposure_usd = store.get_total_exposure()
 
         fresh_candidates, skipped_duplicate_signals = _filter_duplicate_candidates(store, copy_candidates)
-        execution_intents = ExecutionPlanner(config.execution, config.execution.position).plan(
+        planner = ExecutionPlanner(config.execution, config.execution.position)
+        execution_intents = planner.plan(
             fresh_candidates,
             markets,
             store.get_held_market_ids(),
             current_exposure_usd,
         )
+        execution_diagnostics = planner.last_diagnostics
+        planner_ran = True
         _mark_execution_intents_seen(store, execution_intents)
         execution_results = LiveOrderExecutor(config.execution, config.live_data).execute(execution_intents)
         _persist_execution_side_effects(store, config, execution_results)
@@ -223,6 +228,12 @@ def main() -> None:
         "live_input_diagnostics": live_input_diagnostics,
         "scoring_diagnostics": scoring_diagnostics,
         "copy_engine_diagnostics": copy_engine_diagnostics,
+        "execution": {
+            "live_trading_requested": bool(args.live_trading),
+            "execution_enabled": bool(config.execution and config.execution.enabled),
+            "planner_ran": planner_ran,
+            "diagnostics": execution_diagnostics,
+        },
         "portfolio_summary": _portfolio_summary(store, config),
         "wallet_qualities": {wallet: quality.__dict__ for wallet, quality in wallet_qualities.items()},
         "copy_candidates": [candidate.__dict__ for candidate in copy_candidates],
@@ -244,6 +255,7 @@ def main() -> None:
             "live_input_diagnostics": _compact_live_input_diagnostics(live_input_diagnostics),
             "scoring_diagnostics": _compact_scoring_diagnostics(scoring_diagnostics),
             "copy_engine_diagnostics": copy_engine_diagnostics,
+            "execution": output["execution"],
         },
     )
     logger.info("Cycle complete", extra={"summary": summary, "timings": timings, "metrics": metrics.get_metrics(), "db": db_diagnostics})
@@ -454,6 +466,8 @@ def _compact_cycle_output(output: dict[str, Any]) -> dict[str, Any]:
         compact["scoring_diagnostics"] = _compact_scoring_diagnostics(output["scoring_diagnostics"])
     if output.get("copy_engine_diagnostics"):
         compact["copy_engine_diagnostics"] = output["copy_engine_diagnostics"]
+    if output.get("execution"):
+        compact["execution"] = output["execution"]
     top_wallet_qualities = _top_wallet_qualities(output.get("wallet_qualities", {}))
     if top_wallet_qualities:
         compact["wallet_qualities"] = top_wallet_qualities

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -231,6 +231,18 @@ def test_market_regime_detects_trend_and_unstable_books() -> None:
     assert trend.regime_score > unstable.regime_score
 
 
+def test_candidate_reason_describes_scored_orderbook_inputs() -> None:
+    engine = CopyEngine(make_config())
+    trades = [
+        WalletTrade(wallet="w1", topic="geopolitics", market_id="m1", side="YES", price=0.58, size_usd=200, age_seconds=600),
+        WalletTrade(wallet="w2", topic="geopolitics", market_id="m1", side="YES", price=0.6, size_usd=220, age_seconds=800),
+    ]
+
+    candidate = engine.evaluate(trades, {"m1": make_market()}, make_qualities())[0]
+
+    assert candidate.reason == "weighted basket consensus, market regime, confidence, recency, liquidity, drift, and scored orderbook inputs passed"
+
+
 def test_records_market_and_basket_rejections() -> None:
     config = AppConfig(
         baskets=[BasketRule(topic="sports", wallets=["w9"], quorum_ratio=1.0)],

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -229,6 +229,45 @@ def test_execution_planner_skips_missing_depth_or_token() -> None:
     intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=0.0)
 
     assert intents == []
+    assert planner.last_diagnostics["missing_token_id"] == 1
+    assert planner.last_diagnostics["candidates_planned"] == 0
+
+
+def test_execution_planner_reports_skip_reasons() -> None:
+    config = make_execution_config()
+    planner = ExecutionPlanner(config, config.position)
+    candidates = [
+        CopyCandidate("topic", "held", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok"),
+        CopyCandidate("topic", "no_book", "YES", 1.0, 0.5, 0.51, 10000, ["w2"], 1.0, 0.9, "ok"),
+        CopyCandidate("topic", "resolving", "YES", 1.0, 0.5, 0.51, 10000, ["w3"], 1.0, 0.9, "ok"),
+        CopyCandidate("topic", "shallow", "YES", 1.0, 0.5, 0.51, 10000, ["w4"], 1.0, 0.9, "ok", suggested_position_usd=10.0),
+        CopyCandidate("topic", "late", "YES", 1.0, 0.5, 0.96, 10000, ["w5"], 1.0, 0.9, "ok"),
+        CopyCandidate("topic", "good", "YES", 1.0, 0.5, 0.51, 10000, ["w6"], 1.0, 0.9, "ok"),
+    ]
+    markets = {
+        "held": MarketSnapshot("held", "topic", "Held", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_held", yes_ask_size=200, orderbook_ready=True),
+        "no_book": MarketSnapshot("no_book", "topic", "No Book", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_no_book", yes_ask_size=200, orderbook_ready=False),
+        "resolving": MarketSnapshot("resolving", "topic", "Resolving", 0.51, 0.48, 0.5, 10000, 20, yes_token_id="yes_resolving", yes_ask_size=200, orderbook_ready=True),
+        "shallow": MarketSnapshot("shallow", "topic", "Shallow", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_shallow", yes_ask_size=5, orderbook_ready=True),
+        "late": MarketSnapshot("late", "topic", "Late", 0.96, 0.03, 0.95, 10000, 180, yes_token_id="yes_late", yes_ask_size=200, orderbook_ready=True),
+        "good": MarketSnapshot("good", "topic", "Good", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_good", yes_ask_size=200, orderbook_ready=True),
+    }
+
+    intents = planner.plan(candidates, markets, held_market_ids={"held"}, current_exposure_usd=0.0)
+
+    assert [intent.market_id for intent in intents] == ["good"]
+    assert planner.last_diagnostics == {
+        "candidates_seen": 6,
+        "below_copyability_threshold": 0,
+        "already_held": 1,
+        "orderbook_not_ready": 1,
+        "too_close_to_resolution": 1,
+        "zero_amount": 0,
+        "price_too_high": 1,
+        "missing_token_id": 0,
+        "insufficient_side_depth": 1,
+        "candidates_planned": 1,
+    }
 
 
 def test_execution_planner_skips_markets_resolving_within_30_minutes() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import sys
 
 from predictcel import discover_wallets
 from predictcel.main import (
+    _compact_cycle_output,
     _creates_or_updates_paper_position,
     _filter_duplicate_candidates,
     _mark_execution_intents_seen,
@@ -129,3 +130,28 @@ def test_discover_wallets_delegates_to_main(monkeypatch) -> None:
         "--config",
         "config/predictcel.example.json",
     ]
+
+
+def test_compact_cycle_output_includes_execution_state() -> None:
+    compact = _compact_cycle_output(
+        {
+            "mode": "live",
+            "summary": {"copy_candidates": 2, "execution_intents": 0},
+            "latency_ms": {"total_cycle_ms": 10},
+            "db": {"path": "/data/predictcel.db"},
+            "portfolio_summary": {"current_exposure_usd": 0},
+            "execution": {
+                "live_trading_requested": False,
+                "execution_enabled": True,
+                "planner_ran": False,
+                "diagnostics": {"candidates_seen": 2, "candidates_planned": 0},
+            },
+        }
+    )
+
+    assert compact["execution"] == {
+        "live_trading_requested": False,
+        "execution_enabled": True,
+        "planner_ran": False,
+        "diagnostics": {"candidates_seen": 2, "candidates_planned": 0},
+    }


### PR DESCRIPTION
## Summary
- add per-gate execution planner diagnostics so skipped candidates are counted explicitly
- expose execution state in cycle output so live data runs can distinguish planner-not-run from planner-ran-with-zero-intents
- update candidate messaging to describe scored orderbook inputs instead of claiming hard orderbook filters passed

## Verification
- python -m pytest tests/test_execution.py tests/test_main.py tests/test_copy_engine.py -p no:cacheprovider --ignore-glob=pytest-cache-files-*
- python -m ruff check src/predictcel/execution.py src/predictcel/main.py src/predictcel/copy_engine.py tests/test_execution.py tests/test_main.py tests/test_copy_engine.py