### PR TITLE
fix: restore legacy circuit breaker alias

### DIFF
--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -115,6 +115,7 @@ class PolymarketPublicClient:
         self._data_circuit_breaker = CircuitBreaker()
         self._clob_circuit_breaker = CircuitBreaker()
         self._default_circuit_breaker = CircuitBreaker()
+        self._circuit_breaker = self._gamma_circuit_breaker
 
         if use_redis:
             try:


### PR DESCRIPTION
## Summary
- restore the legacy `_circuit_breaker` attribute as an alias to the Gamma circuit breaker

## Why
The recent API-family breaker isolation changed the internal attribute shape, but the integration suite still references `_circuit_breaker` directly for Gamma-focused breaker behavior tests. This compatibility alias preserves the new routing while unblocking the existing test suite.

## Verification
- deploy log shows failures only from missing `_circuit_breaker`
- diff inspected via GitHub MCP
- automated tests were not executed from this read-only workspace