### PR TITLE
fix: propagate enriched market snapshots across aliases

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -347,7 +347,9 @@ def _load_live_inputs(config):
     relevant_market_keys = {market_key for market_key in (*trade_market_ids, *trade_market_slugs) if market_key in markets}
     if relevant_market_keys:
         relevant_snapshots = {market_id: markets[market_id] for market_id in relevant_market_keys}
-        markets.update(enrich_market_snapshots_with_orderbooks(relevant_snapshots, client))
+        enriched_relevant = enrich_market_snapshots_with_orderbooks(relevant_snapshots, client)
+        markets.update(enriched_relevant)
+        _propagate_canonical_market_updates(markets, enriched_relevant.values())
 
     trade_market_keys = sorted(set(trade_market_ids + trade_market_slugs))
     matched_trade_market_keys = [market_key for market_key in trade_market_keys if market_key in markets]
@@ -392,6 +394,20 @@ def _load_live_inputs(config):
         },
     }
     return trades, markets, diagnostics
+
+
+def _propagate_canonical_market_updates(markets: dict[str, Any], updated_snapshots: Any) -> None:
+    canonical_updates = {
+        snapshot.market_id: snapshot
+        for snapshot in updated_snapshots
+        if getattr(snapshot, "market_id", "")
+    }
+    if not canonical_updates:
+        return
+    for market_key, snapshot in list(markets.items()):
+        canonical_snapshot = canonical_updates.get(getattr(snapshot, "market_id", ""))
+        if canonical_snapshot is not None:
+            markets[market_key] = canonical_snapshot
 
 
 def _build_orderbook_probe_samples(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,8 +8,9 @@ from predictcel.main import (
     _mark_execution_intents_seen,
     _probe_token_lookup,
     _probe_token_orderbook,
+    _propagate_canonical_market_updates,
 )
-from predictcel.models import CopyCandidate, ExecutionIntent, ExecutionResult
+from predictcel.models import CopyCandidate, ExecutionIntent, ExecutionResult, MarketSnapshot
 
 
 class FakeStore:
@@ -84,6 +85,26 @@ def make_intent(market_id: str, side: str = "YES") -> ExecutionIntent:
         copyability_score=0.9,
         order_type="FOK",
         reason="test",
+    )
+
+
+def make_snapshot(market_id: str, orderbook_ready: bool = False, yes_ask_size: float = 0.0, no_ask_size: float = 0.0) -> MarketSnapshot:
+    return MarketSnapshot(
+        market_id=market_id,
+        topic="geopolitics",
+        title="One",
+        yes_ask=0.51,
+        no_ask=0.49,
+        best_bid=0.5,
+        liquidity_usd=1000.0,
+        minutes_to_resolution=120,
+        yes_token_id="yes_token",
+        no_token_id="no_token",
+        yes_bid=0.5,
+        no_bid=0.5,
+        yes_ask_size=yes_ask_size,
+        no_ask_size=no_ask_size,
+        orderbook_ready=orderbook_ready,
     )
 
 
@@ -222,3 +243,21 @@ def test_probe_token_lookup_uses_fresh_client(monkeypatch) -> None:
         "token_ids": ["token_yes", "token_no"],
         "matched_input_token": True,
     }
+
+
+def test_propagate_canonical_market_updates_rebinds_stale_aliases() -> None:
+    stale_snapshot = make_snapshot("m1", orderbook_ready=False)
+    enriched_snapshot = make_snapshot("m1", orderbook_ready=True, yes_ask_size=10.0, no_ask_size=20.0)
+    markets = {
+        "m1": stale_snapshot,
+        "slug-1": stale_snapshot,
+        "yes_token": stale_snapshot,
+        "no_token": stale_snapshot,
+    }
+
+    _propagate_canonical_market_updates(markets, [enriched_snapshot])
+
+    assert markets["m1"] is enriched_snapshot
+    assert markets["slug-1"] is enriched_snapshot
+    assert markets["yes_token"] is enriched_snapshot
+    assert markets["no_token"] is enriched_snapshot


### PR DESCRIPTION
## Summary
- propagate enriched market snapshots to every cached alias for the same canonical `market_id`
- add a regression covering stale alias rebinding

## Why
Latest live logs show valid CLOB books for some markets while `orderbook_ready_markets` remains `0`. That indicates enrichment succeeds for at least some canonical snapshots, but stale alias entries later overwrite those enriched snapshots when the cache is re-read by market id. This patch ensures that once a market is enriched, all cached aliases for that market point at the same enriched snapshot.

## Verification
- diff inspected via GitHub MCP
- automated tests were not executed from this read-only workspace