### PR TITLE
chore: isolate orderbook probes from warmed circuit breakers

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -422,12 +422,24 @@ def _build_orderbook_probe_samples(
     return samples
 
 
+def _make_probe_client(client: PolymarketPublicClient) -> PolymarketPublicClient:
+    return PolymarketPublicClient(
+        client.gamma_base_url,
+        client.data_base_url,
+        client.clob_base_url,
+        client.timeout_seconds,
+        client.max_retries,
+        client.retry_base_delay_seconds,
+    )
+
+
 def _probe_token_orderbook(client: PolymarketPublicClient, token_id: str) -> dict[str, Any]:
     token_id = str(token_id).strip()
     if not token_id:
         return {"missing_token_id": True}
     try:
-        return _summarize_order_book_payload(client.fetch_order_book(token_id))
+        probe_client = _make_probe_client(client)
+        return _summarize_order_book_payload(probe_client.fetch_order_book(token_id))
     except Exception as exc:
         return {"token_id": token_id, "error": f"{type(exc).__name__}: {exc}"}
 
@@ -437,7 +449,8 @@ def _probe_token_lookup(client: PolymarketPublicClient, token_id: str) -> dict[s
     if not token_id:
         return {"missing_token_id": True}
     try:
-        rows = client.fetch_markets_by_clob_token_ids([token_id], chunk_size=1)
+        probe_client = _make_probe_client(client)
+        rows = probe_client.fetch_markets_by_clob_token_ids([token_id], chunk_size=1)
     except Exception as exc:
         return {"token_id": token_id, "error": f"{type(exc).__name__}: {exc}"}
     return _summarize_market_lookup_rows(rows, token_id)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,8 @@ from predictcel.main import (
     _creates_or_updates_paper_position,
     _filter_duplicate_candidates,
     _mark_execution_intents_seen,
+    _probe_token_lookup,
+    _probe_token_orderbook,
 )
 from predictcel.models import CopyCandidate, ExecutionIntent, ExecutionResult
 
@@ -27,6 +29,15 @@ class FakeStore:
 
     def mark_signals_seen(self, signals) -> None:
         self.marked_signals.extend(list(signals))
+
+
+class ProbeSourceClient:
+    gamma_base_url = "https://gamma-api.polymarket.com"
+    data_base_url = "https://data-api.polymarket.com"
+    clob_base_url = "https://clob.polymarket.com"
+    timeout_seconds = 15
+    max_retries = 1
+    retry_base_delay_seconds = 0.5
 
 
 def make_result(status: str, order_id: str = "order_123") -> ExecutionResult:
@@ -154,4 +165,60 @@ def test_compact_cycle_output_includes_execution_state() -> None:
         "execution_enabled": True,
         "planner_ran": False,
         "diagnostics": {"candidates_seen": 2, "candidates_planned": 0},
+    }
+
+
+def test_probe_token_orderbook_uses_fresh_client(monkeypatch) -> None:
+    observed = {}
+
+    class FreshProbeClient:
+        def __init__(self, gamma_base_url, data_base_url, clob_base_url, timeout_seconds, max_retries, retry_base_delay_seconds):
+            observed["args"] = (
+                gamma_base_url,
+                data_base_url,
+                clob_base_url,
+                timeout_seconds,
+                max_retries,
+                retry_base_delay_seconds,
+            )
+
+        def fetch_order_book(self, token_id: str):
+            raise RuntimeError(f"root cause for {token_id}")
+
+    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FreshProbeClient)
+
+    result = _probe_token_orderbook(ProbeSourceClient(), "token_yes")
+
+    assert result == {"token_id": "token_yes", "error": "RuntimeError: root cause for token_yes"}
+    assert observed["args"] == (
+        "https://gamma-api.polymarket.com",
+        "https://data-api.polymarket.com",
+        "https://clob.polymarket.com",
+        15,
+        1,
+        0.5,
+    )
+
+
+def test_probe_token_lookup_uses_fresh_client(monkeypatch) -> None:
+    class FreshProbeClient:
+        def __init__(self, *args):
+            pass
+
+        def fetch_markets_by_clob_token_ids(self, token_ids: list[str], chunk_size: int = 25):
+            assert token_ids == ["token_yes"]
+            assert chunk_size == 1
+            return [{"conditionId": "cond_1", "question": "Question", "clobTokenIds": ["token_yes", "token_no"]}]
+
+    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FreshProbeClient)
+
+    result = _probe_token_lookup(ProbeSourceClient(), "token_yes")
+
+    assert result == {
+        "matched_rows": 1,
+        "condition_id": "cond_1",
+        "slug": "",
+        "question": "Question",
+        "token_ids": ["token_yes", "token_no"],
+        "matched_input_token": True,
     }


### PR DESCRIPTION
## Summary
- make orderbook and token-lookup diagnostic probes instantiate a fresh Polymarket client
- add focused tests showing the probe helpers use a fresh client and return the underlying error payload

## Why
Latest live logs still show `Circuit breaker is OPEN` inside `orderbook_probe_samples`, even after API-family breaker isolation. That means the diagnostics are still being contaminated by the state of the already-used runtime client. This patch keeps trading behavior unchanged and only makes the probes surface the underlying failure more accurately.

## Verification
- diff inspected via GitHub MCP
- automated tests were not executed from this read-only workspace