### PR TITLE
[codex] fix unused captured_at test lint

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1259,7 +1259,6 @@ def test_build_wallet_registry_summary_refreshes_registry_statuses_from_trade_fr
         ),
         filters=replace(config.filters, max_trade_age_seconds=3600),
     )
-    captured_at = datetime.now(UTC)
     store = RegistrySummaryStore(
         registry_entries=[
             WalletRegistryEntry(


### PR DESCRIPTION
## What changed
- removed the unused `captured_at` assignment from `tests/test_main.py`

## Why
- GitHub Actions CI on `main` was still failing Ruff with `F841 Local variable captured_at is assigned to but never used` in `tests/test_main.py:1262`

## Validation
- `py -3 -m pytest tests/test_main.py tests/test_config.py::test_example_config_loads tests/test_wallet_registry.py -p no:cacheprovider`
- direct inspection of the failing GitHub lint log for run `25121499210`