### PR TITLE
[codex] fix railway lint import

### DIFF
--- a/src/predictcel/railway.py
+++ b/src/predictcel/railway.py
@@ -6,7 +6,7 @@ import sys
 import time
 import traceback
 from datetime import UTC, datetime
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 
 from .main import main as run_cli
 


### PR DESCRIPTION
## What changed
- removed the unused `Path` import from `src/predictcel/railway.py`

## Why
- the `main` CI workflow has been failing on the Ruff lint step, which skipped the downstream integration job and blocked deploy progression
- this import was the concrete unused-import candidate left by a focused static scan of the repo under Ruff's default rules

## Validation
- `py -3 -m pytest tests/test_config.py::test_example_config_loads tests/test_wallet_registry.py -p no:cacheprovider`
- focused AST import scan across `src/` and `tests/` with no remaining non-`__future__` unused imports reported