### PR TITLE
fix: treat missing CLOB books as non-fatal

### DIFF
--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -336,6 +336,9 @@ class PolymarketPublicClient:
             return self._clob_circuit_breaker
         return self._default_circuit_breaker
 
+    def _is_missing_clob_order_book(self, url: str, error: HTTPError) -> bool:
+        return error.code == 404 and url.startswith(f"{self.clob_base_url}/book?")
+
     def _get_json(self, url: str) -> Any:
         """Make HTTP GET request with caching and retries."""
         def _fetch_url():
@@ -355,7 +358,15 @@ class PolymarketPublicClient:
                         self._validate_response(payload, url)
                         self._set_cached(url, payload)
                         return payload
-                except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
+                except HTTPError as error:
+                    if self._is_missing_clob_order_book(url, error):
+                        return {}
+                    metrics["errors"] += 1
+                    if attempt >= self.max_retries - 1:
+                        raise
+                    delay = _retry_delay(self.retry_base_delay_seconds, attempt)
+                    time.sleep(delay)
+                except (URLError, TimeoutError, OSError, json.JSONDecodeError):
                     metrics["errors"] += 1
                     if attempt >= self.max_retries - 1:
                         raise

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -1,6 +1,6 @@
 import json
 from datetime import UTC, datetime
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -226,6 +226,41 @@ def test_enrich_market_snapshots_requires_tradable_ask_depth() -> None:
     assert enriched["cond_1"].yes_ask_size == 0
     assert enriched["cond_1"].no_ask_size == 0
     assert enriched["cond_1"].orderbook_ready is False
+
+
+def test_fetch_order_book_treats_missing_clob_book_as_empty_payload(monkeypatch) -> None:
+    client = PolymarketPublicClient(max_retries=1)
+
+    def fake_urlopen(request, timeout=15):
+        raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+
+    book = client.fetch_order_book("missing_token")
+
+    assert book == {}
+    assert client._clob_circuit_breaker.state == "CLOSED"
+
+
+def test_missing_clob_book_does_not_block_later_valid_books(monkeypatch) -> None:
+    client = PolymarketPublicClient(max_retries=1)
+
+    def fake_urlopen(request, timeout=15):
+        if "missing_token" in request.full_url:
+            raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
+        return FakeHTTPResponse({
+            "bids": [{"price": "0.48", "size": "10"}],
+            "asks": [{"price": "0.52", "size": "12"}],
+        })
+
+    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+
+    missing_book = client.fetch_order_book("missing_token")
+    valid_book = client.fetch_order_book("valid_token")
+
+    assert missing_book == {}
+    assert valid_book["asks"][0]["price"] == "0.52"
+    assert client._clob_circuit_breaker.state == "CLOSED"
 
 
 def test_gamma_circuit_breaker_does_not_block_clob_requests(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- treat `HTTP 404` from CLOB `/book` requests as an empty order book instead of a breaker-worthy transport failure
- add regressions covering missing books and ensuring they do not block later valid book fetches

## Why
Fresh live probe logs now show the concrete failure mode: some token IDs return `HTTP 404` on CLOB `/book`, while other markets return valid order books. Those 404s currently count as failures against the shared CLOB breaker, which can open during enrichment and suppress later valid book fetches. This patch keeps missing books benign so valid books can still load.

## Verification
- diff inspected via GitHub MCP
- automated tests were not executed from this read-only workspace