### PR TITLE
Add basket controller consensus gate

### DIFF
--- a/src/predictcel/basket_controller.py
+++ b/src/predictcel/basket_controller.py
@@ -1,0 +1,118 @@
+"""Basket Controller v2 consensus helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .config import AppConfig, BasketRule
+from .models import WalletTrade
+
+LIVE_CONSENSUS_TIERS = {"core", "rotating"}
+
+
+@dataclass(frozen=True)
+class BasketConsensusGate:
+    """Computed live-basket consensus state for a market."""
+
+    tracked_wallets: list[str]
+    participating_wallet_count: int
+    aligned_wallet_count: int
+    basket_participation_ratio: float
+    weighted_participation_ratio: float
+    price_band_abs: float
+    time_spread_seconds: int
+
+
+def evaluate_basket_consensus_gate(
+    config: AppConfig,
+    topic: str,
+    basket: BasketRule,
+    wallet_votes: dict[str, WalletTrade],
+    aligned_trades: list[WalletTrade],
+    wallet_weights: dict[str, float],
+    store=None,
+) -> tuple[BasketConsensusGate, str | None]:
+    """Evaluate the opt-in live basket controller gate."""
+    tracked_wallets = _tracked_wallets_for_topic(config, topic, basket, store)
+    tracked_wallet_set = set(tracked_wallets)
+    participating_wallets = [
+        wallet for wallet in tracked_wallets if wallet in wallet_votes
+    ]
+    aligned_wallets = [
+        trade.wallet for trade in aligned_trades if trade.wallet in tracked_wallet_set
+    ]
+
+    tracked_wallet_count = len(tracked_wallets)
+    aligned_wallet_count = len(aligned_wallets)
+    participating_wallet_count = len(participating_wallets)
+    basket_participation_ratio = (
+        aligned_wallet_count / tracked_wallet_count if tracked_wallet_count else 0.0
+    )
+
+    participating_weight = sum(wallet_weights.get(wallet, 0.0) for wallet in participating_wallets)
+    aligned_weight = sum(wallet_weights.get(wallet, 0.0) for wallet in aligned_wallets)
+    weighted_participation_ratio = (
+        aligned_weight / participating_weight if participating_weight else 0.0
+    )
+
+    aligned_prices = [trade.price for trade in aligned_trades if trade.wallet in tracked_wallet_set]
+    price_band_abs = (
+        max(aligned_prices) - min(aligned_prices) if len(aligned_prices) >= 2 else 0.0
+    )
+    aligned_ages = [trade.age_seconds for trade in aligned_trades if trade.wallet in tracked_wallet_set]
+    time_spread_seconds = (
+        max(aligned_ages) - min(aligned_ages) if len(aligned_ages) >= 2 else 0
+    )
+
+    gate = BasketConsensusGate(
+        tracked_wallets=tracked_wallets,
+        participating_wallet_count=participating_wallet_count,
+        aligned_wallet_count=aligned_wallet_count,
+        basket_participation_ratio=round(basket_participation_ratio, 4),
+        weighted_participation_ratio=round(weighted_participation_ratio, 4),
+        price_band_abs=round(price_band_abs, 4),
+        time_spread_seconds=time_spread_seconds,
+    )
+
+    controller = config.basket_controller
+    if participating_wallet_count < controller.min_active_eligible_wallets:
+        return gate, "insufficient_basket_participants"
+    if aligned_wallet_count < controller.min_aligned_wallet_count:
+        return gate, "below_basket_participation"
+    if basket_participation_ratio < controller.min_basket_participation_ratio:
+        return gate, "below_basket_participation"
+    if weighted_participation_ratio < controller.min_weighted_participation_ratio:
+        return gate, "below_weighted_basket_participation"
+    if price_band_abs > controller.max_entry_price_band_abs:
+        return gate, "wide_entry_price_band"
+    if time_spread_seconds > controller.max_entry_time_spread_seconds:
+        return gate, "wide_entry_time_spread"
+    return gate, None
+
+
+def _tracked_wallets_for_topic(
+    config: AppConfig,
+    topic: str,
+    basket: BasketRule,
+    store=None,
+) -> list[str]:
+    if store is None or not hasattr(store, "load_basket_memberships"):
+        return list(basket.wallets)
+
+    memberships = store.load_basket_memberships(topic)
+    if not memberships:
+        return list(basket.wallets)
+
+    live_tiers = set(LIVE_CONSENSUS_TIERS)
+    if config.basket_controller.allow_backup_in_live_consensus:
+        live_tiers.add("backup")
+
+    live_memberships = [
+        membership
+        for membership in memberships
+        if membership.active and membership.tier in live_tiers
+    ]
+    if not live_memberships:
+        return list(basket.wallets)
+
+    live_memberships.sort(key=lambda membership: (membership.rank, membership.wallet))
+    return [membership.wallet for membership in live_memberships]

--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -13,6 +13,7 @@ from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
+from .basket_controller import evaluate_basket_consensus_gate
 from .config import AppConfig, BasketRule
 from .models import CopyCandidate, MarketRegime, MarketSnapshot, WalletQuality, WalletTrade
 from .scoring import compute_copyability_score
@@ -279,11 +280,13 @@ class CopyEngine:
 
         wallet_votes = self._latest_wallet_votes(valid_trades)
         weighted_by_side: dict[str, float] = defaultdict(float)
+        wallet_weights: dict[str, float] = {}
         trade_weights: list[tuple[WalletTrade, float, str]] = []
         for trade in wallet_votes.values():
             side = trade.side.upper()
             weight = self._trade_weight(trade, wallet_qualities)
             weighted_by_side[side] += weight
+            wallet_weights[trade.wallet] = weight
             trade_weights.append((trade, weight, side))
 
         if not weighted_by_side:
@@ -294,10 +297,30 @@ class CopyEngine:
             return None, "no_aligned_trades", Counter()
 
         aligned_wallets = sorted({trade.wallet for trade in aligned})
-        consensus_ratio = len(aligned_wallets) / len(basket.wallets) if basket.wallets else 0.0
+        controller_gate = None
+        if self.config.basket_controller.enabled:
+            controller_gate, controller_rejection = evaluate_basket_consensus_gate(
+                self.config,
+                topic,
+                basket,
+                wallet_votes,
+                aligned,
+                wallet_weights,
+                store=portfolio_summary.get("_store") if portfolio_summary else None,
+            )
+            if controller_rejection is not None:
+                return None, controller_rejection, Counter()
+            tracked_wallet_count = len(controller_gate.tracked_wallets)
+        else:
+            tracked_wallet_count = len(basket.wallets)
+
+        consensus_ratio = len(aligned_wallets) / tracked_wallet_count if tracked_wallet_count else 0.0
         total_weight = sum(weighted_by_side.values())
         aligned_weight = weighted_by_side[side]
-        weighted_consensus = round(aligned_weight / total_weight, 4) if total_weight else 0.0
+        if controller_gate is not None:
+            weighted_consensus = controller_gate.weighted_participation_ratio
+        else:
+            weighted_consensus = round(aligned_weight / total_weight, 4) if total_weight else 0.0
         if consensus_ratio < basket.quorum_ratio:
             return None, "below_quorum", Counter()
         if weighted_consensus < self.config.consensus.min_weighted_consensus:
@@ -547,9 +570,13 @@ class CopyEngine:
     def _portfolio_summary(self, store: Any = None) -> dict[str, float | int]:
         if store is None:
             return {}
-        return store.get_portfolio_summary(
+        summary = store.get_portfolio_summary(
             starting_bankroll_usd=self.config.consensus.bankroll_usd,
         )
+        if isinstance(summary, dict):
+            summary = dict(summary)
+            summary["_store"] = store
+        return summary
 
     def _suggested_position_size(
         self,

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -1,4 +1,5 @@
 import builtins
+from datetime import UTC, datetime
 from dataclasses import replace
 from io import BytesIO
 
@@ -6,6 +7,7 @@ from predictcel import copy_engine as copy_engine_module
 from predictcel.config import (
     ArbitrageConfig,
     AppConfig,
+    BasketControllerConfig,
     BasketRule,
     ConsensusConfig,
     ExecutionConfig,
@@ -15,7 +17,7 @@ from predictcel.config import (
     PositionConfig,
 )
 from predictcel.copy_engine import CopyEngine
-from predictcel.models import MarketSnapshot, WalletQuality, WalletTrade
+from predictcel.models import BasketMembership, MarketSnapshot, WalletQuality, WalletTrade
 
 
 class CountingStore:
@@ -31,12 +33,28 @@ class CountingStore:
         }
 
 
-def make_config(consensus: ConsensusConfig | None = None) -> AppConfig:
+class MembershipStore(CountingStore):
+    def __init__(self, memberships: list[BasketMembership]) -> None:
+        super().__init__()
+        self.memberships = memberships
+
+    def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+        if topic is None:
+            return list(self.memberships)
+        return [membership for membership in self.memberships if membership.topic == topic]
+
+
+def make_config(
+    consensus: ConsensusConfig | None = None,
+    wallets: list[str] | None = None,
+    basket_controller: BasketControllerConfig | None = None,
+) -> AppConfig:
+    wallets = wallets or ["w1", "w2", "w3"]
     return AppConfig(
         baskets=[
             BasketRule(
                 topic="geopolitics",
-                wallets=["w1", "w2", "w3"],
+                wallets=wallets,
                 quorum_ratio=0.66,
             )
         ],
@@ -83,6 +101,7 @@ def make_config(consensus: ConsensusConfig | None = None) -> AppConfig:
             retry_base_delay_seconds=1.0,
         ),
         consensus=consensus or ConsensusConfig(min_confidence_score=0.35),
+        basket_controller=basket_controller or BasketControllerConfig(),
     )
 
 
@@ -133,7 +152,42 @@ def make_qualities() -> dict[str, WalletQuality]:
             average_drift=0.03,
             reason="test",
         ),
+        "w4": WalletQuality(
+            wallet="w4",
+            topic="geopolitics",
+            score=0.75,
+            eligible_trade_count=2,
+            average_age_seconds=800,
+            average_drift=0.02,
+            reason="test",
+        ),
+        "w5": WalletQuality(
+            wallet="w5",
+            topic="geopolitics",
+            score=0.7,
+            eligible_trade_count=2,
+            average_age_seconds=850,
+            average_drift=0.02,
+            reason="test",
+        ),
     }
+
+
+def make_memberships(wallets: list[str], tier: str = "core") -> list[BasketMembership]:
+    return [
+        BasketMembership(
+            topic="geopolitics",
+            wallet=wallet,
+            tier=tier,
+            rank=index,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="test",
+            demotion_reason="",
+        )
+        for index, wallet in enumerate(wallets, start=1)
+    ]
 
 
 def test_emits_candidate_when_quorum_and_drift_pass() -> None:
@@ -739,3 +793,164 @@ def test_copy_engine_ignores_cwd_pickle_fallback(monkeypatch) -> None:
 
     assert engine._ml_model is None
     assert loaded["called"] is False
+
+
+def test_basket_controller_requires_80_percent_same_outcome() -> None:
+    wallets = ["w1", "w2", "w3", "w4", "w5"]
+    engine = CopyEngine(
+        make_config(
+            wallets=wallets,
+            basket_controller=BasketControllerConfig(
+                enabled=True,
+                tracked_basket_target=5,
+                core_slots=5,
+                rotating_slots=0,
+                backup_slots=0,
+                explorer_slots=0,
+                min_basket_participation_ratio=0.8,
+                min_weighted_participation_ratio=0.8,
+                min_active_eligible_wallets=5,
+                min_aligned_wallet_count=4,
+                max_entry_price_band_abs=0.03,
+                max_entry_time_spread_seconds=600,
+            ),
+        )
+    )
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.58, 200, 100),
+        WalletTrade("w2", "geopolitics", "m1", "YES", 0.59, 220, 120),
+        WalletTrade("w3", "geopolitics", "m1", "YES", 0.60, 180, 140),
+        WalletTrade("w4", "geopolitics", "m1", "YES", 0.60, 210, 160),
+        WalletTrade("w5", "geopolitics", "m1", "NO", 0.41, 100, 180),
+    ]
+
+    candidates = engine.evaluate(
+        trades,
+        {"m1": make_market()},
+        make_qualities(),
+        MembershipStore(make_memberships(wallets)),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].consensus_ratio == 0.8
+    assert candidates[0].source_wallets == ["w1", "w2", "w3", "w4"]
+
+
+def test_basket_controller_rejects_when_same_outcome_ratio_is_below_threshold() -> None:
+    wallets = ["w1", "w2", "w3", "w4", "w5"]
+    engine = CopyEngine(
+        make_config(
+            wallets=wallets,
+            basket_controller=BasketControllerConfig(
+                enabled=True,
+                tracked_basket_target=5,
+                core_slots=5,
+                rotating_slots=0,
+                backup_slots=0,
+                explorer_slots=0,
+                min_basket_participation_ratio=0.8,
+                min_weighted_participation_ratio=0.8,
+                min_active_eligible_wallets=5,
+                min_aligned_wallet_count=4,
+                max_entry_price_band_abs=0.03,
+                max_entry_time_spread_seconds=600,
+            ),
+        )
+    )
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.58, 200, 100),
+        WalletTrade("w2", "geopolitics", "m1", "YES", 0.59, 220, 120),
+        WalletTrade("w3", "geopolitics", "m1", "YES", 0.60, 180, 140),
+        WalletTrade("w4", "geopolitics", "m1", "NO", 0.41, 210, 160),
+        WalletTrade("w5", "geopolitics", "m1", "NO", 0.42, 100, 180),
+    ]
+
+    candidates = engine.evaluate(
+        trades,
+        {"m1": make_market()},
+        make_qualities(),
+        MembershipStore(make_memberships(wallets)),
+    )
+
+    assert candidates == []
+    assert engine.last_diagnostics["below_basket_participation"] == 1
+
+
+def test_basket_controller_rejects_when_aligned_wallets_do_not_buy_in_tight_price_band() -> None:
+    wallets = ["w1", "w2", "w3", "w4", "w5"]
+    engine = CopyEngine(
+        make_config(
+            wallets=wallets,
+            basket_controller=BasketControllerConfig(
+                enabled=True,
+                tracked_basket_target=5,
+                core_slots=5,
+                rotating_slots=0,
+                backup_slots=0,
+                explorer_slots=0,
+                min_basket_participation_ratio=0.8,
+                min_weighted_participation_ratio=0.8,
+                min_active_eligible_wallets=5,
+                min_aligned_wallet_count=4,
+                max_entry_price_band_abs=0.03,
+                max_entry_time_spread_seconds=600,
+            ),
+        )
+    )
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.58, 200, 100),
+        WalletTrade("w2", "geopolitics", "m1", "YES", 0.59, 220, 120),
+        WalletTrade("w3", "geopolitics", "m1", "YES", 0.60, 180, 140),
+        WalletTrade("w4", "geopolitics", "m1", "YES", 0.66, 210, 160),
+        WalletTrade("w5", "geopolitics", "m1", "NO", 0.42, 100, 180),
+    ]
+
+    candidates = engine.evaluate(
+        trades,
+        {"m1": make_market()},
+        make_qualities(),
+        MembershipStore(make_memberships(wallets)),
+    )
+
+    assert candidates == []
+    assert engine.last_diagnostics["wide_entry_price_band"] == 1
+
+
+def test_basket_controller_rejects_when_aligned_wallets_are_too_far_apart_in_time() -> None:
+    wallets = ["w1", "w2", "w3", "w4", "w5"]
+    engine = CopyEngine(
+        make_config(
+            wallets=wallets,
+            basket_controller=BasketControllerConfig(
+                enabled=True,
+                tracked_basket_target=5,
+                core_slots=5,
+                rotating_slots=0,
+                backup_slots=0,
+                explorer_slots=0,
+                min_basket_participation_ratio=0.8,
+                min_weighted_participation_ratio=0.8,
+                min_active_eligible_wallets=5,
+                min_aligned_wallet_count=4,
+                max_entry_price_band_abs=0.03,
+                max_entry_time_spread_seconds=120,
+            ),
+        )
+    )
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.58, 200, 100),
+        WalletTrade("w2", "geopolitics", "m1", "YES", 0.59, 220, 120),
+        WalletTrade("w3", "geopolitics", "m1", "YES", 0.60, 180, 140),
+        WalletTrade("w4", "geopolitics", "m1", "YES", 0.60, 210, 500),
+        WalletTrade("w5", "geopolitics", "m1", "NO", 0.42, 100, 180),
+    ]
+
+    candidates = engine.evaluate(
+        trades,
+        {"m1": make_market()},
+        make_qualities(),
+        MembershipStore(make_memberships(wallets)),
+    )
+
+    assert candidates == []
+    assert engine.last_diagnostics["wide_entry_time_spread"] == 1


### PR DESCRIPTION
## Summary
- add an opt-in basket controller module for live basket consensus gating
- require strong live-basket agreement before emitting a copy candidate when `basket_controller.enabled` is on
- enforce the new gate on aligned outcome ratio, tight entry price band, and tight entry time spread

## Testing
- `tests/test_copy_engine.py`
- `tests/test_main.py`
- `tests/test_wallet_registry.py`
- `tests/test_config.py`
