### PR TITLE
feat: add live wallet roster diagnostics

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -36,6 +36,7 @@ from .scoring import WalletQualityScorer
 from .storage import SignalStore
 from .wallet_discovery import WalletDiscoveryPipeline
 from .wallet_registry import (
+    build_live_basket_roster,
     compute_basket_health_from_static_memberships,
     seed_memberships_from_config,
     seed_registry_from_config,
@@ -391,6 +392,7 @@ def _build_wallet_registry_summary(
             "registry_wallet_count": 0,
             "memberships_by_topic": {},
             "basket_health": {},
+            "live_roster_by_topic": {},
         }
 
     captured_at = datetime.now(UTC)
@@ -406,6 +408,7 @@ def _build_wallet_registry_summary(
         trades,
         captured_at=captured_at,
     )
+    live_roster = build_live_basket_roster(config, memberships, trades)
     store.save_basket_health(basket_health)
     latest_health = store.latest_basket_health()
     return {
@@ -416,6 +419,7 @@ def _build_wallet_registry_summary(
             topic: _basket_health_as_dict(health)
             for topic, health in latest_health.items()
         },
+        "live_roster_by_topic": live_roster,
     }
 
 

--- a/src/predictcel/wallet_registry.py
+++ b/src/predictcel/wallet_registry.py
@@ -10,6 +10,9 @@ from .models import BasketHealth, BasketMembership, WalletRegistryEntry, WalletT
 if TYPE_CHECKING:
     from .config import AppConfig
 
+TIER_ORDER = ("core", "rotating", "backup", "explorer")
+TIER_PRIORITY = {tier: index for index, tier in enumerate(TIER_ORDER)}
+
 
 def seed_registry_from_config(
     config: AppConfig,
@@ -152,3 +155,126 @@ def compute_basket_health_from_static_memberships(
         )
 
     return health_snapshots
+
+
+def build_live_basket_roster(
+    config: AppConfig,
+    memberships: Iterable[BasketMembership],
+    trades: Iterable[WalletTrade],
+) -> dict[str, dict[str, object]]:
+    """Derive a live basket roster from recent membership activity."""
+    active_memberships_by_topic: dict[str, list[BasketMembership]] = defaultdict(list)
+    for membership in memberships:
+        if membership.active:
+            active_memberships_by_topic[membership.topic].append(membership)
+
+    trades_by_topic_wallet: dict[tuple[str, str], list[WalletTrade]] = defaultdict(list)
+    for trade in trades:
+        trades_by_topic_wallet[(trade.topic, trade.wallet)].append(trade)
+
+    controller = config.basket_controller
+    slot_counts = {
+        "core": controller.core_slots,
+        "rotating": controller.rotating_slots,
+        "backup": controller.backup_slots,
+        "explorer": controller.explorer_slots,
+    }
+    live_tiers = ["core", "rotating"]
+    if controller.allow_backup_in_live_consensus:
+        live_tiers.append("backup")
+
+    roster: dict[str, dict[str, object]] = {}
+    for topic in sorted(active_memberships_by_topic):
+        ranked_memberships = sorted(
+            active_memberships_by_topic[topic],
+            key=lambda membership: _membership_activity_sort_key(
+                membership,
+                trades_by_topic_wallet.get((topic, membership.wallet), []),
+                config.filters.max_trade_age_seconds,
+            ),
+        )
+
+        selected_wallets: dict[str, list[str]] = {tier: [] for tier in TIER_ORDER}
+        selected_memberships: dict[str, list[BasketMembership]] = {
+            tier: [] for tier in TIER_ORDER
+        }
+        start = 0
+        for tier in TIER_ORDER:
+            slots = slot_counts[tier]
+            if slots <= 0:
+                continue
+            tier_memberships = ranked_memberships[start : start + slots]
+            selected_memberships[tier] = tier_memberships
+            selected_wallets[tier] = [membership.wallet for membership in tier_memberships]
+            start += slots
+
+        fresh_core_wallet_count = sum(
+            1
+            for membership in selected_memberships["core"]
+            if _has_trade_within(
+                trades_by_topic_wallet.get((topic, membership.wallet), []),
+                86_400,
+            )
+        )
+        live_eligible_wallet_count = sum(
+            1
+            for tier in live_tiers
+            for membership in selected_memberships[tier]
+            if _has_trade_within(
+                trades_by_topic_wallet.get((topic, membership.wallet), []),
+                config.filters.max_trade_age_seconds,
+            )
+        )
+        unfilled_slots = {
+            tier: max(0, slot_counts[tier] - len(selected_wallets[tier]))
+            for tier in TIER_ORDER
+        }
+        refresh_reasons: list[str] = []
+        if fresh_core_wallet_count < controller.force_refresh_if_fresh_core_below:
+            refresh_reasons.append("fresh_core_below_threshold")
+        if live_eligible_wallet_count < controller.min_active_eligible_wallets:
+            refresh_reasons.append("live_eligible_wallets_below_threshold")
+        if unfilled_slots["core"] > 0:
+            refresh_reasons.append("core_slots_unfilled")
+
+        roster[topic] = {
+            "selected_wallets": selected_wallets,
+            "fresh_core_wallet_count": fresh_core_wallet_count,
+            "live_eligible_wallet_count": live_eligible_wallet_count,
+            "tracked_wallet_count": len(active_memberships_by_topic[topic]),
+            "unfilled_slots": unfilled_slots,
+            "needs_refresh": bool(refresh_reasons),
+            "refresh_reasons": refresh_reasons,
+        }
+
+    return roster
+
+
+def _membership_activity_sort_key(
+    membership: BasketMembership,
+    trades: list[WalletTrade],
+    max_trade_age_seconds: int,
+) -> tuple[int, int, int, int, int, int, int, str]:
+    eligible_trade_count = sum(
+        1 for trade in trades if trade.age_seconds <= max_trade_age_seconds
+    )
+    recent_trade_count_24h = sum(1 for trade in trades if trade.age_seconds <= 86_400)
+    active_trade_count_7d = sum(1 for trade in trades if trade.age_seconds <= 604_800)
+    freshest_trade_age_seconds = min(
+        (trade.age_seconds for trade in trades),
+        default=10**12,
+    )
+    return (
+        0 if eligible_trade_count > 0 else 1,
+        freshest_trade_age_seconds,
+        -recent_trade_count_24h,
+        -active_trade_count_7d,
+        -eligible_trade_count,
+        TIER_PRIORITY.get(membership.tier, len(TIER_PRIORITY)),
+        membership.rank,
+        membership.wallet,
+    )
+
+
+def _has_trade_within(trades: list[WalletTrade], max_age_seconds: int) -> bool:
+    return any(trade.age_seconds <= max_age_seconds for trade in trades)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,12 @@
 import sys
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
 
+from predictcel.config import load_config
 from predictcel import discover_wallets
 from predictcel.main import (
+    _build_wallet_registry_summary,
     _compact_cycle_output,
     _creates_or_updates_paper_position,
     _filter_duplicate_candidates,
@@ -11,10 +16,14 @@ from predictcel.main import (
     _propagate_canonical_market_updates,
 )
 from predictcel.models import (
+    BasketHealth,
+    BasketMembership,
     CopyCandidate,
     ExecutionIntent,
     ExecutionResult,
     MarketSnapshot,
+    WalletRegistryEntry,
+    WalletTrade,
 )
 
 
@@ -45,6 +54,37 @@ class ProbeSourceClient:
     timeout_seconds = 15
     max_retries = 1
     retry_base_delay_seconds = 0.5
+
+
+class RegistrySummaryStore:
+    def __init__(
+        self,
+        registry_entries: list[WalletRegistryEntry],
+        memberships: list[BasketMembership],
+    ) -> None:
+        self.registry_entries = registry_entries
+        self.memberships = memberships
+        self.saved_health: list[BasketHealth] = []
+
+    def upsert_wallet_registry_entries(self, entries) -> None:
+        self.registry_entries = list(entries)
+
+    def upsert_basket_memberships(self, memberships) -> None:
+        self.memberships = list(memberships)
+
+    def load_wallet_registry_entries(self) -> list[WalletRegistryEntry]:
+        return list(self.registry_entries)
+
+    def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+        if topic is None:
+            return list(self.memberships)
+        return [membership for membership in self.memberships if membership.topic == topic]
+
+    def save_basket_health(self, health_snapshots: list[BasketHealth]) -> None:
+        self.saved_health = list(health_snapshots)
+
+    def latest_basket_health(self) -> dict[str, BasketHealth]:
+        return {health.topic: health for health in self.saved_health}
 
 
 def make_result(status: str, order_id: str = "order_123") -> ExecutionResult:
@@ -253,6 +293,81 @@ def test_compact_cycle_output_includes_wallet_registry_summary() -> None:
                 "health_state": "thin",
             }
         },
+    }
+
+
+def test_build_wallet_registry_summary_includes_live_roster() -> None:
+    config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        config,
+        wallet_registry=replace(config.wallet_registry, enabled=True, seed_from_baskets=False),
+        basket_controller=replace(
+            config.basket_controller,
+            tracked_basket_target=4,
+            core_slots=2,
+            rotating_slots=1,
+            backup_slots=1,
+            explorer_slots=0,
+            force_refresh_if_fresh_core_below=2,
+            min_active_eligible_wallets=3,
+        ),
+    )
+    captured_at = datetime(2026, 1, 1, tzinfo=UTC)
+    store = RegistrySummaryStore(
+        registry_entries=[
+            WalletRegistryEntry(
+                wallet=wallet,
+                source_type="static_basket",
+                source_ref="config.baskets",
+                trust_seed=1.0,
+                status="active",
+                first_seen_at=captured_at,
+            )
+            for wallet in ["w1", "w2", "w3", "w4"]
+        ],
+        memberships=[
+            BasketMembership(
+                topic="geopolitics",
+                wallet=wallet,
+                tier="core",
+                rank=index,
+                active=True,
+                joined_at=captured_at,
+                effective_until=None,
+                promotion_reason="seeded",
+                demotion_reason="",
+            )
+            for index, wallet in enumerate(["w1", "w2", "w3", "w4"], start=1)
+        ],
+    )
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.5, 20.0, 1_200),
+        WalletTrade("w2", "geopolitics", "m2", "NO", 0.4, 15.0, 90_000),
+    ]
+
+    summary = _build_wallet_registry_summary(config, store, trades)
+
+    assert summary["live_roster_by_topic"]["geopolitics"] == {
+        "selected_wallets": {
+            "core": ["w1", "w2"],
+            "rotating": ["w3"],
+            "backup": ["w4"],
+            "explorer": [],
+        },
+        "fresh_core_wallet_count": 1,
+        "live_eligible_wallet_count": 1,
+        "tracked_wallet_count": 4,
+        "unfilled_slots": {
+            "core": 0,
+            "rotating": 0,
+            "backup": 0,
+            "explorer": 0,
+        },
+        "needs_refresh": True,
+        "refresh_reasons": [
+            "fresh_core_below_threshold",
+            "live_eligible_wallets_below_threshold",
+        ],
     }
 
 

--- a/tests/test_wallet_registry.py
+++ b/tests/test_wallet_registry.py
@@ -1,11 +1,13 @@
 from datetime import UTC, datetime
 from pathlib import Path
+from dataclasses import replace
 
 import pytest
 
 from predictcel.config import load_config
 from predictcel.models import BasketMembership, WalletTrade
 from predictcel.wallet_registry import (
+    build_live_basket_roster,
     compute_basket_health_from_static_memberships,
     seed_memberships_from_config,
     seed_registry_from_config,
@@ -123,3 +125,131 @@ def test_compute_basket_health_from_static_memberships() -> None:
     assert health[0].stale_ratio == pytest.approx(1 / 3, rel=1e-3)
     assert health[0].clustered_ratio == 0.0
     assert health[0].health_state == "thin"
+
+
+def test_build_live_basket_roster_ranks_recent_wallets_into_live_slots() -> None:
+    config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        config,
+        basket_controller=replace(
+            config.basket_controller,
+            tracked_basket_target=4,
+            core_slots=2,
+            rotating_slots=1,
+            backup_slots=1,
+            explorer_slots=0,
+            force_refresh_if_fresh_core_below=1,
+            min_active_eligible_wallets=3,
+        ),
+    )
+    memberships = [
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w1",
+            tier="core",
+            rank=1,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w2",
+            tier="rotating",
+            rank=2,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w3",
+            tier="backup",
+            rank=3,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w4",
+            tier="explorer",
+            rank=4,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+    ]
+    trades = [
+        WalletTrade("w2", "geopolitics", "m1", "YES", 0.5, 20.0, 700),
+        WalletTrade("w2", "geopolitics", "m2", "NO", 0.4, 15.0, 1_400),
+        WalletTrade("w3", "geopolitics", "m3", "YES", 0.6, 12.0, 300),
+        WalletTrade("w4", "geopolitics", "m4", "YES", 0.6, 12.0, 86_000),
+    ]
+
+    roster = build_live_basket_roster(config, memberships, trades)
+
+    assert roster["geopolitics"]["selected_wallets"] == {
+        "core": ["w3", "w2"],
+        "rotating": ["w4"],
+        "backup": ["w1"],
+        "explorer": [],
+    }
+    assert roster["geopolitics"]["fresh_core_wallet_count"] == 2
+    assert roster["geopolitics"]["live_eligible_wallet_count"] == 3
+    assert roster["geopolitics"]["needs_refresh"] is False
+    assert roster["geopolitics"]["refresh_reasons"] == []
+
+
+def test_build_live_basket_roster_flags_refresh_when_core_is_not_fresh_enough() -> None:
+    config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        config,
+        basket_controller=replace(
+            config.basket_controller,
+            tracked_basket_target=4,
+            core_slots=2,
+            rotating_slots=1,
+            backup_slots=1,
+            explorer_slots=0,
+            force_refresh_if_fresh_core_below=2,
+            min_active_eligible_wallets=3,
+        ),
+    )
+    memberships = [
+        BasketMembership(
+            topic="geopolitics",
+            wallet=wallet,
+            tier="core",
+            rank=index,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        )
+        for index, wallet in enumerate(["w1", "w2", "w3", "w4"], start=1)
+    ]
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.5, 20.0, 1_200),
+        WalletTrade("w2", "geopolitics", "m2", "NO", 0.4, 15.0, 90_000),
+    ]
+
+    roster = build_live_basket_roster(config, memberships, trades)
+
+    assert roster["geopolitics"]["selected_wallets"]["core"] == ["w1", "w2"]
+    assert roster["geopolitics"]["fresh_core_wallet_count"] == 1
+    assert roster["geopolitics"]["live_eligible_wallet_count"] == 1
+    assert roster["geopolitics"]["needs_refresh"] is True
+    assert roster["geopolitics"]["refresh_reasons"] == [
+        "fresh_core_below_threshold",
+        "live_eligible_wallets_below_threshold",
+    ]


### PR DESCRIPTION
## Summary
- derive a live basket roster from recent wallet activity across core, rotating, backup, and explorer slots
- expose refresh pressure diagnostics in the wallet registry summary without changing trade execution behavior
- cover the new roster selection and summary output with focused tests

## Verification
- `$env:PYTHONPATH='src'; & 'C:\Users\CM265\AppData\Roaming\Python\Python314\Scripts\pytest.exe' tests\\test_copy_engine.py tests\\test_main.py tests\\test_wallet_registry.py tests\\test_config.py -q`
- `38 passed`
