### PR TITLE
[codex] apply ruff format baseline

### DIFF
--- a/src/predictcel/alerting.py
+++ b/src/predictcel/alerting.py
@@ -42,7 +42,11 @@ class SlackFormatter:
         blocks = [
             {
                 "type": "header",
-                "text": {"type": "plain_text", "text": f"🔔 {payload.title}", "emoji": True},
+                "text": {
+                    "type": "plain_text",
+                    "text": f"🔔 {payload.title}",
+                    "emoji": True,
+                },
             },
             {
                 "type": "section",
@@ -51,7 +55,10 @@ class SlackFormatter:
             {
                 "type": "context",
                 "elements": [
-                    {"type": "mrkdwn", "text": f"*Severity:* {payload.severity.upper()} | *Time:* {payload.timestamp}"}
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Severity:* {payload.severity.upper()} | *Time:* {payload.timestamp}",
+                    }
                 ],
             },
         ]
@@ -62,7 +69,14 @@ class SlackFormatter:
             ]
             blocks.append({"type": "section", "fields": fields})
         if payload.cycle_id:
-            blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": f"*Cycle ID:* `{payload.cycle_id}`"}]})
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [
+                        {"type": "mrkdwn", "text": f"*Cycle ID:* `{payload.cycle_id}`"}
+                    ],
+                }
+            )
         return {"attachments": [{"color": color, "blocks": blocks}]}
 
 
@@ -73,9 +87,13 @@ class DiscordFormatter:
 
     @classmethod
     def format(cls, payload: AlertPayload) -> dict[str, Any]:
-        fields = [{"name": "Severity", "value": payload.severity.upper(), "inline": True}]
+        fields = [
+            {"name": "Severity", "value": payload.severity.upper(), "inline": True}
+        ]
         if payload.cycle_id:
-            fields.append({"name": "Cycle ID", "value": payload.cycle_id, "inline": True})
+            fields.append(
+                {"name": "Cycle ID", "value": payload.cycle_id, "inline": True}
+            )
         if payload.metadata:
             fields.extend(
                 {"name": str(key), "value": str(value), "inline": True}
@@ -99,8 +117,12 @@ class AlertManager:
     """Centralized alerting manager for PredictCel."""
 
     def __init__(self):
-        self.slack_url = os.environ.get("SLACK_WEBHOOK_URL") or os.environ.get("SLACK_WEBHOOK")
-        self.discord_url = os.environ.get("DISCORD_WEBHOOK_URL") or os.environ.get("DISCORD_WEBHOOK")
+        self.slack_url = os.environ.get("SLACK_WEBHOOK_URL") or os.environ.get(
+            "SLACK_WEBHOOK"
+        )
+        self.discord_url = os.environ.get("DISCORD_WEBHOOK_URL") or os.environ.get(
+            "DISCORD_WEBHOOK"
+        )
         self.generic_url = os.environ.get("ALERT_WEBHOOK_URL")
         self._setup_logging()
 
@@ -119,7 +141,12 @@ class AlertManager:
     def _send_webhook(self, url: str, payload: dict[str, Any]) -> bool:
         try:
             body = json.dumps(payload).encode("utf-8")
-            request = Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+            request = Request(
+                url,
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
             with urlopen(request, timeout=10) as resp:
                 return 200 <= resp.status < 300
         except Exception as e:
@@ -175,7 +202,9 @@ class AlertManager:
     def alert_info(self, title: str, message: str, **kwargs) -> bool:
         return self.send("info", title, message, **kwargs)
 
-    def alert_cycle_failure(self, cycle_id: str, stage: str, error: str, **kwargs) -> bool:
+    def alert_cycle_failure(
+        self, cycle_id: str, stage: str, error: str, **kwargs
+    ) -> bool:
         meta = kwargs.get("metadata", {})
         meta.update({"stage": stage, "error_type": "cycle_failure"})
         return self.alert_critical(
@@ -192,7 +221,9 @@ class AlertManager:
             metadata={"endpoint": endpoint, "retry_count": retry_count},
         )
 
-    def alert_no_signals(self, cycle_id: str, reason: str = "No signals generated") -> bool:
+    def alert_no_signals(
+        self, cycle_id: str, reason: str = "No signals generated"
+    ) -> bool:
         return self.alert_warning(
             title="No Signals Generated",
             message=f"Cycle `{cycle_id}` produced no trading signals.\n\n*Reason:* {reason}",
@@ -200,7 +231,9 @@ class AlertManager:
             metadata={"reason": reason},
         )
 
-    def alert_cycle_success(self, cycle_id: str, signals_count: int, metadata: dict[str, Any] | None = None) -> bool:
+    def alert_cycle_success(
+        self, cycle_id: str, signals_count: int, metadata: dict[str, Any] | None = None
+    ) -> bool:
         meta = metadata or {}
         meta["signals_count"] = signals_count
         return self.alert_info(
@@ -222,4 +255,10 @@ def get_alert_manager() -> AlertManager:
     return _alert_manager
 
 
-__all__ = ["AlertManager", "AlertPayload", "DiscordFormatter", "SlackFormatter", "get_alert_manager"]
+__all__ = [
+    "AlertManager",
+    "AlertPayload",
+    "DiscordFormatter",
+    "SlackFormatter",
+    "get_alert_manager",
+]

--- a/src/predictcel/arb_sidecar.py
+++ b/src/predictcel/arb_sidecar.py
@@ -14,7 +14,9 @@ class ArbitrageSidecar:
     def __init__(self, config: ArbitrageConfig) -> None:
         self.config = config
 
-    def _unique_markets(self, markets: dict[str, MarketSnapshot]) -> dict[str, MarketSnapshot]:
+    def _unique_markets(
+        self, markets: dict[str, MarketSnapshot]
+    ) -> dict[str, MarketSnapshot]:
         unique: dict[str, MarketSnapshot] = {}
         for market in markets.values():
             if market.market_id not in unique:
@@ -27,11 +29,18 @@ class ArbitrageSidecar:
             opportunity = self._evaluate_market(market)
             if opportunity is not None:
                 opportunities.append(opportunity)
-        return sorted(opportunities, key=lambda item: (item.quality_score, item.net_edge), reverse=True)
+        return sorted(
+            opportunities,
+            key=lambda item: (item.quality_score, item.net_edge),
+            reverse=True,
+        )
 
-    def scan_multi_market(self, markets: dict[str, MarketSnapshot]) -> list[ArbitrageOpportunity]:
+    def scan_multi_market(
+        self, markets: dict[str, MarketSnapshot]
+    ) -> list[ArbitrageOpportunity]:
         """Detect arbitrage opportunities across correlated markets using statistical analysis."""
         import pandas as pd
+
         opportunities = []
         market_list = list(self._unique_markets(markets).values())
 
@@ -59,14 +68,16 @@ class ArbitrageSidecar:
             corr_matrix = df.T.corr()
             high_corr_pairs = []
             for i in range(len(corr_matrix)):
-                for j in range(i+1, len(corr_matrix)):
+                for j in range(i + 1, len(corr_matrix)):
                     corr = corr_matrix.iloc[i, j]
                     if abs(corr) > 0.5:  # High correlation threshold
                         market1 = corr_matrix.index[i]
                         market2 = corr_matrix.index[j]
                         high_corr_pairs.append((market1, market2, corr))
 
-            logger.info(f"Found {len(high_corr_pairs)} highly correlated market pairs in topic {topic}")
+            logger.info(
+                f"Found {len(high_corr_pairs)} highly correlated market pairs in topic {topic}"
+            )
             for market1_id, market2_id, corr in high_corr_pairs:
                 market1 = markets[market1_id]
                 market2 = markets[market2_id]
@@ -78,29 +89,35 @@ class ArbitrageSidecar:
                 if abs(avg_price1 - avg_price2) > 0.1:  # Significant difference
                     combined_cost = avg_price1 + avg_price2
                     if combined_cost < 1.0:
-                        logger.info(f"Cross-asset arbitrage opportunity detected: {market1_id} + {market2_id} with correlation {corr:.2f}")
-                        opportunities.append(ArbitrageOpportunity(
-                            market_id=f"{market1_id}+{market2_id}",
-                            topic=topic,
-                            yes_ask=market1.yes_ask,
-                            no_ask=market1.no_ask,
-                            total_cost=combined_cost,
-                            gross_edge=1.0 - combined_cost,
-                            liquidity_usd=min(market1.liquidity_usd, market2.liquidity_usd),
-                            reason=f"cross-asset arbitrage with correlation {corr:.2f}",
-                            net_edge=1.0 - combined_cost,
-                            annualized_return=0.0,
-                            min_profitable_position=5.0,
-                            safe_position_size=10.0,
-                            quality_score=0.6,
-                            liquidity_score=0.5,
-                            speed_score=0.5,
-                            confidence_score=0.5,
-                            gas_cost_percentage=0.0,
-                            resolution_risk="MEDIUM",
-                            estimated_slippage=0.001,
-                            best_execution_path="multi-market",
-                        ))
+                        logger.info(
+                            f"Cross-asset arbitrage opportunity detected: {market1_id} + {market2_id} with correlation {corr:.2f}"
+                        )
+                        opportunities.append(
+                            ArbitrageOpportunity(
+                                market_id=f"{market1_id}+{market2_id}",
+                                topic=topic,
+                                yes_ask=market1.yes_ask,
+                                no_ask=market1.no_ask,
+                                total_cost=combined_cost,
+                                gross_edge=1.0 - combined_cost,
+                                liquidity_usd=min(
+                                    market1.liquidity_usd, market2.liquidity_usd
+                                ),
+                                reason=f"cross-asset arbitrage with correlation {corr:.2f}",
+                                net_edge=1.0 - combined_cost,
+                                annualized_return=0.0,
+                                min_profitable_position=5.0,
+                                safe_position_size=10.0,
+                                quality_score=0.6,
+                                liquidity_score=0.5,
+                                speed_score=0.5,
+                                confidence_score=0.5,
+                                gas_cost_percentage=0.0,
+                                resolution_risk="MEDIUM",
+                                estimated_slippage=0.001,
+                                best_execution_path="multi-market",
+                            )
+                        )
         return opportunities
 
     def _evaluate_market(self, market: MarketSnapshot) -> ArbitrageOpportunity | None:
@@ -122,20 +139,28 @@ class ArbitrageSidecar:
 
         min_profitable_position = max(
             self.config.min_profitable_position_usd,
-            fixed_cost / net_edge_rate if fixed_cost > 0 else self.config.min_profitable_position_usd,
+            fixed_cost / net_edge_rate
+            if fixed_cost > 0
+            else self.config.min_profitable_position_usd,
         )
         min_profitable_position = round(min_profitable_position, 4)
         if min_profitable_position > self.config.max_position_usd:
             return None
 
-        safe_position_size = min(self.config.max_position_usd, market.liquidity_usd * 0.05)
+        safe_position_size = min(
+            self.config.max_position_usd, market.liquidity_usd * 0.05
+        )
         safe_position_size = round(max(min_profitable_position, safe_position_size), 4)
-        fixed_cost_rate = fixed_cost / safe_position_size if safe_position_size > 0 else 1.0
+        fixed_cost_rate = (
+            fixed_cost / safe_position_size if safe_position_size > 0 else 1.0
+        )
         net_edge = round(net_edge_rate - fixed_cost_rate, 6)
         if net_edge <= 0:
             return None
 
-        annualized_return = self._annualized_return(net_edge, total_cost, market.minutes_to_resolution)
+        annualized_return = self._annualized_return(
+            net_edge, total_cost, market.minutes_to_resolution
+        )
         if annualized_return < self.config.target_annualized_return:
             return None
 
@@ -175,7 +200,9 @@ class ArbitrageSidecar:
             best_execution_path="direct",
         )
 
-    def _annualized_return(self, net_edge: float, total_cost: float, minutes_to_resolution: int) -> float:
+    def _annualized_return(
+        self, net_edge: float, total_cost: float, minutes_to_resolution: int
+    ) -> float:
         minutes = max(minutes_to_resolution, 1)
         capital_required = max(total_cost, 0.000001)
         annualized = (net_edge / capital_required) * (MINUTES_PER_YEAR / minutes)
@@ -200,7 +227,9 @@ class ArbitrageSidecar:
         orderbook_bonus = 0.15 if market.orderbook_ready else 0.0
         spread_penalty = min(max(market.yes_spread, market.no_spread) / 0.10, 0.35)
         edge_component = min(net_edge / max(self.config.min_gross_edge, 0.000001), 0.85)
-        return round(max(0.0, min(edge_component + orderbook_bonus - spread_penalty, 1.0)), 4)
+        return round(
+            max(0.0, min(edge_component + orderbook_bonus - spread_penalty, 1.0)), 4
+        )
 
     def _resolution_risk(self, minutes_to_resolution: int) -> str:
         if minutes_to_resolution <= 0:

--- a/src/predictcel/backtesting.py
+++ b/src/predictcel/backtesting.py
@@ -31,7 +31,9 @@ class Backtester:
     def __init__(self, config, db_path: str = ":memory:"):
         self.config = config
         self.store = SignalStore(db_path)
-        self.scorer = WalletQualityScorer(config.filters, config.consensus.recency_half_life_seconds)
+        self.scorer = WalletQualityScorer(
+            config.filters, config.consensus.recency_half_life_seconds
+        )
         self.copy_engine = CopyEngine(config)
 
     def run_backtest(
@@ -47,23 +49,27 @@ class Backtester:
         if start_date or end_date:
             if start_date:
                 trades = [
-                    trade for trade in trades
+                    trade
+                    for trade in trades
                     if trade.timestamp is not None and trade.timestamp >= start_date
                 ]
                 markets = {
                     market_id: market
                     for market_id, market in markets.items()
-                    if market.snapshot_time is not None and market.snapshot_time >= start_date
+                    if market.snapshot_time is not None
+                    and market.snapshot_time >= start_date
                 }
             if end_date:
                 trades = [
-                    trade for trade in trades
+                    trade
+                    for trade in trades
                     if trade.timestamp is not None and trade.timestamp <= end_date
                 ]
                 markets = {
                     market_id: market
                     for market_id, market in markets.items()
-                    if market.snapshot_time is not None and market.snapshot_time <= end_date
+                    if market.snapshot_time is not None
+                    and market.snapshot_time <= end_date
                 }
 
         wallet_qualities = self.scorer.score(trades, markets)
@@ -83,9 +89,16 @@ class Backtester:
             actual_price = self._payout_for_side(market, candidate.side)
             if actual_price is None:
                 import random
-                actual_price = 1.0 if random.random() < candidate.consensus_ratio else 0.0
 
-            pnl = candidate.suggested_position_usd * (actual_price - entry_price) / entry_price
+                actual_price = (
+                    1.0 if random.random() < candidate.consensus_ratio else 0.0
+                )
+
+            pnl = (
+                candidate.suggested_position_usd
+                * (actual_price - entry_price)
+                / entry_price
+            )
             pnls.append(pnl)
             total_pnl += pnl
 
@@ -132,13 +145,17 @@ class Backtester:
         if market.resolved_outcome is not None:
             return 1.0 if market.resolved_outcome == side else 0.0
         if market.resolution_price is not None:
-            return market.resolution_price if side == "YES" else 1.0 - market.resolution_price
+            return (
+                market.resolution_price
+                if side == "YES"
+                else 1.0 - market.resolution_price
+            )
         return None
 
     def _calculate_max_drawdown(self, pnls: list[float]) -> float:
         if not pnls:
             return 0.0
-        cumulative = [sum(pnls[:i+1]) for i in range(len(pnls))]
+        cumulative = [sum(pnls[: i + 1]) for i in range(len(pnls))]
         peak = cumulative[0]
         max_dd = 0.0
         for val in cumulative:
@@ -148,12 +165,14 @@ class Backtester:
             max_dd = max(max_dd, dd)
         return max_dd
 
-    def _calculate_sharpe_ratio(self, pnls: list[float], risk_free_rate: float = 0.02) -> float:
+    def _calculate_sharpe_ratio(
+        self, pnls: list[float], risk_free_rate: float = 0.02
+    ) -> float:
         if not pnls or len(pnls) < 2:
             return 0.0
         avg_return = sum(pnls) / len(pnls)
         variance = sum((pnl - avg_return) ** 2 for pnl in pnls) / (len(pnls) - 1)
-        std_dev = variance ** 0.5
+        std_dev = variance**0.5
         return (avg_return - risk_free_rate) / std_dev if std_dev > 0 else 0.0
 
 
@@ -165,13 +184,18 @@ def run_backtest_example() -> None:
         str(project_root / config.wallet_trades_path),
         str(project_root / config.market_snapshots_path),
     )
-    print(json.dumps({
-        "total_trades": result.total_trades,
-        "win_rate": result.win_rate,
-        "total_pnl": result.total_pnl,
-        "sharpe_ratio": result.sharpe_ratio,
-        "attribution": result.attribution,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "total_trades": result.total_trades,
+                "win_rate": result.win_rate,
+                "total_pnl": result.total_pnl,
+                "sharpe_ratio": result.sharpe_ratio,
+                "attribution": result.attribution,
+            },
+            indent=2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/src/predictcel/basket_assignment.py
+++ b/src/predictcel/basket_assignment.py
@@ -14,7 +14,10 @@ class BasketAssignmentEngine:
             for topic, affinity in candidate.topic_profile.topic_affinities.items()
             if topic in self.config.topics and affinity >= 0.15
         ]
-        if not recommended and candidate.topic_profile.primary_topic in self.config.topics:
+        if (
+            not recommended
+            and candidate.topic_profile.primary_topic in self.config.topics
+        ):
             recommended = [candidate.topic_profile.primary_topic]
 
         confidence = self._confidence(candidate.score)

--- a/src/predictcel/basket_controller.py
+++ b/src/predictcel/basket_controller.py
@@ -1,4 +1,5 @@
 """Basket Controller v2 consensus helpers."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -55,17 +56,25 @@ def evaluate_basket_consensus_gate(
         aligned_wallet_count / tracked_wallet_count if tracked_wallet_count else 0.0
     )
 
-    participating_weight = sum(wallet_weights.get(wallet, 0.0) for wallet in participating_wallets)
+    participating_weight = sum(
+        wallet_weights.get(wallet, 0.0) for wallet in participating_wallets
+    )
     aligned_weight = sum(wallet_weights.get(wallet, 0.0) for wallet in aligned_wallets)
     weighted_participation_ratio = (
         aligned_weight / participating_weight if participating_weight else 0.0
     )
 
-    aligned_prices = [trade.price for trade in aligned_trades if trade.wallet in tracked_wallet_set]
+    aligned_prices = [
+        trade.price for trade in aligned_trades if trade.wallet in tracked_wallet_set
+    ]
     price_band_abs = (
         max(aligned_prices) - min(aligned_prices) if len(aligned_prices) >= 2 else 0.0
     )
-    aligned_ages = [trade.age_seconds for trade in aligned_trades if trade.wallet in tracked_wallet_set]
+    aligned_ages = [
+        trade.age_seconds
+        for trade in aligned_trades
+        if trade.wallet in tracked_wallet_set
+    ]
     time_spread_seconds = (
         max(aligned_ages) - min(aligned_ages) if len(aligned_ages) >= 2 else 0
     )

--- a/src/predictcel/basket_manager.py
+++ b/src/predictcel/basket_manager.py
@@ -39,7 +39,9 @@ class BasketManagerPlanner:
         added_by_basket: dict[str, int] = {topic: 0 for topic in self.current_by_topic}
         planned_keys: set[tuple[str, str, str]] = set()
 
-        for assignment in sorted(assignments, key=lambda item: item.overall_score, reverse=True):
+        for assignment in sorted(
+            assignments, key=lambda item: item.overall_score, reverse=True
+        ):
             wallet_key = assignment.wallet_address.lower()
             current_baskets = self._current_baskets(wallet_key)
 
@@ -53,16 +55,40 @@ class BasketManagerPlanner:
                 actions.append(lifecycle_action)
                 planned_keys.add(action_key)
 
-            if assignment.overall_score < self.config.wallet_discovery.min_assignment_score:
+            if (
+                assignment.overall_score
+                < self.config.wallet_discovery.min_assignment_score
+            ):
                 if not current_baskets:
-                    actions.append(self._action("observe", assignment.primary_topic, assignment, "below assignment score threshold"))
+                    actions.append(
+                        self._action(
+                            "observe",
+                            assignment.primary_topic,
+                            assignment,
+                            "below assignment score threshold",
+                        )
+                    )
                 continue
             if assignment.confidence == "LOW":
                 if not current_baskets:
-                    actions.append(self._action("observe", assignment.primary_topic, assignment, "low confidence assignment"))
+                    actions.append(
+                        self._action(
+                            "observe",
+                            assignment.primary_topic,
+                            assignment,
+                            "low confidence assignment",
+                        )
+                    )
                 continue
             if not current_baskets and not self._clears_promotion_buffer(assignment):
-                actions.append(self._action("observe", assignment.primary_topic, assignment, "below promotion quality buffer"))
+                actions.append(
+                    self._action(
+                        "observe",
+                        assignment.primary_topic,
+                        assignment,
+                        "below promotion quality buffer",
+                    )
+                )
                 continue
 
             added = False
@@ -71,33 +97,66 @@ class BasketManagerPlanner:
                 action_key = ("add", basket, wallet_key)
                 if wallet_key in current or action_key in planned_keys:
                     continue
-                if len(current) + added_by_basket.get(basket, 0) >= self.config.wallet_discovery.max_wallets_per_basket:
-                    actions.append(self._action("observe", basket, assignment, "basket is at max wallet capacity"))
+                if (
+                    len(current) + added_by_basket.get(basket, 0)
+                    >= self.config.wallet_discovery.max_wallets_per_basket
+                ):
+                    actions.append(
+                        self._action(
+                            "observe",
+                            basket,
+                            assignment,
+                            "basket is at max wallet capacity",
+                        )
+                    )
                     continue
-                if added_by_basket.get(basket, 0) >= self.config.wallet_discovery.max_new_wallets_per_run:
-                    actions.append(self._action("observe", basket, assignment, "max new wallets per run reached"))
+                if (
+                    added_by_basket.get(basket, 0)
+                    >= self.config.wallet_discovery.max_new_wallets_per_run
+                ):
+                    actions.append(
+                        self._action(
+                            "observe",
+                            basket,
+                            assignment,
+                            "max new wallets per run reached",
+                        )
+                    )
                     continue
-                actions.append(self._action("add", basket, assignment, self._add_reason()))
+                actions.append(
+                    self._action("add", basket, assignment, self._add_reason())
+                )
                 planned_keys.add(action_key)
                 added_by_basket[basket] = added_by_basket.get(basket, 0) + 1
                 added = True
             if not added and not assignment.recommended_baskets and not current_baskets:
-                actions.append(self._action("observe", assignment.primary_topic, assignment, "no configured basket matched topic profile"))
+                actions.append(
+                    self._action(
+                        "observe",
+                        assignment.primary_topic,
+                        assignment,
+                        "no configured basket matched topic profile",
+                    )
+                )
 
         return actions
 
     def rebalance(self, current_positions: list[dict]) -> list[BasketManagerAction]:
         """Rebalance basket allocations to maintain target allocations, reducing concentration risk."""
         actions: list[BasketManagerAction] = []
-        total_allocation = sum(basket.target_allocation for basket in self.config.baskets if basket.target_allocation > 0)
+        total_allocation = sum(
+            basket.target_allocation
+            for basket in self.config.baskets
+            if basket.target_allocation > 0
+        )
         if total_allocation == 0:
             logger.info("No target allocations set for baskets, skipping rebalancing")
             return actions
 
         current_by_topic = {}
         for pos in current_positions:
-            topic = pos.get('topic', 'unknown')
-            exposure = pos.get('exposure_usd', 0.0)
+            topic = pos.get("topic", "unknown")
+            exposure = pos.get("exposure_usd", 0.0)
             current_by_topic[topic] = current_by_topic.get(topic, 0.0) + exposure
 
         total_exposure = sum(current_by_topic.values())
@@ -110,38 +169,69 @@ class BasketManagerPlanner:
         for basket in self.config.baskets:
             if basket.target_allocation == 0:
                 continue
-            target_exposure = total_exposure * (basket.target_allocation / total_allocation)
+            target_exposure = total_exposure * (
+                basket.target_allocation / total_allocation
+            )
             current_exposure = current_by_topic.get(basket.topic, 0.0)
-            drift = abs(current_exposure - target_exposure) / target_exposure if target_exposure > 0 else 0
+            drift = (
+                abs(current_exposure - target_exposure) / target_exposure
+                if target_exposure > 0
+                else 0
+            )
             if drift > drift_threshold:
                 rebalance_needed = True
                 reason = f"Allocation drift {drift:.2%} exceeds threshold {drift_threshold:.2%}"
                 logger.info(f"Rebalancing advisory for basket {basket.topic}: {reason}")
-                actions.append(BasketManagerAction(
-                    action="rebalance",
-                    basket=basket.topic,
-                    wallet_address="",
-                    score=0.0,
-                    confidence="HIGH",
-                    reason=reason
-                ))
+                actions.append(
+                    BasketManagerAction(
+                        action="rebalance",
+                        basket=basket.topic,
+                        wallet_address="",
+                        score=0.0,
+                        confidence="HIGH",
+                        reason=reason,
+                    )
+                )
         if not rebalance_needed:
             logger.info("Portfolio allocations within acceptable drift thresholds")
         return actions
 
     def _current_baskets(self, wallet_address: str) -> list[str]:
-        return [topic for topic, wallets in self.current_by_topic.items() if wallet_address in wallets]
+        return [
+            topic
+            for topic, wallets in self.current_by_topic.items()
+            if wallet_address in wallets
+        ]
 
-    def _existing_wallet_action(self, basket: str, assignment: BasketAssignment) -> BasketManagerAction | None:
+    def _existing_wallet_action(
+        self, basket: str, assignment: BasketAssignment
+    ) -> BasketManagerAction | None:
         threshold = self.config.wallet_discovery.min_assignment_score
         if basket not in assignment.recommended_baskets:
             if assignment.overall_score < threshold and assignment.confidence == "LOW":
-                return self._action("remove", basket, assignment, "wallet no longer matches basket topic and score fell below lifecycle threshold")
-            return self._action("suspend", basket, assignment, "wallet topic profile drifted away from basket")
+                return self._action(
+                    "remove",
+                    basket,
+                    assignment,
+                    "wallet no longer matches basket topic and score fell below lifecycle threshold",
+                )
+            return self._action(
+                "suspend",
+                basket,
+                assignment,
+                "wallet topic profile drifted away from basket",
+            )
         if assignment.overall_score < threshold:
-            return self._action("suspend", basket, assignment, "existing wallet score fell below assignment threshold")
+            return self._action(
+                "suspend",
+                basket,
+                assignment,
+                "existing wallet score fell below assignment threshold",
+            )
         if assignment.confidence == "LOW":
-            return self._action("suspend", basket, assignment, "existing wallet confidence fell to LOW")
+            return self._action(
+                "suspend", basket, assignment, "existing wallet confidence fell to LOW"
+            )
         return None
 
     def _add_reason(self) -> str:
@@ -158,7 +248,9 @@ class BasketManagerPlanner:
             return True
         return assignment.overall_score >= min(threshold + 0.05, 1.0)
 
-    def _action(self, action: str, basket: str, assignment: BasketAssignment, reason: str) -> BasketManagerAction:
+    def _action(
+        self, action: str, basket: str, assignment: BasketAssignment, reason: str
+    ) -> BasketManagerAction:
         return BasketManagerAction(
             action=action,
             basket=basket,

--- a/src/predictcel/config.py
+++ b/src/predictcel/config.py
@@ -4,6 +4,7 @@ Configuration loading and validation for PredictCel.
 This module handles loading configuration from JSON files and
 validating all parameters to ensure they meet requirements.
 """
+
 from __future__ import annotations
 
 import json
@@ -15,7 +16,15 @@ from typing import Any
 def _default_topic_keywords() -> dict[str, list[str]]:
     """Default topic keywords for wallet discovery."""
     return {
-        "geopolitics": ["election", "trump", "biden", "war", "federal", "senate", "president"],
+        "geopolitics": [
+            "election",
+            "trump",
+            "biden",
+            "war",
+            "federal",
+            "senate",
+            "president",
+        ],
         "sports": ["nba", "nfl", "mlb", "nhl", "ufc", "soccer", "football", "tennis"],
         "crypto": ["btc", "eth", "sol", "bitcoin", "ethereum", "crypto"],
         "macro": ["economy", "gdp", "inflation", "rates", "stock", "fed", "recession"],
@@ -209,7 +218,6 @@ class ConfigError(ValueError):
     """Raised when configuration validation fails."""
 
 
-
 def _validate_range(
     value: float,
     min_val: float,
@@ -219,7 +227,6 @@ def _validate_range(
     """Validate that a value is within a range."""
     if not min_val <= value <= max_val:
         raise ConfigError(f"{name} must be between {min_val} and {max_val}.")
-
 
 
 def _validate_positive(
@@ -236,7 +243,6 @@ def _validate_positive(
             raise ConfigError(f"{name} must be positive.")
 
 
-
 def _validate_baskets(baskets: list[BasketRule]) -> None:
     """Validate basket configuration."""
     if not baskets:
@@ -249,7 +255,6 @@ def _validate_baskets(baskets: list[BasketRule]) -> None:
             raise ConfigError(f"Basket {basket.topic} has no wallets.")
 
 
-
 def _validate_filters(filters: FilterConfig) -> None:
     """Validate filter configuration."""
     _validate_positive(filters.max_trade_age_seconds, "max_trade_age_seconds")
@@ -259,18 +264,18 @@ def _validate_filters(filters: FilterConfig) -> None:
         raise ConfigError("Resolution window is invalid.")
 
 
-
 def _validate_consensus(config: ConsensusConfig) -> None:
     """Validate consensus configuration."""
     _validate_positive(config.recency_half_life_seconds, "recency_half_life_seconds")
     _validate_range(config.min_weighted_consensus, 0, 1, "min_weighted_consensus")
-    _validate_positive(config.confidence_prior_strength, "confidence_prior_strength", True)
+    _validate_positive(
+        config.confidence_prior_strength, "confidence_prior_strength", True
+    )
     _validate_range(config.min_confidence_score, 0, 1, "min_confidence_score")
     _validate_range(config.conflict_penalty_weight, 0, 1, "conflict_penalty_weight")
     _validate_positive(config.bankroll_usd, "bankroll_usd")
     _validate_range(config.kelly_fraction, 0, 1, "kelly_fraction")
     _validate_positive(config.max_suggested_position_usd, "max_suggested_position_usd")
-
 
 
 def _validate_market_regime(config: MarketRegimeConfig) -> None:
@@ -286,19 +291,27 @@ def _validate_market_regime(config: MarketRegimeConfig) -> None:
         raise ConfigError("unstable_penalty must be non-negative.")
 
 
-
 def _validate_wallet_discovery(config: WalletDiscoveryConfig) -> None:
     """Validate wallet discovery configuration."""
     valid_modes = {"report_only", "propose_config", "auto_update"}
     if config.mode not in valid_modes:
         raise ConfigError(f"mode must be one of: {', '.join(valid_modes)}.")
-    valid_sources = {"data_api_leaderboard", "data_api_market_trades", "curated_wallet_file"}
+    valid_sources = {
+        "data_api_leaderboard",
+        "data_api_market_trades",
+        "curated_wallet_file",
+    }
     if config.source not in valid_sources:
         raise ConfigError(
             f"wallet discovery source must be one of: {', '.join(sorted(valid_sources))}."
         )
-    if config.source == "curated_wallet_file" and not str(config.wallet_candidates_path).strip():
-        raise ConfigError("wallet_candidates_path is required when wallet discovery source is curated_wallet_file.")
+    if (
+        config.source == "curated_wallet_file"
+        and not str(config.wallet_candidates_path).strip()
+    ):
+        raise ConfigError(
+            "wallet_candidates_path is required when wallet discovery source is curated_wallet_file."
+        )
 
     _validate_positive(config.candidate_limit, "candidate_limit")
     _validate_positive(config.trade_limit_per_wallet, "trade_limit_per_wallet")
@@ -310,7 +323,6 @@ def _validate_wallet_discovery(config: WalletDiscoveryConfig) -> None:
     _validate_range(config.min_assignment_score, 0, 1, "min_assignment_score")
     _validate_positive(config.max_wallets_per_basket, "max_wallets_per_basket")
     _validate_positive(config.max_new_wallets_per_run, "max_new_wallets_per_run")
-
 
 
 def _validate_wallet_registry(config: WalletRegistryConfig) -> None:
@@ -331,7 +343,6 @@ def _validate_wallet_registry(config: WalletRegistryConfig) -> None:
 
     if config.suspend_after_hours < config.stale_after_hours:
         raise ConfigError("suspend_after_hours cannot be less than stale_after_hours.")
-
 
 
 def _validate_basket_controller(config: BasketControllerConfig) -> None:
@@ -359,7 +370,9 @@ def _validate_basket_controller(config: BasketControllerConfig) -> None:
         1,
         "min_weighted_participation_ratio",
     )
-    _validate_positive(config.min_active_eligible_wallets, "min_active_eligible_wallets")
+    _validate_positive(
+        config.min_active_eligible_wallets, "min_active_eligible_wallets"
+    )
     _validate_positive(config.min_aligned_wallet_count, "min_aligned_wallet_count")
     _validate_range(config.max_entry_price_band_abs, 0, 1, "max_entry_price_band_abs")
     _validate_positive(
@@ -380,15 +393,21 @@ def _validate_basket_controller(config: BasketControllerConfig) -> None:
     if config.force_refresh_if_fresh_core_below > config.core_slots:
         raise ConfigError("force_refresh_if_fresh_core_below cannot exceed core_slots.")
     if config.min_aligned_wallet_count > config.min_active_eligible_wallets:
-        raise ConfigError("min_aligned_wallet_count cannot exceed min_active_eligible_wallets.")
+        raise ConfigError(
+            "min_aligned_wallet_count cannot exceed min_active_eligible_wallets."
+        )
     if config.min_active_eligible_wallets > config.tracked_basket_target:
-        raise ConfigError("min_active_eligible_wallets cannot exceed tracked_basket_target.")
+        raise ConfigError(
+            "min_active_eligible_wallets cannot exceed tracked_basket_target."
+        )
 
 
 def _validate_basket_promotion(config: BasketPromotionConfig) -> None:
     """Validate basket promotion configuration."""
     _validate_positive(config.min_tracked_wallets, "min_tracked_wallets")
-    _validate_positive(config.min_fresh_active_wallets_7d, "min_fresh_active_wallets_7d")
+    _validate_positive(
+        config.min_fresh_active_wallets_7d, "min_fresh_active_wallets_7d"
+    )
     _validate_positive(config.min_live_eligible_wallets, "min_live_eligible_wallets")
     _validate_positive(config.min_fresh_core_wallets_24h, "min_fresh_core_wallets_24h")
     _validate_positive(config.min_eligible_trades_7d, "min_eligible_trades_7d")
@@ -399,7 +418,9 @@ def _validate_basket_promotion(config: BasketPromotionConfig) -> None:
             "min_fresh_active_wallets_7d cannot exceed min_tracked_wallets."
         )
     if config.min_live_eligible_wallets > config.min_tracked_wallets:
-        raise ConfigError("min_live_eligible_wallets cannot exceed min_tracked_wallets.")
+        raise ConfigError(
+            "min_live_eligible_wallets cannot exceed min_tracked_wallets."
+        )
     if config.min_fresh_core_wallets_24h > config.min_live_eligible_wallets:
         raise ConfigError(
             "min_fresh_core_wallets_24h cannot exceed min_live_eligible_wallets."
@@ -415,8 +436,9 @@ def _validate_registry_controller_compatibility(
     if basket_controller.allow_backup_in_live_consensus:
         live_tier_capacity += basket_controller.backup_slots
     if wallet_registry.max_cluster_members_in_live_tiers > live_tier_capacity:
-        raise ConfigError("max_cluster_members_in_live_tiers cannot exceed live basket capacity.")
-
+        raise ConfigError(
+            "max_cluster_members_in_live_tiers cannot exceed live basket capacity."
+        )
 
 
 def _validate_arbitrage(config: ArbitrageConfig) -> None:
@@ -427,11 +449,14 @@ def _validate_arbitrage(config: ArbitrageConfig) -> None:
     _validate_positive(config.gas_cost_per_tx_usd, "gas_cost_per_tx_usd", True)
     _validate_positive(config.settlement_tx_count, "settlement_tx_count", True)
     _validate_range(config.slippage_rate, 0, 1, "slippage_rate")
-    _validate_positive(config.min_profitable_position_usd, "min_profitable_position_usd", True)
+    _validate_positive(
+        config.min_profitable_position_usd, "min_profitable_position_usd", True
+    )
     _validate_positive(config.max_position_usd, "max_position_usd")
-    _validate_positive(config.target_annualized_return, "target_annualized_return", True)
+    _validate_positive(
+        config.target_annualized_return, "target_annualized_return", True
+    )
     _validate_positive(config.max_annualized_return, "max_annualized_return")
-
 
 
 def _validate_live_data(config: LiveDataConfig | None) -> None:
@@ -442,7 +467,6 @@ def _validate_live_data(config: LiveDataConfig | None) -> None:
     _validate_positive(config.market_limit, "market_limit")
     _validate_positive(config.trade_limit, "trade_limit")
     _validate_positive(config.request_timeout_seconds, "request_timeout_seconds")
-
 
 
 def _validate_execution(config: ExecutionConfig | None) -> None:
@@ -484,7 +508,6 @@ def _validate_execution(config: ExecutionConfig | None) -> None:
         )
 
 
-
 def _build_execution_config(payload: dict[str, Any]) -> ExecutionConfig:
     """Build ExecutionConfig from payload dictionary."""
     position_payload = payload.get("position", {})
@@ -523,10 +546,11 @@ def _build_execution_config(payload: dict[str, Any]) -> ExecutionConfig:
         max_retries=int(payload.get("max_retries", 3)),
         retry_base_delay_seconds=float(payload.get("retry_base_delay_seconds", 1.0)),
         min_signal_allocation_usd=float(
-            payload.get("min_signal_allocation_usd", min(float(payload["buy_amount_usd"]), 5.0))
+            payload.get(
+                "min_signal_allocation_usd", min(float(payload["buy_amount_usd"]), 5.0)
+            )
         ),
     )
-
 
 
 def load_config(path: str | Path) -> AppConfig:
@@ -568,7 +592,9 @@ def load_config(path: str | Path) -> AppConfig:
     live_data = LiveDataConfig(**live_data_payload) if live_data_payload else None
 
     execution_payload = payload.get("execution")
-    execution = _build_execution_config(execution_payload) if execution_payload else None
+    execution = (
+        _build_execution_config(execution_payload) if execution_payload else None
+    )
 
     _validate_baskets(baskets)
     _validate_filters(filters)

--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -15,7 +15,13 @@ from typing import Any
 
 from .basket_controller import evaluate_basket_consensus_gate
 from .config import AppConfig, BasketRule
-from .models import CopyCandidate, MarketRegime, MarketSnapshot, WalletQuality, WalletTrade
+from .models import (
+    CopyCandidate,
+    MarketRegime,
+    MarketSnapshot,
+    WalletQuality,
+    WalletTrade,
+)
 from .scoring import compute_copyability_score
 from .wallet_registry import build_live_basket_roster
 
@@ -37,7 +43,9 @@ class CopyEngine:
     def __init__(self, config: AppConfig) -> None:
         self.config = config
         self.baskets_by_topic = {basket.topic: basket for basket in config.baskets}
-        self.basket_wallets_by_topic = {basket.topic: set(basket.wallets) for basket in config.baskets}
+        self.basket_wallets_by_topic = {
+            basket.topic: set(basket.wallets) for basket in config.baskets
+        }
         self.last_diagnostics: dict[str, int] = {}
         self._ml_model = None
         self._ml_model_loaded = False
@@ -46,7 +54,9 @@ class CopyEngine:
     def _load_ml_model(self) -> Any | None:
         if self._ml_model_loaded:
             return self._ml_model
-        model_path = os.path.join(os.path.dirname(__file__), "position_sizing_model.pkl")
+        model_path = os.path.join(
+            os.path.dirname(__file__), "position_sizing_model.pkl"
+        )
         if not os.path.exists(model_path):
             self._ml_model_loaded = True
             return None
@@ -95,7 +105,9 @@ class CopyEngine:
         mse = mean_squared_error(y_test, y_pred)
         logger.info(f"ML position sizing model trained with MSE: {mse:.4f}")
 
-        model_path = os.path.join(os.path.dirname(__file__), "position_sizing_model.pkl")
+        model_path = os.path.join(
+            os.path.dirname(__file__), "position_sizing_model.pkl"
+        )
         with open(model_path, "wb") as f:
             pickle.dump(model, f)
         self._ml_model = model
@@ -124,7 +136,9 @@ class CopyEngine:
             return []
 
         portfolio_summary = self._portfolio_summary(store)
-        live_tracked_wallets_by_topic = self._live_tracked_wallets_by_topic(trades, store)
+        live_tracked_wallets_by_topic = self._live_tracked_wallets_by_topic(
+            trades, store
+        )
         candidates: list[CopyCandidate] = []
         market_not_found = 0
         basket_not_found = 0
@@ -301,7 +315,9 @@ class CopyEngine:
         if not weighted_by_side:
             return None, "no_weighted_votes", Counter()
         side = max(weighted_by_side, key=weighted_by_side.get)
-        aligned = [trade for trade, _, trade_side in price_weights if trade_side == side]
+        aligned = [
+            trade for trade, _, trade_side in price_weights if trade_side == side
+        ]
         if not aligned:
             return None, "no_aligned_trades", Counter()
 
@@ -324,20 +340,26 @@ class CopyEngine:
         else:
             tracked_wallet_count = len(basket.wallets)
 
-        consensus_ratio = len(aligned_wallets) / tracked_wallet_count if tracked_wallet_count else 0.0
+        consensus_ratio = (
+            len(aligned_wallets) / tracked_wallet_count if tracked_wallet_count else 0.0
+        )
         total_weight = sum(weighted_by_side.values())
         aligned_weight = weighted_by_side[side]
         if controller_gate is not None:
             weighted_consensus = controller_gate.weighted_participation_ratio
         else:
-            weighted_consensus = round(aligned_weight / total_weight, 4) if total_weight else 0.0
+            weighted_consensus = (
+                round(aligned_weight / total_weight, 4) if total_weight else 0.0
+            )
         if consensus_ratio < basket.quorum_ratio:
             return None, "below_quorum", Counter()
         if weighted_consensus < self.config.consensus.min_weighted_consensus:
             return None, "below_weighted_consensus", Counter()
 
         quality_consensus = self._quality_consensus(aligned_wallets, wallet_qualities)
-        dominant_wallet_share = self._dominant_wallet_share(aligned_wallets, wallet_weights)
+        dominant_wallet_share = self._dominant_wallet_share(
+            aligned_wallets, wallet_weights
+        )
         confidence_score = self._confidence_score(
             aligned_weight,
             total_weight,
@@ -373,10 +395,14 @@ class CopyEngine:
             for wallet in aligned_wallets
             if wallet in wallet_qualities
         ]
-        wallet_quality_score = round(
-            sum(quality_values) / len(quality_values),
-            4,
-        ) if quality_values else 0.5
+        wallet_quality_score = (
+            round(
+                sum(quality_values) / len(quality_values),
+                4,
+            )
+            if quality_values
+            else 0.5
+        )
         conflict_penalty = self._conflict_penalty(aligned_weight, total_weight)
         recency_score = self._recency_score(aligned)
         regime = self._classify_market_regime(
@@ -562,10 +588,7 @@ class CopyEngine:
     ) -> float:
         if not aligned_wallets:
             return 0.0
-        aligned_values = [
-            wallet_weights.get(wallet, 0.0)
-            for wallet in aligned_wallets
-        ]
+        aligned_values = [wallet_weights.get(wallet, 0.0) for wallet in aligned_wallets]
         total = sum(aligned_values)
         if total <= 0:
             return 0.0
@@ -584,9 +607,7 @@ class CopyEngine:
         if not trades:
             return 0.0
         weights = [
-            0.5 ** (
-                trade.age_seconds / self.config.consensus.recency_half_life_seconds
-            )
+            0.5 ** (trade.age_seconds / self.config.consensus.recency_half_life_seconds)
             for trade in trades
         ]
         return round(sum(weights) / len(weights), 4)
@@ -622,9 +643,8 @@ class CopyEngine:
 
         skew = abs(current_price - 0.5)
         if skew >= config.trend_price_skew:
-            directional_match = (
-                (side == "YES" and current_price > 0.5)
-                or (side == "NO" and current_price < 0.5)
+            directional_match = (side == "YES" and current_price > 0.5) or (
+                side == "NO" and current_price < 0.5
             )
             score = 0.75 + config.trend_bonus if directional_match else 0.60
             score += 0.05 * (1 - volatility_score)
@@ -744,9 +764,7 @@ class CopyEngine:
             q = 1.0 - p
             kelly_fraction = max(0.0, ((b * p) - q) / b) if b > 0 else 0.0
             raw_size = (
-                self.config.consensus.bankroll_usd
-                * kelly_fraction
-                * adjusted_kelly
+                self.config.consensus.bankroll_usd * kelly_fraction * adjusted_kelly
             )
             logger.debug(
                 f"Kelly position sizing: fraction {kelly_fraction:.4f}, size {raw_size:.2f}",

--- a/src/predictcel/discovery.py
+++ b/src/predictcel/discovery.py
@@ -13,7 +13,6 @@ from typing import Any
 __all__ = ["WalletCandidate", "score_wallet_candidates", "candidates_as_dicts"]
 
 
-
 @dataclass(frozen=True)
 class WalletCandidate:
     wallet: str
@@ -45,14 +44,23 @@ def score_wallet_candidates(
 
         topics = [_classify_topic(trade) for trade in trades]
         topic_counts = Counter(topic for topic in topics if topic != "unknown")
-        dominant_topic, dominant_count = topic_counts.most_common(1)[0] if topic_counts else ("unknown", 0)
+        dominant_topic, dominant_count = (
+            topic_counts.most_common(1)[0] if topic_counts else ("unknown", 0)
+        )
         trade_count = len(trades)
-        unique_markets = len({str(trade.get("conditionId") or trade.get("slug") or trade.get("title")) for trade in trades})
+        unique_markets = len(
+            {
+                str(trade.get("conditionId") or trade.get("slug") or trade.get("title"))
+                for trade in trades
+            }
+        )
         focus_ratio = dominant_count / trade_count if trade_count else 0.0
         average_trade_size = _average_trade_size(trades)
         pnl = float(row.get("pnl") or 0.0)
         volume = float(row.get("vol") or row.get("volume") or 0.0)
-        score = _candidate_score(focus_ratio, trade_count, average_trade_size, pnl, volume)
+        score = _candidate_score(
+            focus_ratio, trade_count, average_trade_size, pnl, volume
+        )
 
         candidates.append(
             WalletCandidate(
@@ -89,7 +97,13 @@ def _candidate_score(
     size_component = min(average_trade_size / 500, 1.0) * 0.15
     pnl_component = min(max(pnl, 0.0) / 100_000, 1.0) * 0.15
     efficiency_component = min(max(pnl / volume if volume else 0.0, 0.0), 1.0) * 0.05
-    return focus_component + activity_component + size_component + pnl_component + efficiency_component
+    return (
+        focus_component
+        + activity_component
+        + size_component
+        + pnl_component
+        + efficiency_component
+    )
 
 
 def _classify_topic(trade: dict[str, Any]) -> str:
@@ -99,7 +113,16 @@ def _classify_topic(trade: dict[str, Any]) -> str:
     )
     sports_markers = ("nba", "nfl", "nhl", "mlb", "soccer", "ufc", "tennis", "vs.")
     crypto_markers = ("btc", "bitcoin", "eth", "ethereum", "solana", "xrp", "crypto")
-    politics_markers = ("election", "trump", "biden", "senate", "congress", "president", "fed", "rates")
+    politics_markers = (
+        "election",
+        "trump",
+        "biden",
+        "senate",
+        "congress",
+        "president",
+        "fed",
+        "rates",
+    )
     weather_markers = ("weather", "rain", "snow", "temperature", "hurricane")
 
     if any(marker in text for marker in sports_markers):
@@ -114,5 +137,8 @@ def _classify_topic(trade: dict[str, Any]) -> str:
 
 
 def _average_trade_size(trades: list[dict[str, Any]]) -> float:
-    sizes = [float(trade.get("size") or trade.get("sizeUsd") or trade.get("amount") or 0.0) for trade in trades]
+    sizes = [
+        float(trade.get("size") or trade.get("sizeUsd") or trade.get("amount") or 0.0)
+        for trade in trades
+    ]
     return sum(sizes) / len(sizes) if sizes else 0.0

--- a/src/predictcel/execution.py
+++ b/src/predictcel/execution.py
@@ -21,7 +21,9 @@ MAX_ENTRY_PRICE = 0.95
 
 
 class ExecutionPlanner:
-    def __init__(self, config: ExecutionConfig, position_config: PositionConfig) -> None:
+    def __init__(
+        self, config: ExecutionConfig, position_config: PositionConfig
+    ) -> None:
         self.config = config
         self.position_config = position_config
         self.last_diagnostics: dict[str, int] = {}
@@ -33,7 +35,9 @@ class ExecutionPlanner:
         held_market_ids: set[str],
         current_exposure_usd: float,
     ) -> list[ExecutionIntent]:
-        ranked = sorted(candidates, key=lambda item: item.copyability_score, reverse=True)
+        ranked = sorted(
+            candidates, key=lambda item: item.copyability_score, reverse=True
+        )
         intents: list[ExecutionIntent] = []
         planned_exposure_usd = current_exposure_usd
         diagnostics = {
@@ -69,12 +73,16 @@ class ExecutionPlanner:
                 diagnostics["zero_amount"] += 1
                 continue
 
-            token_id = market.yes_token_id if candidate.side == "YES" else market.no_token_id
+            token_id = (
+                market.yes_token_id if candidate.side == "YES" else market.no_token_id
+            )
             current_price = market.yes_ask if candidate.side == "YES" else market.no_ask
             if current_price >= MAX_ENTRY_PRICE:
                 diagnostics["price_too_high"] += 1
                 continue
-            side_depth_shares = market.yes_ask_size if candidate.side == "YES" else market.no_ask_size
+            side_depth_shares = (
+                market.yes_ask_size if candidate.side == "YES" else market.no_ask_size
+            )
             side_depth_usd = side_depth_shares * current_price
             if not token_id:
                 diagnostics["missing_token_id"] += 1
@@ -83,7 +91,9 @@ class ExecutionPlanner:
                 diagnostics["insufficient_side_depth"] += 1
                 continue
 
-            worst_price = min(round(current_price + self.config.worst_price_buffer, 4), 0.99)
+            worst_price = min(
+                round(current_price + self.config.worst_price_buffer, 4), 0.99
+            )
             intents.append(
                 ExecutionIntent(
                     market_id=candidate.market_id,
@@ -105,15 +115,25 @@ class ExecutionPlanner:
         self.last_diagnostics = diagnostics
         return intents
 
-    def _planned_amount_usd(self, candidate: CopyCandidate, planned_exposure_usd: float) -> float:
-        suggested_amount = candidate.suggested_position_usd if candidate.suggested_position_usd > 0 else self.config.buy_amount_usd
+    def _planned_amount_usd(
+        self, candidate: CopyCandidate, planned_exposure_usd: float
+    ) -> float:
+        suggested_amount = (
+            candidate.suggested_position_usd
+            if candidate.suggested_position_usd > 0
+            else self.config.buy_amount_usd
+        )
         amount_usd = max(suggested_amount, self.config.min_signal_allocation_usd)
         amount_usd = min(amount_usd, self.config.buy_amount_usd)
         if self.config.exposure is not None:
             if self.config.exposure.max_single_position_usd > 0:
-                amount_usd = min(amount_usd, self.config.exposure.max_single_position_usd)
+                amount_usd = min(
+                    amount_usd, self.config.exposure.max_single_position_usd
+                )
             if self.config.exposure.max_total_exposure_usd > 0:
-                remaining_capacity = self.config.exposure.max_total_exposure_usd - planned_exposure_usd
+                remaining_capacity = (
+                    self.config.exposure.max_total_exposure_usd - planned_exposure_usd
+                )
                 if remaining_capacity < self.config.min_signal_allocation_usd:
                     return 0.0
                 amount_usd = min(amount_usd, remaining_capacity)
@@ -121,7 +141,9 @@ class ExecutionPlanner:
 
 
 class LiveOrderExecutor:
-    def __init__(self, config: ExecutionConfig, live_data: LiveDataConfig | None) -> None:
+    def __init__(
+        self, config: ExecutionConfig, live_data: LiveDataConfig | None
+    ) -> None:
         self.config = config
         self.live_data = live_data
 
@@ -154,14 +176,25 @@ class LiveOrderExecutor:
         try:
             from py_clob_client.client import ClobClient
         except ImportError as exc:
-            raise RuntimeError("py-clob-client is required for live trading. Install with `pip install -e .[trade]`.") from exc
+            raise RuntimeError(
+                "py-clob-client is required for live trading. Install with `pip install -e .[trade]`."
+            ) from exc
 
         private_key = os.getenv("PREDICTCEL_POLY_PRIVATE_KEY", "").strip()
         funder = os.getenv("PREDICTCEL_POLY_FUNDER", "").strip()
         if not private_key or not funder:
-            raise RuntimeError("Live trading requires PREDICTCEL_POLY_PRIVATE_KEY and PREDICTCEL_POLY_FUNDER.")
+            raise RuntimeError(
+                "Live trading requires PREDICTCEL_POLY_PRIVATE_KEY and PREDICTCEL_POLY_FUNDER."
+            )
 
-        host = os.getenv("PREDICTCEL_POLY_HOST", (self.live_data.clob_base_url if self.live_data else "https://clob.polymarket.com"))
+        host = os.getenv(
+            "PREDICTCEL_POLY_HOST",
+            (
+                self.live_data.clob_base_url
+                if self.live_data
+                else "https://clob.polymarket.com"
+            ),
+        )
         client = ClobClient(
             host,
             key=private_key,
@@ -190,9 +223,21 @@ class LiveOrderExecutor:
                 signed = client.create_market_order(order_args)
                 order_type = getattr(OrderType, intent.order_type)
                 response = client.post_order(signed, order_type)
-                order_id = str(response.get("orderID") or response.get("orderId") or "") if isinstance(response, dict) else ""
-                status = str(response.get("status") or "submitted") if isinstance(response, dict) else "submitted"
-                error = str(response.get("errorMsg") or "") if isinstance(response, dict) else ""
+                order_id = (
+                    str(response.get("orderID") or response.get("orderId") or "")
+                    if isinstance(response, dict)
+                    else ""
+                )
+                status = (
+                    str(response.get("status") or "submitted")
+                    if isinstance(response, dict)
+                    else "submitted"
+                )
+                error = (
+                    str(response.get("errorMsg") or "")
+                    if isinstance(response, dict)
+                    else ""
+                )
 
                 if isinstance(response, dict) and str(response.get("status")) == "429":
                     raise RuntimeError("Rate limited (429)")
@@ -243,7 +288,9 @@ class LiveOrderExecutor:
 
 
 class ExitRunner:
-    def __init__(self, config: ExecutionConfig, live_data: LiveDataConfig | None) -> None:
+    def __init__(
+        self, config: ExecutionConfig, live_data: LiveDataConfig | None
+    ) -> None:
         self.config = config
         self.live_data = live_data
 
@@ -293,14 +340,20 @@ class ExitRunner:
                 reason = f"take_profit triggered: pnl={pnl_pct:.4f} >= tp={pos.take_profit_pct}"
             elif pos.stop_loss_pct > 0 and pnl_pct <= -pos.stop_loss_pct:
                 should_close = True
-                reason = f"stop_loss triggered: pnl={pnl_pct:.4f} <= sl={pos.stop_loss_pct}"
+                reason = (
+                    f"stop_loss triggered: pnl={pnl_pct:.4f} <= sl={pos.stop_loss_pct}"
+                )
             elif pos.max_hold_minutes > 0:
                 elapsed_minutes = (now - pos.opened_at).total_seconds() / 60.0
                 if elapsed_minutes >= pos.max_hold_minutes:
                     should_close = True
                     reason = f"max_hold exceeded: {elapsed_minutes:.1f} min >= {pos.max_hold_minutes} min"
 
-            if not should_close and market.minutes_to_resolution > 0 and market.minutes_to_resolution <= 10:
+            if (
+                not should_close
+                and market.minutes_to_resolution > 0
+                and market.minutes_to_resolution <= 10
+            ):
                 should_close = True
                 reason = f"market resolving soon: {market.minutes_to_resolution} min to resolution"
 
@@ -325,7 +378,7 @@ class ExitRunner:
 
 
 def retry_delay(base_delay: float, attempt: int) -> float:
-    return base_delay * (2 ** attempt) * random.uniform(0.5, 1.5)
+    return base_delay * (2**attempt) * random.uniform(0.5, 1.5)
 
 
 def intents_as_dicts(intents: list[ExecutionIntent]) -> list[dict[str, Any]]:

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -109,8 +109,14 @@ def build_parser() -> argparse.ArgumentParser:
 def build_discovery_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="PredictCel wallet discovery reports")
     parser.add_argument("--config", required=True, help="Path to config JSON file")
-    parser.add_argument("--output-dir", default="data", help="Directory for discovery JSON reports")
-    parser.add_argument("--db", default=None, help="Optional SQLite database path for persisting wallet registry discovery inputs")
+    parser.add_argument(
+        "--output-dir", default="data", help="Directory for discovery JSON reports"
+    )
+    parser.add_argument(
+        "--db",
+        default=None,
+        help="Optional SQLite database path for persisting wallet registry discovery inputs",
+    )
     parser.add_argument(
         "--config-output",
         default=None,
@@ -128,7 +134,9 @@ def main() -> None:
     timings: dict[str, int] = {}
     args = build_parser().parse_args()
     config = load_config(args.config)
-    use_live_data = bool(args.live_data or (config.live_data and config.live_data.enabled))
+    use_live_data = bool(
+        args.live_data or (config.live_data and config.live_data.enabled)
+    )
 
     logger.info(
         "Starting PredictCel cycle",
@@ -169,7 +177,9 @@ def main() -> None:
     metrics.set("markets_loaded", len(markets))
     metrics.set("trades_loaded", len(trades))
 
-    wallet_discovery_auto_feed = _auto_feed_wallet_registry_from_discovery(config, store)
+    wallet_discovery_auto_feed = _auto_feed_wallet_registry_from_discovery(
+        config, store
+    )
     wallet_registry_summary = _build_wallet_registry_summary(config, store, trades)
     wallet_registry_summary["auto_feed"] = wallet_discovery_auto_feed
     open_positions_at_start = store.get_open_positions()
@@ -235,7 +245,9 @@ def main() -> None:
                 config.live_data,
             ).evaluate_and_close(open_positions, markets)
             close_results = (
-                LiveOrderExecutor(config.execution, config.live_data).execute(close_intents)
+                LiveOrderExecutor(config.execution, config.live_data).execute(
+                    close_intents
+                )
                 if close_intents
                 else []
             )
@@ -286,7 +298,9 @@ def main() -> None:
         arbitrage_opportunities,
         execution_results + close_results,
     )
-    open_positions = _decorate_positions_with_titles(store.get_open_positions(), markets)
+    open_positions = _decorate_positions_with_titles(
+        store.get_open_positions(), markets
+    )
     db_diagnostics["open_position_count_at_end"] = len(open_positions)
     timings["storage_ms"] = _elapsed_ms(started)
     timings["total_cycle_ms"] = _elapsed_ms(cycle_started)
@@ -321,8 +335,7 @@ def main() -> None:
         },
         "portfolio_summary": _portfolio_summary(store, config),
         "wallet_qualities": {
-            wallet: quality.__dict__
-            for wallet, quality in wallet_qualities.items()
+            wallet: quality.__dict__ for wallet, quality in wallet_qualities.items()
         },
         "copy_candidates": [candidate.__dict__ for candidate in copy_candidates],
         "arbitrage_opportunities": [
@@ -361,7 +374,10 @@ def main() -> None:
             "wallet_registry": wallet_registry_summary,
         },
     )
-    print(json.dumps(_compact_cycle_output(output), sort_keys=True, default=str), flush=True)
+    print(
+        json.dumps(_compact_cycle_output(output), sort_keys=True, default=str),
+        flush=True,
+    )
 
 
 def _run_wallet_discovery(argv: list[str]) -> None:
@@ -383,7 +399,9 @@ def _run_wallet_discovery(argv: list[str]) -> None:
     registry_ingestion = {
         "enabled": bool(args.db),
         "persisted": False,
-        "mode": getattr(getattr(config, "wallet_discovery", None), "mode", "auto_update"),
+        "mode": getattr(
+            getattr(config, "wallet_discovery", None), "mode", "auto_update"
+        ),
         "discovered_wallets_ingested": 0,
         "new_registry_entries": 0,
         "new_explorer_memberships": 0,
@@ -427,15 +445,15 @@ def _run_wallet_discovery(argv: list[str]) -> None:
             "persisted": True,
             "mode": getattr(config.wallet_discovery, "mode", "auto_update"),
             "discovered_wallets_ingested": len(accepted_wallets),
-            "new_registry_entries": len(after_registry_wallets - before_registry_wallets),
+            "new_registry_entries": len(
+                after_registry_wallets - before_registry_wallets
+            ),
             "new_explorer_memberships": len(
                 after_explorer_memberships - before_explorer_memberships
             ),
             "manager_actions_applied": int(action_diagnostics["actions_applied"]),
             "manager_action_counts": action_diagnostics["action_counts"],
-            "skipped_existing_wallets": len(
-                accepted_wallets & before_registry_wallets
-            ),
+            "skipped_existing_wallets": len(accepted_wallets & before_registry_wallets),
         }
     print(
         json.dumps(
@@ -514,7 +532,9 @@ def _auto_feed_wallet_registry_from_discovery(
             {
                 "ran": True,
                 "discovered_wallets_ingested": len(accepted_wallets),
-                "new_registry_entries": len(after_registry_wallets - before_registry_wallets),
+                "new_registry_entries": len(
+                    after_registry_wallets - before_registry_wallets
+                ),
                 "new_explorer_memberships": len(
                     after_explorer_memberships - before_explorer_memberships
                 ),
@@ -646,12 +666,15 @@ def _build_wallet_registry_summary(
             captured_at=captured_at,
         )
 
-    registry_entries = refresh_registry_entries_from_trades(
-        config,
-        store,
-        trades,
-        captured_at=captured_at,
-    ) or existing_registry_entries
+    registry_entries = (
+        refresh_registry_entries_from_trades(
+            config,
+            store,
+            trades,
+            captured_at=captured_at,
+        )
+        or existing_registry_entries
+    )
     memberships = store.load_basket_memberships() or existing_memberships
     basket_health = compute_basket_health_from_static_memberships(
         config,
@@ -749,7 +772,8 @@ def _ensure_static_membership_bootstrap(
         return existing_memberships
 
     memberships_by_key = {
-        (membership.topic, membership.wallet): membership for membership in existing_memberships
+        (membership.topic, membership.wallet): membership
+        for membership in existing_memberships
     }
     updated_memberships = list(existing_memberships)
     for basket in config.baskets:
@@ -813,9 +837,7 @@ def _promotion_watch_by_topic(
 ) -> dict[str, dict[str, Any]]:
     explorer_counts_by_topic: dict[str, int] = defaultdict(int)
     discovery_explorer_counts_by_topic: dict[str, int] = defaultdict(int)
-    registry_entries_by_wallet = {
-        entry.wallet: entry for entry in registry_entries
-    }
+    registry_entries_by_wallet = {entry.wallet: entry for entry in registry_entries}
     for membership in memberships:
         if not membership.active or membership.tier != "explorer":
             continue
@@ -837,8 +859,12 @@ def _promotion_watch_by_topic(
         watch[topic] = {
             "explorer_wallet_count": explorer_count,
             "wallet_discovery_explorer_wallet_count": discovery_explorer_count,
-            "live_eligible_wallet_count": int(roster_entry.get("live_eligible_wallet_count", 0)),
-            "fresh_core_wallet_count": int(roster_entry.get("fresh_core_wallet_count", 0)),
+            "live_eligible_wallet_count": int(
+                roster_entry.get("live_eligible_wallet_count", 0)
+            ),
+            "fresh_core_wallet_count": int(
+                roster_entry.get("fresh_core_wallet_count", 0)
+            ),
             "reason": "bench_depth_available",
         }
     return watch
@@ -964,7 +990,9 @@ def _load_live_inputs(config, store: SignalStore | None = None):
     ]
     wallets_with_payloads = sum(1 for items in wallet_payloads.values() if items)
     wallets_with_parsed_trades = len({trade.wallet for trade in trades})
-    unique_market_snapshots = {snapshot.market_id: snapshot for snapshot in markets.values()}
+    unique_market_snapshots = {
+        snapshot.market_id: snapshot for snapshot in markets.values()
+    }
     relevant_canonical_market_ids = {
         markets[market_key].market_id for market_key in relevant_market_keys
     }
@@ -1031,7 +1059,9 @@ def _load_live_inputs(config, store: SignalStore | None = None):
     return trades, markets, diagnostics
 
 
-def _propagate_canonical_market_updates(markets: dict[str, Any], updated_snapshots: Any) -> None:
+def _propagate_canonical_market_updates(
+    markets: dict[str, Any], updated_snapshots: Any
+) -> None:
     canonical_updates = {
         snapshot.market_id: snapshot
         for snapshot in updated_snapshots
@@ -1084,7 +1114,9 @@ def _make_probe_client(client: PolymarketPublicClient) -> PolymarketPublicClient
     )
 
 
-def _probe_token_orderbook(client: PolymarketPublicClient, token_id: str) -> dict[str, Any]:
+def _probe_token_orderbook(
+    client: PolymarketPublicClient, token_id: str
+) -> dict[str, Any]:
     token_id = str(token_id).strip()
     if not token_id:
         return {"missing_token_id": True}
@@ -1095,7 +1127,9 @@ def _probe_token_orderbook(client: PolymarketPublicClient, token_id: str) -> dic
         return {"token_id": token_id, "error": f"{type(exc).__name__}: {exc}"}
 
 
-def _probe_token_lookup(client: PolymarketPublicClient, token_id: str) -> dict[str, Any]:
+def _probe_token_lookup(
+    client: PolymarketPublicClient, token_id: str
+) -> dict[str, Any]:
     token_id = str(token_id).strip()
     if not token_id:
         return {"missing_token_id": True}
@@ -1134,7 +1168,9 @@ def _first_book_level_value(levels: Any, key: str) -> float:
     return float(best.get(key) or 0.0)
 
 
-def _summarize_market_lookup_rows(rows: list[dict[str, Any]], token_id: str) -> dict[str, Any]:
+def _summarize_market_lookup_rows(
+    rows: list[dict[str, Any]], token_id: str
+) -> dict[str, Any]:
     if not rows:
         return {"matched_rows": 0}
     row = rows[0]
@@ -1199,13 +1235,20 @@ def _fetch_wallet_payloads(
     return payloads
 
 
-def _filter_duplicate_candidates(store: SignalStore, candidates: list) -> tuple[list, int]:
+def _filter_duplicate_candidates(
+    store: SignalStore, candidates: list
+) -> tuple[list, int]:
     fingerprints = [
-        store.make_signal_fingerprint(candidate.market_id, candidate.topic, candidate.side)
+        store.make_signal_fingerprint(
+            candidate.market_id, candidate.topic, candidate.side
+        )
         for candidate in candidates
     ]
     recent_fingerprints = store.has_recent_signals(
-        [(candidate.market_id, candidate.topic, candidate.side) for candidate in candidates]
+        [
+            (candidate.market_id, candidate.topic, candidate.side)
+            for candidate in candidates
+        ]
     )
     fresh = []
     seen_in_batch: set[str] = set()
@@ -1224,15 +1267,17 @@ def _is_trusted_execution_result(result) -> bool:
 
 
 def _creates_or_updates_paper_position(result) -> bool:
-    return str(result.status).strip().lower() == "dry_run" or _is_trusted_execution_result(
-        result
-    )
+    return str(
+        result.status
+    ).strip().lower() == "dry_run" or _is_trusted_execution_result(result)
 
 
 def _is_evm_address(value: str) -> bool:
     value = str(value).strip()
-    return len(value) == 42 and value.startswith("0x") and all(
-        char in HEX_CHARS for char in value[2:]
+    return (
+        len(value) == 42
+        and value.startswith("0x")
+        and all(char in HEX_CHARS for char in value[2:])
     )
 
 

--- a/src/predictcel/markets.py
+++ b/src/predictcel/markets.py
@@ -15,7 +15,6 @@ from .models import MarketSnapshot
 __all__ = ["load_market_snapshots"]
 
 
-
 def load_market_snapshots(path: str) -> dict[str, MarketSnapshot]:
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     snapshots = {}
@@ -38,7 +37,11 @@ def load_market_snapshots(path: str) -> dict[str, MarketSnapshot]:
             yes_spread=float(item.get("yes_spread", 0.0)),
             no_spread=float(item.get("no_spread", 0.0)),
             orderbook_ready=bool(item.get("orderbook_ready", False)),
-            snapshot_time=_parse_datetime(item.get("snapshot_time") or item.get("timestamp") or item.get("created_at")),
+            snapshot_time=_parse_datetime(
+                item.get("snapshot_time")
+                or item.get("timestamp")
+                or item.get("created_at")
+            ),
             resolved_outcome=_parse_outcome(item),
             resolution_price=_parse_resolution_price(item),
         )

--- a/src/predictcel/models.py
+++ b/src/predictcel/models.py
@@ -4,6 +4,7 @@ PredictCel data models.
 This module defines all data structures used throughout the PredictCel system,
 including wallet trades, market snapshots, quality scores, and execution results.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -120,6 +120,7 @@ class PolymarketPublicClient:
         if use_redis:
             try:
                 import redis
+
                 self.redis_client = redis.Redis(
                     host=redis_host,
                     port=redis_port,
@@ -130,10 +131,14 @@ class PolymarketPublicClient:
                 self.redis_client.ping()
                 logger.info("Redis caching enabled")
             except (ModuleNotFoundError, ImportError):
-                logger.warning("Redis package not installed, falling back to in-memory cache")
+                logger.warning(
+                    "Redis package not installed, falling back to in-memory cache"
+                )
                 self.use_redis = False
             except Exception as e:
-                logger.warning(f"Redis connection failed ({e}), falling back to in-memory cache")
+                logger.warning(
+                    f"Redis connection failed ({e}), falling back to in-memory cache"
+                )
                 self.use_redis = False
                 self.redis_client = None
 
@@ -143,25 +148,39 @@ class PolymarketPublicClient:
         payload = self._get_json(f"{self.gamma_base_url}/markets?{query}")
         return _extract_list(payload)
 
-    def fetch_markets_by_condition_ids(self, condition_ids: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
+    def fetch_markets_by_condition_ids(
+        self, condition_ids: list[str], chunk_size: int = 25
+    ) -> list[dict[str, Any]]:
         """Fetch markets by condition IDs."""
-        return self._fetch_markets_by_array_filter("condition_ids", condition_ids, chunk_size)
+        return self._fetch_markets_by_array_filter(
+            "condition_ids", condition_ids, chunk_size
+        )
 
-    def fetch_markets_by_clob_token_ids(self, token_ids: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
+    def fetch_markets_by_clob_token_ids(
+        self, token_ids: list[str], chunk_size: int = 25
+    ) -> list[dict[str, Any]]:
         """Fetch markets by CLOB token IDs."""
-        return self._fetch_markets_by_array_filter("clob_token_ids", token_ids, chunk_size)
+        return self._fetch_markets_by_array_filter(
+            "clob_token_ids", token_ids, chunk_size
+        )
 
     def fetch_market_by_slug(self, slug: str) -> dict[str, Any]:
         """Fetch market by slug."""
         normalized_slug = str(slug).strip()
         if not normalized_slug:
             return {}
-        payload = self._get_json(f"{self.gamma_base_url}/markets/slug/{quote(normalized_slug, safe='')}")
+        payload = self._get_json(
+            f"{self.gamma_base_url}/markets/slug/{quote(normalized_slug, safe='')}"
+        )
         return payload if isinstance(payload, dict) else {}
 
-    def fetch_markets_by_slugs(self, slugs: list[str], max_workers: int = 8) -> list[dict[str, Any]]:
+    def fetch_markets_by_slugs(
+        self, slugs: list[str], max_workers: int = 8
+    ) -> list[dict[str, Any]]:
         """Fetch markets by slugs with parallel execution."""
-        unique_slugs = sorted({str(slug).strip() for slug in slugs if str(slug).strip()})
+        unique_slugs = sorted(
+            {str(slug).strip() for slug in slugs if str(slug).strip()}
+        )
         if not unique_slugs:
             return []
 
@@ -170,12 +189,17 @@ class PolymarketPublicClient:
         workers = max(1, min(max_workers, len(unique_slugs)))
 
         with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = {executor.submit(self.fetch_market_by_slug, slug): slug for slug in unique_slugs}
+            futures = {
+                executor.submit(self.fetch_market_by_slug, slug): slug
+                for slug in unique_slugs
+            }
             for future in as_completed(futures):
                 try:
                     payload = future.result()
                 except Exception as e:
-                    logger.debug(f"Failed to fetch market for slug {futures[future]}: {e}")
+                    logger.debug(
+                        f"Failed to fetch market for slug {futures[future]}: {e}"
+                    )
                     continue
 
                 rows = _extract_list(payload)
@@ -183,7 +207,13 @@ class PolymarketPublicClient:
                     rows = [payload]
 
                 for row in rows:
-                    key = str(row.get("conditionId") or row.get("condition_id") or row.get("id") or row.get("slug") or row).strip()
+                    key = str(
+                        row.get("conditionId")
+                        or row.get("condition_id")
+                        or row.get("id")
+                        or row.get("slug")
+                        or row
+                    ).strip()
                     if key in seen_market_keys:
                         continue
                     seen_market_keys.add(key)
@@ -191,7 +221,9 @@ class PolymarketPublicClient:
 
         return results
 
-    def fetch_markets_by_identifiers(self, identifiers: list[str], chunk_size: int = 25) -> list[dict[str, Any]]:
+    def fetch_markets_by_identifiers(
+        self, identifiers: list[str], chunk_size: int = 25
+    ) -> list[dict[str, Any]]:
         """Fetch markets by various identifiers."""
         results: list[dict[str, Any]] = []
         seen_market_keys: set[str] = set()
@@ -201,7 +233,12 @@ class PolymarketPublicClient:
             self.fetch_markets_by_clob_token_ids(identifiers, chunk_size),
         ):
             for row in rows:
-                key = str(row.get("conditionId") or row.get("condition_id") or row.get("id") or row).strip()
+                key = str(
+                    row.get("conditionId")
+                    or row.get("condition_id")
+                    or row.get("id")
+                    or row
+                ).strip()
                 if key in seen_market_keys:
                     continue
                 seen_market_keys.add(key)
@@ -248,8 +285,12 @@ class PolymarketPublicClient:
                 continue
 
             normalized = [_flatten_trade_payload(item) for item in rows]
-            matching_rows = [item for item in normalized if _trade_matches_wallet(item, wallet_key)]
-            rows_with_owner = [item for item in normalized if _trade_wallet_address(item)]
+            matching_rows = [
+                item for item in normalized if _trade_matches_wallet(item, wallet_key)
+            ]
+            rows_with_owner = [
+                item for item in normalized if _trade_wallet_address(item)
+            ]
             candidate_rows = matching_rows if rows_with_owner else normalized
 
             if _score_trade_rows(candidate_rows) > _score_trade_rows(best_scored_rows):
@@ -258,7 +299,9 @@ class PolymarketPublicClient:
             elif len(candidate_rows) > len(best_rows):
                 best_rows = candidate_rows
 
-            if matching_rows and _count_trade_items_with_ids(matching_rows) >= min(limit, len(matching_rows)):
+            if matching_rows and _count_trade_items_with_ids(matching_rows) >= min(
+                limit, len(matching_rows)
+            ):
                 break
 
         if not best_rows and errors:
@@ -269,9 +312,17 @@ class PolymarketPublicClient:
 
         return best_rows[:limit]
 
-    def fetch_market_trades(self, market_ids: list[str], limit: int, chunk_size: int = 25) -> list[dict[str, Any]]:
+    def fetch_market_trades(
+        self, market_ids: list[str], limit: int, chunk_size: int = 25
+    ) -> list[dict[str, Any]]:
         """Fetch recent public trades for one or more markets from the data API."""
-        unique_market_ids = sorted({str(market_id).strip() for market_id in market_ids if str(market_id).strip()})
+        unique_market_ids = sorted(
+            {
+                str(market_id).strip()
+                for market_id in market_ids
+                if str(market_id).strip()
+            }
+        )
         if not unique_market_ids or limit <= 0:
             return []
 
@@ -302,10 +353,14 @@ class PolymarketPublicClient:
         payload = self._get_json(f"{self.clob_base_url}/book?{query}")
         return payload if isinstance(payload, dict) else {}
 
-    async def subscribe_market_updates(self, market_ids: list[str], callback: callable) -> None:
+    async def subscribe_market_updates(
+        self, market_ids: list[str], callback: callable
+    ) -> None:
         """Subscribe to real-time market updates via WebSocket."""
         ws_url = "wss://ws.polymarket.com"
-        logger.info(f"Connecting to WebSocket at {ws_url} for {len(market_ids)} markets")
+        logger.info(
+            f"Connecting to WebSocket at {ws_url} for {len(market_ids)} markets"
+        )
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -337,10 +392,14 @@ class PolymarketPublicClient:
             logger.error(f"WebSocket unexpected error: {e}")
             raise
 
-    def _fetch_markets_by_array_filter(self, filter_name: str, values: list[str], chunk_size: int) -> list[dict[str, Any]]:
+    def _fetch_markets_by_array_filter(
+        self, filter_name: str, values: list[str], chunk_size: int
+    ) -> list[dict[str, Any]]:
         """Fetch markets using array filter with chunking."""
         results: list[dict[str, Any]] = []
-        unique_values = sorted({value.strip() for value in values if value and value.strip()})
+        unique_values = sorted(
+            {value.strip() for value in values if value and value.strip()}
+        )
 
         for chunk in _chunks(unique_values, max(chunk_size, 1)):
             query = urlencode({filter_name: chunk, "limit": len(chunk)}, doseq=True)
@@ -368,6 +427,7 @@ class PolymarketPublicClient:
 
     def _get_json(self, url: str) -> Any:
         """Make HTTP GET request with caching and retries."""
+
         def _fetch_url():
             metrics = _get_metrics()
             metrics["requests"] += 1
@@ -413,8 +473,15 @@ class PolymarketPublicClient:
                     try:
                         payload = json.loads(cached)
                         if isinstance(payload, dict) and payload.get("_cached_at"):
-                            if time.time() - payload["_cached_at"] < self.DEFAULT_CACHE_TTL_SECONDS:
-                                return {k: v for k, v in payload.items() if k != "_cached_at"}
+                            if (
+                                time.time() - payload["_cached_at"]
+                                < self.DEFAULT_CACHE_TTL_SECONDS
+                            ):
+                                return {
+                                    k: v
+                                    for k, v in payload.items()
+                                    if k != "_cached_at"
+                                }
                         elif not isinstance(payload, dict):
                             return payload
                     except json.JSONDecodeError:
@@ -426,7 +493,10 @@ class PolymarketPublicClient:
             if url in self._request_cache:
                 cached = self._request_cache[url]
                 if isinstance(cached, dict) and cached.get("_cached_at"):
-                    if time.time() - cached["_cached_at"] < self.DEFAULT_CACHE_TTL_SECONDS:
+                    if (
+                        time.time() - cached["_cached_at"]
+                        < self.DEFAULT_CACHE_TTL_SECONDS
+                    ):
                         return {k: v for k, v in cached.items() if k != "_cached_at"}
                 elif not isinstance(cached, dict):
                     return cached
@@ -440,7 +510,9 @@ class PolymarketPublicClient:
                 cache_data = payload.copy() if isinstance(payload, dict) else payload
                 if isinstance(cache_data, dict):
                     cache_data["_cached_at"] = time.time()
-                self.redis_client.setex(url, self.DEFAULT_CACHE_TTL_SECONDS, json.dumps(cache_data))
+                self.redis_client.setex(
+                    url, self.DEFAULT_CACHE_TTL_SECONDS, json.dumps(cache_data)
+                )
                 return
             except Exception as e:
                 logger.debug(f"Redis set failed: {e}")
@@ -469,6 +541,7 @@ class PolymarketPublicClient:
 
             if prices:
                 import statistics
+
                 mean_price = statistics.mean(prices)
                 stdev_price = statistics.stdev(prices) if len(prices) > 1 else 0
 
@@ -480,17 +553,25 @@ class PolymarketPublicClient:
                             anomalies += 1
 
                 if anomalies > 0:
-                    logger.warning(f"Detected {anomalies} anomalous prices in response from {url}")
+                    logger.warning(
+                        f"Detected {anomalies} anomalous prices in response from {url}"
+                    )
 
         if "markets" in url and isinstance(payload, dict):
             data = payload.get("data", payload)
             if isinstance(data, list) and data:
                 sample = data[0]
-                has_market_identifier = any(field in sample for field in ("conditionId", "condition_id", "id"))
+                has_market_identifier = any(
+                    field in sample for field in ("conditionId", "condition_id", "id")
+                )
                 has_direct_prices = all(field in sample for field in ("yes", "no"))
-                has_outcome_prices = any(field in sample for field in ("outcomePrices", "outcomes"))
+                has_outcome_prices = any(
+                    field in sample for field in ("outcomePrices", "outcomes")
+                )
 
-                if not has_market_identifier or not (has_direct_prices or has_outcome_prices):
+                if not has_market_identifier or not (
+                    has_direct_prices or has_outcome_prices
+                ):
                     logger.error(f"Unexpected market data shape from {url}")
                     raise ValueError("Unexpected market data shape")
 
@@ -527,7 +608,10 @@ def enrich_market_snapshots_with_orderbooks(
     workers = max(1, min(max_workers, len(unique_snapshots)))
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {executor.submit(_enrich_one_snapshot, snapshot, client): market_id for market_id, snapshot in unique_snapshots.items()}
+        futures = {
+            executor.submit(_enrich_one_snapshot, snapshot, client): market_id
+            for market_id, snapshot in unique_snapshots.items()
+        }
         for future in as_completed(futures):
             market_id = futures[future]
             try:
@@ -545,10 +629,16 @@ def enrich_market_snapshots_with_orderbooks(
     return enriched
 
 
-def _enrich_one_snapshot(snapshot: MarketSnapshot, client: PolymarketPublicClient) -> MarketSnapshot:
+def _enrich_one_snapshot(
+    snapshot: MarketSnapshot, client: PolymarketPublicClient
+) -> MarketSnapshot:
     """Enrich a single snapshot with order book data."""
-    yes_book = client.fetch_order_book(snapshot.yes_token_id) if snapshot.yes_token_id else {}
-    no_book = client.fetch_order_book(snapshot.no_token_id) if snapshot.no_token_id else {}
+    yes_book = (
+        client.fetch_order_book(snapshot.yes_token_id) if snapshot.yes_token_id else {}
+    )
+    no_book = (
+        client.fetch_order_book(snapshot.no_token_id) if snapshot.no_token_id else {}
+    )
 
     yes_bid = _book_best_price(yes_book, "bids")
     no_bid = _book_best_price(no_book, "bids")
@@ -603,7 +693,9 @@ def build_wallet_trades(
     return trades
 
 
-def extract_trade_market_ids(wallet_payloads: dict[str, list[dict[str, Any]]]) -> list[str]:
+def extract_trade_market_ids(
+    wallet_payloads: dict[str, list[dict[str, Any]]],
+) -> list[str]:
     """Extract unique market IDs from trade payloads."""
     market_ids: set[str] = set()
     for items in wallet_payloads.values():
@@ -614,7 +706,9 @@ def extract_trade_market_ids(wallet_payloads: dict[str, list[dict[str, Any]]]) -
     return sorted(market_ids)
 
 
-def extract_trade_market_slugs(wallet_payloads: dict[str, list[dict[str, Any]]]) -> list[str]:
+def extract_trade_market_slugs(
+    wallet_payloads: dict[str, list[dict[str, Any]]],
+) -> list[str]:
     """Extract unique market slugs from trade payloads."""
     market_slugs: set[str] = set()
     for items in wallet_payloads.values():
@@ -627,7 +721,9 @@ def extract_trade_market_slugs(wallet_payloads: dict[str, list[dict[str, Any]]])
 
 def market_snapshot_from_gamma(item: dict[str, Any]) -> MarketSnapshot | None:
     """Create MarketSnapshot from Gamma API item."""
-    market_id = str(item.get("conditionId") or item.get("condition_id") or item.get("id") or "").strip()
+    market_id = str(
+        item.get("conditionId") or item.get("condition_id") or item.get("id") or ""
+    ).strip()
     if not market_id:
         return None
 
@@ -639,9 +735,13 @@ def market_snapshot_from_gamma(item: dict[str, Any]) -> MarketSnapshot | None:
     no_ask = float(prices[1]) if len(prices) > 1 else 0.0
 
     token_ids = _parse_token_ids(item)
-    minutes_to_resolution = _minutes_to_resolution(item.get("endDate") or item.get("end_date"))
+    minutes_to_resolution = _minutes_to_resolution(
+        item.get("endDate") or item.get("end_date")
+    )
     title = str(item.get("question") or item.get("title") or market_id)
-    topic = str(item.get("category") or item.get("tag") or item.get("seriesSlug") or "unknown")
+    topic = str(
+        item.get("category") or item.get("tag") or item.get("seriesSlug") or "unknown"
+    )
 
     best_bid_api = float(item.get("bestBid") or item.get("best_bid") or 0.0)
 
@@ -714,7 +814,16 @@ def _extract_list(payload: Any) -> list[dict[str, Any]]:
     if isinstance(payload, list):
         return [item for item in payload if isinstance(item, dict)]
     if isinstance(payload, dict):
-        for key in ("data", "markets", "trades", "users", "leaderboard", "results", "history", "activity"):
+        for key in (
+            "data",
+            "markets",
+            "trades",
+            "users",
+            "leaderboard",
+            "results",
+            "history",
+            "activity",
+        ):
             value = payload.get(key)
             if isinstance(value, list):
                 return [item for item in value if isinstance(item, dict)]
@@ -723,9 +832,20 @@ def _extract_list(payload: Any) -> list[dict[str, Any]]:
 
 def _trade_market_id(item: dict[str, Any]) -> str:
     for key in (
-        "conditionId", "condition_id", "conditionID", "condition",
-        "market_id", "marketId", "market", "asset", "asset_id",
-        "tokenID", "tokenId", "token_id", "clobTokenId", "clob_token_id",
+        "conditionId",
+        "condition_id",
+        "conditionID",
+        "condition",
+        "market_id",
+        "marketId",
+        "market",
+        "asset",
+        "asset_id",
+        "tokenID",
+        "tokenId",
+        "token_id",
+        "clobTokenId",
+        "clob_token_id",
     ):
         value = item.get(key)
         if value is not None and str(value).strip():
@@ -748,17 +868,36 @@ def _trade_market_slug(item: dict[str, Any]) -> str:
     return ""
 
 
-def _market_snapshot_aliases(item: dict[str, Any], snapshot: MarketSnapshot) -> list[str]:
+def _market_snapshot_aliases(
+    item: dict[str, Any], snapshot: MarketSnapshot
+) -> list[str]:
     aliases = [snapshot.market_id]
-    for key in ("conditionId", "condition_id", "conditionID", "condition", "id", "market_id", "marketId", "market", "slug", "marketSlug"):
+    for key in (
+        "conditionId",
+        "condition_id",
+        "conditionID",
+        "condition",
+        "id",
+        "market_id",
+        "marketId",
+        "market",
+        "slug",
+        "marketSlug",
+    ):
         value = item.get(key)
         if value is not None and str(value).strip():
             aliases.append(str(value).strip())
-    aliases.extend(token_id for token_id in (snapshot.yes_token_id, snapshot.no_token_id) if token_id)
+    aliases.extend(
+        token_id
+        for token_id in (snapshot.yes_token_id, snapshot.no_token_id)
+        if token_id
+    )
     return list(dict.fromkeys(aliases))
 
 
-def _normalize_topics(value: str | list[str] | tuple[str, ...] | set[str] | None) -> list[str]:
+def _normalize_topics(
+    value: str | list[str] | tuple[str, ...] | set[str] | None,
+) -> list[str]:
     if value is None:
         return []
     if isinstance(value, str):
@@ -826,7 +965,9 @@ def _parse_token_ids(item: dict[str, Any]) -> list[str]:
         result = []
         for token in tokens[:2]:
             if isinstance(token, dict):
-                token_id = token.get("token_id") or token.get("id") or token.get("tokenId")
+                token_id = (
+                    token.get("token_id") or token.get("id") or token.get("tokenId")
+                )
                 if token_id:
                     result.append(str(token_id))
         return result
@@ -846,13 +987,23 @@ def _flatten_trade_payload(item: dict[str, Any]) -> dict[str, Any]:
             ("question", "question"),
             ("title", "title"),
         ):
-            if target_key not in normalized and nested_market.get(source_key) is not None:
+            if (
+                target_key not in normalized
+                and nested_market.get(source_key) is not None
+            ):
                 normalized[target_key] = nested_market.get(source_key)
 
     nested_asset = item.get("asset")
     if isinstance(nested_asset, dict):
-        for source_key, target_key in (("id", "asset"), ("tokenId", "tokenId"), ("token_id", "token_id")):
-            if target_key not in normalized and nested_asset.get(source_key) is not None:
+        for source_key, target_key in (
+            ("id", "asset"),
+            ("tokenId", "tokenId"),
+            ("token_id", "token_id"),
+        ):
+            if (
+                target_key not in normalized
+                and nested_asset.get(source_key) is not None
+            ):
                 normalized[target_key] = nested_asset.get(source_key)
 
     return normalized
@@ -874,7 +1025,17 @@ def _trade_matches_wallet(item: dict[str, Any], wallet: str) -> bool:
 
 
 def _trade_wallet_address(item: dict[str, Any]) -> str:
-    for key in ("user", "userAddress", "wallet", "walletAddress", "address", "proxyWallet", "proxy_wallet", "maker", "taker"):
+    for key in (
+        "user",
+        "userAddress",
+        "wallet",
+        "walletAddress",
+        "address",
+        "proxyWallet",
+        "proxy_wallet",
+        "maker",
+        "taker",
+    ):
         value = item.get(key)
         if value is not None and str(value).strip():
             return str(value).strip().lower()
@@ -944,4 +1105,4 @@ def _chunks(items: list[str], size: int) -> list[list[str]]:
 
 
 def _retry_delay(base_delay: float, attempt: int) -> float:
-    return base_delay * (2 ** attempt) * random.uniform(0.5, 1.5)
+    return base_delay * (2**attempt) * random.uniform(0.5, 1.5)

--- a/src/predictcel/railway.py
+++ b/src/predictcel/railway.py
@@ -15,7 +15,9 @@ LIVE_MODES = {"live-data", "dry-run-trading", "live-trading"}
 
 
 def main() -> None:
-    interval_seconds = int(os.getenv("PREDICTCEL_RUN_INTERVAL_SECONDS", str(_default_interval_seconds())))
+    interval_seconds = int(
+        os.getenv("PREDICTCEL_RUN_INTERVAL_SECONDS", str(_default_interval_seconds()))
+    )
     run_once = _env_enabled("PREDICTCEL_RUN_ONCE", default=False)
     interval = max(interval_seconds, 30)
 
@@ -23,7 +25,13 @@ def main() -> None:
         started = time.perf_counter()
         try:
             _run_once_from_env()
-            _log_event("predictcel_run_complete", {"duration_ms": _elapsed_ms(started), "next_interval_seconds": 0 if run_once else interval})
+            _log_event(
+                "predictcel_run_complete",
+                {
+                    "duration_ms": _elapsed_ms(started),
+                    "next_interval_seconds": 0 if run_once else interval,
+                },
+            )
         except Exception as exc:  # pragma: no cover - defensive worker boundary
             _log_event(
                 "predictcel_run_error",
@@ -46,7 +54,9 @@ def _run_once_from_env() -> None:
     argv = ["predictcel", "--config", config_path, "--db", db_path]
     if mode:
         if mode not in VALID_MODES:
-            raise ValueError(f"Invalid PREDICTCEL_MODE={mode!r}. Expected one of {sorted(VALID_MODES)}.")
+            raise ValueError(
+                f"Invalid PREDICTCEL_MODE={mode!r}. Expected one of {sorted(VALID_MODES)}."
+            )
         if mode in LIVE_MODES:
             argv.append("--live-data")
         if mode in {"dry-run-trading", "live-trading"}:
@@ -76,7 +86,9 @@ def _run_once_from_env() -> None:
 
 def _default_interval_seconds() -> int:
     mode = os.getenv("PREDICTCEL_MODE", "").strip().lower()
-    legacy_live = _env_enabled("PREDICTCEL_LIVE_DATA", default=False) or _env_enabled("PREDICTCEL_LIVE_TRADING", default=False)
+    legacy_live = _env_enabled("PREDICTCEL_LIVE_DATA", default=False) or _env_enabled(
+        "PREDICTCEL_LIVE_TRADING", default=False
+    )
     return 60 if mode in LIVE_MODES or legacy_live else 300
 
 
@@ -102,7 +114,13 @@ def _elapsed_ms(started: float) -> int:
 
 
 def _log_event(event: str, payload: dict) -> None:
-    print(json.dumps({"event": event, "ts": datetime.now(UTC).isoformat(), **payload}, sort_keys=True), flush=True)
+    print(
+        json.dumps(
+            {"event": event, "ts": datetime.now(UTC).isoformat(), **payload},
+            sort_keys=True,
+        ),
+        flush=True,
+    )
 
 
 if __name__ == "__main__":

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -4,6 +4,7 @@ Wallet quality scoring and copyability calculation.
 This module provides algorithms for scoring wallet trading quality
 and calculating copyability scores for trade candidates.
 """
+
 from __future__ import annotations
 import math
 from collections import Counter, defaultdict
@@ -13,13 +14,13 @@ from .models import MarketSnapshot, WalletQuality, WalletTrade
 
 class WalletQualityScorer:
     """Scores wallets based on their trading activity quality.
-    
+
     Analyzes wallet trades against market data to determine:
     - Trade freshness (recency)
     - Price drift from entry
     - Sample size adequacy
     - Eligibility against filters
-    
+
     Attributes:
         filters: Configuration for trade filtering
         recency_half_life_seconds: Half-life for freshness decay calculation
@@ -27,40 +28,36 @@ class WalletQualityScorer:
         last_wallet_rejection_counts: Per-wallet rejection statistics
         last_missing_market_samples: Sample of markets not found
     """
-    
+
     def __init__(
-        self,
-        filters: FilterConfig,
-        recency_half_life_seconds: int | None = None
+        self, filters: FilterConfig, recency_half_life_seconds: int | None = None
     ) -> None:
         """Initialize the scorer with filter configuration.
-        
+
         Args:
             filters: Configuration for filtering trades
             recency_half_life_seconds: Optional override for freshness decay
         """
         self.filters = filters
-        self.recency_half_life_seconds = (
-            recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1)
+        self.recency_half_life_seconds = recency_half_life_seconds or max(
+            filters.max_trade_age_seconds // 2, 1
         )
         self.last_rejection_counts: dict[str, int] = {}
         self.last_wallet_rejection_counts: dict[str, dict[str, int]] = {}
         self.last_missing_market_samples: list[str] = []
 
     def score(
-        self,
-        trades: list[WalletTrade],
-        markets: dict[str, MarketSnapshot]
+        self, trades: list[WalletTrade], markets: dict[str, MarketSnapshot]
     ) -> dict[str, WalletQuality]:
         """Score all wallets based on their trading activity.
-        
+
         Groups trades by wallet, filters eligible trades, and calculates
         quality scores based on freshness, drift, and sample size.
-        
+
         Args:
             trades: List of all wallet trades to analyze
             markets: Dictionary of market_id -> MarketSnapshot
-            
+
         Returns:
             Dictionary mapping wallet addresses to WalletQuality scores
         """
@@ -99,13 +96,17 @@ class WalletQualityScorer:
                 for trade in eligible
                 if trade.market_id in markets
             ]
-            average_drift = sum(drifts) / len(drifts) if drifts else self.filters.max_price_drift
+            average_drift = (
+                sum(drifts) / len(drifts) if drifts else self.filters.max_price_drift
+            )
 
             freshness_score = freshness_decay(
                 average_age, self.recency_half_life_seconds
             )
             drift_score = (
-                max(0.0, 1.0 - (average_drift / self.filters.max_price_drift)) if self.filters.max_price_drift > 0 else 1.0
+                max(0.0, 1.0 - (average_drift / self.filters.max_price_drift))
+                if self.filters.max_price_drift > 0
+                else 1.0
                 if self.filters.max_price_drift
                 else 0.0
             )
@@ -151,16 +152,14 @@ class WalletQualityScorer:
         return scores
 
     def rejection_reason(
-        self,
-        trade: WalletTrade,
-        markets: dict[str, MarketSnapshot]
+        self, trade: WalletTrade, markets: dict[str, MarketSnapshot]
     ) -> str | None:
         """Determine why a trade is ineligible, if it is.
-        
+
         Args:
             trade: The trade to check
             markets: Available market data
-            
+
         Returns:
             Rejection reason string, or None if trade is eligible
         """
@@ -180,54 +179,43 @@ class WalletQualityScorer:
         return None
 
     def _is_eligible_trade(
-        self,
-        trade: WalletTrade,
-        markets: dict[str, MarketSnapshot]
+        self, trade: WalletTrade, markets: dict[str, MarketSnapshot]
     ) -> bool:
         """Check if a trade passes all eligibility filters.
-        
+
         Args:
             trade: The trade to check
             markets: Available market data
-            
+
         Returns:
             True if trade is eligible, False otherwise
         """
         return self.rejection_reason(trade, markets) is None
 
-    def _trade_drift(
-        self,
-        trade: WalletTrade,
-        market: MarketSnapshot
-    ) -> float:
+    def _trade_drift(self, trade: WalletTrade, market: MarketSnapshot) -> float:
         """Calculate price drift from trade entry to current market.
-        
+
         Args:
             trade: The historical trade
             market: Current market snapshot
-            
+
         Returns:
             Absolute price drift
         """
-        current_price = (
-            market.yes_ask if trade.side.upper() == "YES" else market.no_ask
-        )
+        current_price = market.yes_ask if trade.side.upper() == "YES" else market.no_ask
         return abs(current_price - trade.price)
 
 
-def freshness_decay(
-    age_seconds: float,
-    half_life_seconds: int | float
-) -> float:
+def freshness_decay(age_seconds: float, half_life_seconds: int | float) -> float:
     """Calculate freshness score using exponential decay.
-    
+
     The score decays exponentially based on age relative to half-life.
     At half-life age, score is 0.5. At 2x half-life, score is 0.25, etc.
-    
+
     Args:
         age_seconds: Age of the data in seconds
         half_life_seconds: Half-life for the decay calculation
-        
+
     Returns:
         Freshness score between 0.0 and 1.0
     """
@@ -235,7 +223,7 @@ def freshness_decay(
         return 0.0
     return max(
         0.0,
-        min(1.0, math.exp(-math.log(2) * max(age_seconds, 0.0) / half_life_seconds))
+        min(1.0, math.exp(-math.log(2) * max(age_seconds, 0.0) / half_life_seconds)),
     )
 
 
@@ -251,7 +239,7 @@ def compute_copyability_score(
     recency_half_life_seconds: int | None = None,
 ) -> float:
     """Compute overall copyability score for a trade candidate.
-    
+
     Combines multiple factors into a single copyability score:
     - Consensus ratio (30%): Agreement among source wallets
     - Wallet quality (25%): Average quality of source wallets
@@ -260,7 +248,7 @@ def compute_copyability_score(
     - Liquidity (8%): Market liquidity
     - Spread (7%): Bid-ask spread
     - Depth (5%): Order book depth
-    
+
     Args:
         consensus_ratio: Ratio of wallets agreeing on trade
         wallet_quality_score: Average quality of source wallets
@@ -271,16 +259,18 @@ def compute_copyability_score(
         side_depth_usd: Order book depth for the side
         filters: Configuration for thresholds
         recency_half_life_seconds: Optional override for freshness
-        
+
     Returns:
         Copyability score between 0.0 and 1.0
     """
     freshness_score = freshness_decay(
         average_age_seconds,
-        recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1)
+        recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1),
     )
     drift_score = (
-        max(0.0, 1.0 - (drift / filters.max_price_drift)) if filters.max_price_drift > 0 else 1.0
+        max(0.0, 1.0 - (drift / filters.max_price_drift))
+        if filters.max_price_drift > 0
+        else 1.0
         if filters.max_price_drift
         else 0.0
     )
@@ -290,10 +280,7 @@ def compute_copyability_score(
         else 0.0
     )
     spread_score = max(0.0, 1.0 - (side_spread / 0.1))
-    depth_score = min(
-        side_depth_usd / max(filters.min_position_size_usd, 1.0),
-        1.0
-    )
+    depth_score = min(side_depth_usd / max(filters.min_position_size_usd, 1.0), 1.0)
 
     score = (
         consensus_ratio * 0.3
@@ -307,14 +294,12 @@ def compute_copyability_score(
     return round(score, 4)
 
 
-def _dedupe_wallet_trades(
-    trades: list[WalletTrade]
-) -> list[WalletTrade]:
+def _dedupe_wallet_trades(trades: list[WalletTrade]) -> list[WalletTrade]:
     """Remove duplicate trades based on key fields.
-    
+
     Args:
         trades: List of trades that may contain duplicates
-        
+
     Returns:
         List with duplicates removed, keeping first occurrence
     """
@@ -325,7 +310,7 @@ def _dedupe_wallet_trades(
             trade.side.upper(),
             trade.price,
             trade.size_usd,
-            trade.age_seconds
+            trade.age_seconds,
         )
         deduped.setdefault(key, trade)
     return list(deduped.values())

--- a/src/predictcel/storage.py
+++ b/src/predictcel/storage.py
@@ -445,7 +445,9 @@ class SignalStore:
                 entry.trust_seed,
                 entry.status,
                 entry.first_seen_at.isoformat(),
-                entry.last_seen_trade_at.isoformat() if entry.last_seen_trade_at else None,
+                entry.last_seen_trade_at.isoformat()
+                if entry.last_seen_trade_at
+                else None,
                 entry.last_scored_at.isoformat() if entry.last_scored_at else None,
                 entry.notes,
             )
@@ -516,7 +518,9 @@ class SignalStore:
                 membership.rank,
                 1 if membership.active else 0,
                 membership.joined_at.isoformat(),
-                membership.effective_until.isoformat() if membership.effective_until else None,
+                membership.effective_until.isoformat()
+                if membership.effective_until
+                else None,
                 membership.promotion_reason,
                 membership.demotion_reason,
             )
@@ -550,7 +554,9 @@ class SignalStore:
         )
         self.connection.commit()
 
-    def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+    def load_basket_memberships(
+        self, topic: str | None = None
+    ) -> list[BasketMembership]:
         """Load basket memberships, optionally scoped to a topic."""
         cursor = self.connection.cursor()
         if topic is None:
@@ -668,7 +674,7 @@ class SignalStore:
         position_vars = []
         for pos in positions:
             volatility = 0.02
-            position_var = pos.entry_amount_usd * volatility * (time_horizon_days ** 0.5)
+            position_var = pos.entry_amount_usd * volatility * (time_horizon_days**0.5)
             position_vars.append(position_var)
 
         correlation = 0.3
@@ -759,7 +765,9 @@ class SignalStore:
         realized_pnl = round(float(row[2] or 0.0), 4)
         unrealized_pnl = round(float(row[1] or 0.0), 4)
         decisive_closed_count = wins + losses
-        win_rate = round(wins / decisive_closed_count, 4) if decisive_closed_count else 0.0
+        win_rate = (
+            round(wins / decisive_closed_count, 4) if decisive_closed_count else 0.0
+        )
 
         return {
             "starting_bankroll_usd": round(starting_bankroll_usd, 4),
@@ -791,7 +799,9 @@ class SignalStore:
         now = datetime.now(UTC)
         cutoff = now - timedelta(minutes=ttl_minutes)
         fingerprints = [
-            self.make_signal_fingerprint(candidate.market_id, candidate.topic, candidate.side)
+            self.make_signal_fingerprint(
+                candidate.market_id, candidate.topic, candidate.side
+            )
             for candidate in candidates
         ]
 

--- a/src/predictcel/wallet_discovery.py
+++ b/src/predictcel/wallet_discovery.py
@@ -18,11 +18,14 @@ from .basket_manager import BasketManagerPlanner
 from .config import AppConfig
 from .models import BasketAssignment, BasketManagerAction, WalletDiscoveryCandidate
 from .polymarket import PolymarketPublicClient, extract_trade_market_ids
-from .wallet_sources import CuratedWalletFileSource, DataApiMarketTradesWalletSource, DataApiWalletSource
+from .wallet_sources import (
+    CuratedWalletFileSource,
+    DataApiMarketTradesWalletSource,
+    DataApiWalletSource,
+)
 from .wallet_topics import classify_wallet_topics
 
 __all__ = ["WalletDiscoveryPipeline"]
-
 
 
 class WalletDiscoveryPipeline:
@@ -30,9 +33,15 @@ class WalletDiscoveryPipeline:
         self.config = config
         live_data = config.live_data
         self.client = PolymarketPublicClient(
-            gamma_base_url=live_data.gamma_base_url if live_data else "https://gamma-api.polymarket.com",
-            data_base_url=live_data.data_base_url if live_data else "https://data-api.polymarket.com",
-            clob_base_url=live_data.clob_base_url if live_data else "https://clob.polymarket.com",
+            gamma_base_url=live_data.gamma_base_url
+            if live_data
+            else "https://gamma-api.polymarket.com",
+            data_base_url=live_data.data_base_url
+            if live_data
+            else "https://data-api.polymarket.com",
+            clob_base_url=live_data.clob_base_url
+            if live_data
+            else "https://clob.polymarket.com",
             timeout_seconds=live_data.request_timeout_seconds if live_data else 15,
         )
         self.source = self._build_source()
@@ -59,8 +68,16 @@ class WalletDiscoveryPipeline:
             current_wallets_by_topic=self.current_wallets_by_topic,
         )
 
-    def run(self) -> tuple[list[WalletDiscoveryCandidate], list[BasketAssignment], list[BasketManagerAction]]:
-        raw_candidates = self.source.fetch_candidates(self.config.wallet_discovery.candidate_limit)
+    def run(
+        self,
+    ) -> tuple[
+        list[WalletDiscoveryCandidate],
+        list[BasketAssignment],
+        list[BasketManagerAction],
+    ]:
+        raw_candidates = self.source.fetch_candidates(
+            self.config.wallet_discovery.candidate_limit
+        )
         existing = self._existing_wallets()
         candidates: list[WalletDiscoveryCandidate] = []
         manager_candidates: list[WalletDiscoveryCandidate] = []
@@ -71,9 +88,14 @@ class WalletDiscoveryPipeline:
             if address in seen:
                 continue
             seen.add(address)
-            candidate = self._build_candidate(address, raw.get("source", "unknown"), self._safe_fetch_trades(address))
+            candidate = self._build_candidate(
+                address, raw.get("source", "unknown"), self._safe_fetch_trades(address)
+            )
             manager_candidates.append(candidate)
-            if self.config.wallet_discovery.exclude_existing_wallets and address in existing:
+            if (
+                self.config.wallet_discovery.exclude_existing_wallets
+                and address in existing
+            ):
                 continue
             candidates.append(candidate)
 
@@ -81,10 +103,20 @@ class WalletDiscoveryPipeline:
             if address in seen:
                 continue
             seen.add(address)
-            manager_candidates.append(self._build_candidate(address, "current_basket", self._safe_fetch_trades(address)))
+            manager_candidates.append(
+                self._build_candidate(
+                    address, "current_basket", self._safe_fetch_trades(address)
+                )
+            )
 
-        accepted = [candidate for candidate in manager_candidates if not candidate.rejected_reasons]
-        assignments = [self.assignment_engine.assign(candidate) for candidate in accepted]
+        accepted = [
+            candidate
+            for candidate in manager_candidates
+            if not candidate.rejected_reasons
+        ]
+        assignments = [
+            self.assignment_engine.assign(candidate) for candidate in accepted
+        ]
         actions = self.manager.plan(assignments)
         return candidates, assignments, actions
 
@@ -97,7 +129,8 @@ class WalletDiscoveryPipeline:
             list[WalletDiscoveryCandidate],
             list[BasketAssignment],
             list[BasketManagerAction],
-        ] | None = None,
+        ]
+        | None = None,
     ) -> dict[str, str]:
         if results is None:
             candidates, assignments, actions = self.run()
@@ -110,23 +143,39 @@ class WalletDiscoveryPipeline:
             "basket_assignments": output_path / "basket_assignments.json",
             "basket_manager_plan": output_path / "basket_manager_plan.json",
         }
-        self._write_json(files["wallet_discovery_report"], [asdict(item) for item in candidates])
-        self._write_json(files["basket_assignments"], [asdict(item) for item in assignments])
-        self._write_json(files["basket_manager_plan"], [asdict(item) for item in actions])
+        self._write_json(
+            files["wallet_discovery_report"], [asdict(item) for item in candidates]
+        )
+        self._write_json(
+            files["basket_assignments"], [asdict(item) for item in assignments]
+        )
+        self._write_json(
+            files["basket_manager_plan"], [asdict(item) for item in actions]
+        )
 
-        mutation_path = self._write_mutated_config_if_enabled(output_path, actions, config_path, config_output_path)
+        mutation_path = self._write_mutated_config_if_enabled(
+            output_path, actions, config_path, config_output_path
+        )
         if mutation_path is not None:
-            key = "updated_config" if self.config.wallet_discovery.mode == "auto_update" else "config_proposal"
+            key = (
+                "updated_config"
+                if self.config.wallet_discovery.mode == "auto_update"
+                else "config_proposal"
+            )
             files[key] = mutation_path
         return {name: str(path) for name, path in files.items()}
 
-    def build_mutated_config(self, payload: dict[str, Any], actions: list[BasketManagerAction]) -> dict[str, Any]:
+    def build_mutated_config(
+        self, payload: dict[str, Any], actions: list[BasketManagerAction]
+    ) -> dict[str, Any]:
         updated = deepcopy(payload)
         baskets = updated.get("baskets")
         if not isinstance(baskets, list):
             return updated
 
-        baskets_by_topic = {str(item.get("topic")): item for item in baskets if isinstance(item, dict)}
+        baskets_by_topic = {
+            str(item.get("topic")): item for item in baskets if isinstance(item, dict)
+        }
         for action in actions:
             basket = baskets_by_topic.get(action.basket)
             if not basket:
@@ -142,7 +191,9 @@ class WalletDiscoveryPipeline:
                     wallets.append(action.wallet_address)
                 continue
             if action.action in {"remove", "suspend"}:
-                basket["wallets"] = [wallet for wallet in wallets if str(wallet).lower() != wallet_key]
+                basket["wallets"] = [
+                    wallet for wallet in wallets if str(wallet).lower() != wallet_key
+                ]
         return updated
 
     def _write_mutated_config_if_enabled(
@@ -162,26 +213,45 @@ class WalletDiscoveryPipeline:
         payload = json.loads(source_path.read_text(encoding="utf-8"))
         mutated = self.build_mutated_config(payload, actions)
         if mode == "auto_update":
-            target_path = Path(config_output_path) if config_output_path else source_path
+            target_path = (
+                Path(config_output_path) if config_output_path else source_path
+            )
         else:
-            target_path = Path(config_output_path) if config_output_path else output_dir / "predictcel.proposed.json"
+            target_path = (
+                Path(config_output_path)
+                if config_output_path
+                else output_dir / "predictcel.proposed.json"
+            )
         self._write_json(target_path, mutated)
         return target_path
 
-    def _build_candidate(self, address: str, source: str, trades: list[dict[str, Any]]) -> WalletDiscoveryCandidate:
+    def _build_candidate(
+        self, address: str, source: str, trades: list[dict[str, Any]]
+    ) -> WalletDiscoveryCandidate:
         profile = classify_wallet_topics(trades, self.config.wallet_discovery.topics)
         total_trades = len(trades)
-        recent_trades = sum(1 for trade in trades if _age_seconds(trade) <= self.config.wallet_discovery.recent_window_seconds)
+        recent_trades = sum(
+            1
+            for trade in trades
+            if _age_seconds(trade) <= self.config.wallet_discovery.recent_window_seconds
+        )
         history_days = _observed_history_days(trades)
         avg_size = _average_trade_size(trades)
-        sample_score = min(total_trades / max(self.config.wallet_discovery.min_trades * 3, 1), 1.0)
-        recency_score = min(recent_trades / max(self.config.wallet_discovery.min_recent_trades * 3, 1), 1.0)
+        sample_score = min(
+            total_trades / max(self.config.wallet_discovery.min_trades * 3, 1), 1.0
+        )
+        recency_score = min(
+            recent_trades / max(self.config.wallet_discovery.min_recent_trades * 3, 1),
+            1.0,
+        )
         history_score = min(
             history_days / max(self.config.wallet_discovery.min_history_days, 1),
             1.0,
         )
         activity_score = _activity_score(trades)
-        size_band_score = _size_band_score(avg_size, self.config.wallet_discovery.min_avg_trade_size_usd)
+        size_band_score = _size_band_score(
+            avg_size, self.config.wallet_discovery.min_avg_trade_size_usd
+        )
         rejected = []
         if total_trades < self.config.wallet_discovery.min_trades:
             rejected.append("not enough total trades")
@@ -241,14 +311,22 @@ class WalletDiscoveryPipeline:
 
     def _safe_fetch_trades(self, address: str) -> list[dict[str, Any]]:
         try:
-            return self.source.fetch_wallet_trades(address, self.config.wallet_discovery.trade_limit_per_wallet)
+            return self.source.fetch_wallet_trades(
+                address, self.config.wallet_discovery.trade_limit_per_wallet
+            )
         except Exception:
             return []
 
-    def _build_source(self) -> DataApiWalletSource | DataApiMarketTradesWalletSource | CuratedWalletFileSource:
+    def _build_source(
+        self,
+    ) -> (
+        DataApiWalletSource | DataApiMarketTradesWalletSource | CuratedWalletFileSource
+    ):
         source = self.config.wallet_discovery.source
         if source == "data_api_market_trades":
-            return DataApiMarketTradesWalletSource(self.client, self._discovery_market_ids())
+            return DataApiMarketTradesWalletSource(
+                self.client, self._discovery_market_ids()
+            )
         if source == "curated_wallet_file":
             return CuratedWalletFileSource(
                 self.client,
@@ -283,7 +361,10 @@ class WalletDiscoveryPipeline:
 
 
 def _average_trade_size(trades: list[dict[str, Any]]) -> float:
-    sizes = [float(trade.get("size") or trade.get("sizeUsd") or trade.get("amount") or 0.0) for trade in trades]
+    sizes = [
+        float(trade.get("size") or trade.get("sizeUsd") or trade.get("amount") or 0.0)
+        for trade in trades
+    ]
     return sum(sizes) / len(sizes) if sizes else 0.0
 
 
@@ -314,9 +395,7 @@ def _estimated_trades_per_day(trades: list[dict[str, Any]]) -> float:
 
 def _observed_history_days(trades: list[dict[str, Any]]) -> int:
     trade_datetimes = [
-        trade_dt
-        for trade in trades
-        if (trade_dt := _trade_datetime(trade)) is not None
+        trade_dt for trade in trades if (trade_dt := _trade_datetime(trade)) is not None
     ]
     if not trade_datetimes:
         return 0

--- a/src/predictcel/wallet_registry.py
+++ b/src/predictcel/wallet_registry.py
@@ -1,4 +1,5 @@
 """Wallet Registry v2 foundation helpers."""
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -322,13 +323,17 @@ def build_live_basket_roster(
                 "wallet": membership.wallet,
                 "membership_tier": membership.tier,
                 "membership_rank": membership.rank,
-                "registry_status": registry_status_by_wallet.get(membership.wallet, "active"),
+                "registry_status": registry_status_by_wallet.get(
+                    membership.wallet, "active"
+                ),
                 "trust_seed": registry_trust_seed_by_wallet.get(membership.wallet, 0.0),
                 "selected": False,
                 "selected_tier": None,
                 "eligible_trade_count": sum(
                     1
-                    for trade in trades_by_topic_wallet.get((topic, membership.wallet), [])
+                    for trade in trades_by_topic_wallet.get(
+                        (topic, membership.wallet), []
+                    )
                     if trade.age_seconds <= config.filters.max_trade_age_seconds
                 ),
                 "eligible_market_count": len(
@@ -370,8 +375,12 @@ def build_live_basket_roster(
                     continue
                 if not _quality_allowed_for_tier(
                     tier=tier,
-                    source_type=registry_source_type_by_wallet.get(membership.wallet, "static_basket"),
-                    trust_seed=registry_trust_seed_by_wallet.get(membership.wallet, 0.0),
+                    source_type=registry_source_type_by_wallet.get(
+                        membership.wallet, "static_basket"
+                    ),
+                    trust_seed=registry_trust_seed_by_wallet.get(
+                        membership.wallet, 0.0
+                    ),
                     minimum_quality=config.wallet_discovery.min_assignment_score,
                     backup_is_live=controller.allow_backup_in_live_consensus,
                 ):
@@ -396,7 +405,9 @@ def build_live_basket_roster(
                 decision["selected"] = True
                 decision["selected_tier"] = tier
             selected_memberships[tier] = tier_memberships
-            selected_wallets[tier] = [membership.wallet for membership in tier_memberships]
+            selected_wallets[tier] = [
+                membership.wallet for membership in tier_memberships
+            ]
             if tier in live_tiers:
                 selected_live_wallets.extend(selected_wallets[tier])
             selected_set = {membership.wallet for membership in tier_memberships}
@@ -448,8 +459,7 @@ def build_live_basket_roster(
         roster[topic] = {
             "selected_wallets": selected_wallets,
             "wallet_decisions": [
-                wallet_decisions[membership.wallet]
-                for membership in ranked_memberships
+                wallet_decisions[membership.wallet] for membership in ranked_memberships
             ],
             "fresh_core_wallet_count": fresh_core_wallet_count,
             "live_eligible_wallet_count": live_eligible_wallet_count,
@@ -509,9 +519,7 @@ def recommend_basket_promotions(
         roster = live_roster_by_topic.get(topic, {})
         selected_wallets = roster.get("selected_wallets", {})
         recommended_wallets = tuple(
-            wallet
-            for tier in live_tiers
-            for wallet in selected_wallets.get(tier, [])
+            wallet for tier in live_tiers for wallet in selected_wallets.get(tier, [])
         )
         tracked_wallet_count = health.tracked_wallet_count if health is not None else 0
         fresh_active_wallets_7d = (
@@ -596,7 +604,11 @@ def rebalance_memberships_from_live_roster(
         selected_assignments: dict[str, tuple[str, int]] = {}
         rank = 1
         for tier in TIER_ORDER:
-            wallets = selected_wallets.get(tier, []) if isinstance(selected_wallets, dict) else []
+            wallets = (
+                selected_wallets.get(tier, [])
+                if isinstance(selected_wallets, dict)
+                else []
+            )
             for wallet in wallets:
                 normalized_wallet = str(wallet).strip()
                 if not normalized_wallet:
@@ -643,7 +655,9 @@ def rebalance_memberships_from_live_roster(
                 )
             )
 
-    updated_memberships.sort(key=lambda membership: (membership.topic, membership.rank, membership.wallet))
+    updated_memberships.sort(
+        key=lambda membership: (membership.topic, membership.rank, membership.wallet)
+    )
     if updated_memberships == memberships:
         return memberships
     store.upsert_basket_memberships(updated_memberships)
@@ -666,8 +680,7 @@ def apply_basket_manager_actions_to_memberships(
         else []
     )
     memberships_by_key = {
-        (membership.topic, membership.wallet): membership
-        for membership in memberships
+        (membership.topic, membership.wallet): membership for membership in memberships
     }
     next_rank_by_topic: dict[str, int] = defaultdict(int)
     for membership in memberships:
@@ -691,7 +704,11 @@ def apply_basket_manager_actions_to_memberships(
             if existing_membership is not None and existing_membership.active:
                 continue
             next_rank_by_topic[action.basket] += 1
-            joined_at = captured_at if existing_membership is None else existing_membership.joined_at
+            joined_at = (
+                captured_at
+                if existing_membership is None
+                else existing_membership.joined_at
+            )
             memberships_by_key[membership_key] = BasketMembership(
                 topic=action.basket,
                 wallet=action.wallet_address,
@@ -741,7 +758,9 @@ def apply_basket_manager_actions_to_memberships(
     )
     if updated_memberships:
         store.upsert_basket_memberships(updated_memberships)
-    updated_entries = sorted(registry_by_wallet.values(), key=lambda entry: entry.wallet)
+    updated_entries = sorted(
+        registry_by_wallet.values(), key=lambda entry: entry.wallet
+    )
     if updated_entries and hasattr(store, "upsert_wallet_registry_entries"):
         store.upsert_wallet_registry_entries(updated_entries)
     diagnostics = {
@@ -934,7 +953,8 @@ def _registry_status_from_freshness(
     probation_age_days = (captured_at - entry.first_seen_at).total_seconds() / 86_400
     if (
         probation_age_days < config.wallet_registry.min_probation_days
-        or eligible_trade_count < config.wallet_registry.min_eligible_trades_for_approval
+        or eligible_trade_count
+        < config.wallet_registry.min_eligible_trades_for_approval
     ):
         return "probation"
     if not _meets_registry_quality_floor(config, entry):

--- a/src/predictcel/wallet_sources.py
+++ b/src/predictcel/wallet_sources.py
@@ -11,8 +11,12 @@ from typing import Any
 
 from .polymarket import PolymarketPublicClient
 
-__all__ = ["CuratedWalletFileSource", "DataApiWalletSource", "DataApiMarketTradesWalletSource", "extract_wallet_address"]
-
+__all__ = [
+    "CuratedWalletFileSource",
+    "DataApiWalletSource",
+    "DataApiMarketTradesWalletSource",
+    "extract_wallet_address",
+]
 
 
 class DataApiWalletSource:
@@ -26,7 +30,13 @@ class DataApiWalletSource:
             address = extract_wallet_address(item)
             if not address:
                 continue
-            candidates.append({"address": address.lower(), "source": "polymarket_data_api", "raw": item})
+            candidates.append(
+                {
+                    "address": address.lower(),
+                    "source": "polymarket_data_api",
+                    "raw": item,
+                }
+            )
         return candidates
 
     def fetch_wallet_trades(self, address: str, limit: int) -> list[dict[str, Any]]:
@@ -36,7 +46,9 @@ class DataApiWalletSource:
 class DataApiMarketTradesWalletSource:
     def __init__(self, client: PolymarketPublicClient, market_ids: list[str]) -> None:
         self.client = client
-        self.market_ids = [str(market_id).strip() for market_id in market_ids if str(market_id).strip()]
+        self.market_ids = [
+            str(market_id).strip() for market_id in market_ids if str(market_id).strip()
+        ]
 
     def fetch_candidates(self, limit: int) -> list[dict[str, Any]]:
         if not self.market_ids or limit <= 0:
@@ -66,7 +78,9 @@ class DataApiMarketTradesWalletSource:
 
 
 class CuratedWalletFileSource:
-    def __init__(self, client: PolymarketPublicClient, wallet_candidates_path: str | Path) -> None:
+    def __init__(
+        self, client: PolymarketPublicClient, wallet_candidates_path: str | Path
+    ) -> None:
         self.client = client
         self.wallet_candidates_path = Path(wallet_candidates_path)
 
@@ -102,7 +116,15 @@ class CuratedWalletFileSource:
 
 
 def extract_wallet_address(item: dict[str, Any]) -> str:
-    for key in ("address", "wallet", "walletAddress", "user", "userAddress", "proxyWallet", "proxy_wallet"):
+    for key in (
+        "address",
+        "wallet",
+        "walletAddress",
+        "user",
+        "userAddress",
+        "proxyWallet",
+        "proxy_wallet",
+    ):
         value = item.get(key)
         if value:
             return str(value).strip()

--- a/src/predictcel/wallet_topics.py
+++ b/src/predictcel/wallet_topics.py
@@ -17,7 +17,9 @@ __all__ = ["classify_wallet_topics", "classify_trade_topic"]
 UNKNOWN_TOPIC = "other"
 
 
-def classify_wallet_topics(trades: list[dict[str, Any]], topic_keywords: dict[str, list[str]]) -> WalletTopicProfile:
+def classify_wallet_topics(
+    trades: list[dict[str, Any]], topic_keywords: dict[str, list[str]]
+) -> WalletTopicProfile:
     counts: Counter[str] = Counter()
     for trade in trades:
         topic = _explicit_topic(trade)
@@ -27,19 +29,27 @@ def classify_wallet_topics(trades: list[dict[str, Any]], topic_keywords: dict[st
 
     total = sum(counts.values())
     if total <= 0:
-        return WalletTopicProfile(topic_affinities={UNKNOWN_TOPIC: 1.0}, primary_topic=UNKNOWN_TOPIC, specialization_score=1.0)
+        return WalletTopicProfile(
+            topic_affinities={UNKNOWN_TOPIC: 1.0},
+            primary_topic=UNKNOWN_TOPIC,
+            specialization_score=1.0,
+        )
 
     affinities = {topic: round(count / total, 4) for topic, count in counts.items()}
     primary_topic = max(affinities.items(), key=lambda item: item[1])[0]
     specialization = round(sum(value * value for value in affinities.values()), 4)
     return WalletTopicProfile(
-        topic_affinities=dict(sorted(affinities.items(), key=lambda item: item[1], reverse=True)),
+        topic_affinities=dict(
+            sorted(affinities.items(), key=lambda item: item[1], reverse=True)
+        ),
         primary_topic=primary_topic,
         specialization_score=specialization,
     )
 
 
-def classify_trade_topic(trade: dict[str, Any], topic_keywords: dict[str, list[str]]) -> str:
+def classify_trade_topic(
+    trade: dict[str, Any], topic_keywords: dict[str, list[str]]
+) -> str:
     text = _trade_text(trade)
     for topic, keywords in topic_keywords.items():
         if any(keyword.lower() in text for keyword in keywords):
@@ -57,7 +67,15 @@ def _explicit_topic(trade: dict[str, Any]) -> str:
 
 def _trade_text(trade: dict[str, Any]) -> str:
     parts = []
-    for key in ("slug", "marketSlug", "title", "question", "market", "eventTitle", "description"):
+    for key in (
+        "slug",
+        "marketSlug",
+        "title",
+        "question",
+        "market",
+        "eventTitle",
+        "description",
+    ):
         value = trade.get(key)
         if value:
             parts.append(str(value))

--- a/src/predictcel/wallets.py
+++ b/src/predictcel/wallets.py
@@ -16,7 +16,6 @@ from .models import WalletTrade
 __all__ = ["load_wallet_trades", "bucket_trades_by_market"]
 
 
-
 def _parse_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -37,7 +36,11 @@ def load_wallet_trades(path: str) -> list[WalletTrade]:
             price=float(item["price"]),
             size_usd=float(item["size_usd"]),
             age_seconds=int(item["age_seconds"]),
-            timestamp=_parse_datetime(item.get("timestamp") or item.get("trade_time") or item.get("created_at")),
+            timestamp=_parse_datetime(
+                item.get("timestamp")
+                or item.get("trade_time")
+                or item.get("created_at")
+            ),
         )
         for item in payload
     ]

--- a/tests/integration/test_discovery_pipeline.py
+++ b/tests/integration/test_discovery_pipeline.py
@@ -88,18 +88,68 @@ class TestWalletDiscoveryPipeline:
 
         trades_by_wallet = {
             "0xwallet1abcdef": [
-                {"conditionId": "0xabc123def456", "outcome": "YES", "price": "0.61", "size": "500"},
-                {"conditionId": "0xabc123def456", "outcome": "NO", "price": "0.37", "size": "300"},
-                {"conditionId": "0xabc123def456", "outcome": "YES", "price": "0.60", "size": "450"},
-                {"conditionId": "0xabc123def456", "outcome": "YES", "price": "0.62", "size": "600"},
-                {"conditionId": "0xabc123def456", "outcome": "YES", "price": "0.59", "size": "550"},
+                {
+                    "conditionId": "0xabc123def456",
+                    "outcome": "YES",
+                    "price": "0.61",
+                    "size": "500",
+                },
+                {
+                    "conditionId": "0xabc123def456",
+                    "outcome": "NO",
+                    "price": "0.37",
+                    "size": "300",
+                },
+                {
+                    "conditionId": "0xabc123def456",
+                    "outcome": "YES",
+                    "price": "0.60",
+                    "size": "450",
+                },
+                {
+                    "conditionId": "0xabc123def456",
+                    "outcome": "YES",
+                    "price": "0.62",
+                    "size": "600",
+                },
+                {
+                    "conditionId": "0xabc123def456",
+                    "outcome": "YES",
+                    "price": "0.59",
+                    "size": "550",
+                },
             ],
             "0xwallet2ghijkl": [
-                {"conditionId": "0xdef789abc012", "outcome": "YES", "price": "0.46", "size": "100"},
-                {"conditionId": "0xdef789abc012", "outcome": "NO", "price": "0.55", "size": "80"},
-                {"conditionId": "0xdef789abc012", "outcome": "YES", "price": "0.44", "size": "120"},
-                {"conditionId": "0xdef789abc012", "outcome": "YES", "price": "0.47", "size": "90"},
-                {"conditionId": "0xdef789abc012", "outcome": "YES", "price": "0.45", "size": "110"},
+                {
+                    "conditionId": "0xdef789abc012",
+                    "outcome": "YES",
+                    "price": "0.46",
+                    "size": "100",
+                },
+                {
+                    "conditionId": "0xdef789abc012",
+                    "outcome": "NO",
+                    "price": "0.55",
+                    "size": "80",
+                },
+                {
+                    "conditionId": "0xdef789abc012",
+                    "outcome": "YES",
+                    "price": "0.44",
+                    "size": "120",
+                },
+                {
+                    "conditionId": "0xdef789abc012",
+                    "outcome": "YES",
+                    "price": "0.47",
+                    "size": "90",
+                },
+                {
+                    "conditionId": "0xdef789abc012",
+                    "outcome": "YES",
+                    "price": "0.45",
+                    "size": "110",
+                },
             ],
         }
 
@@ -166,8 +216,14 @@ class TestMarketSnapshotPipeline:
         class FakeBookClient:
             def fetch_order_book(self, token_id: str):
                 books = {
-                    "yes_test": {"bids": [{"price": "0.59", "size": "500"}], "asks": [{"price": "0.62", "size": "400"}]},
-                    "no_test": {"bids": [{"price": "0.38", "size": "600"}], "asks": [{"price": "0.42", "size": "350"}]},
+                    "yes_test": {
+                        "bids": [{"price": "0.59", "size": "500"}],
+                        "asks": [{"price": "0.62", "size": "400"}],
+                    },
+                    "no_test": {
+                        "bids": [{"price": "0.38", "size": "600"}],
+                        "asks": [{"price": "0.42", "size": "350"}],
+                    },
                 }
                 return books.get(token_id, {})
 

--- a/tests/integration/test_polymarket_api.py
+++ b/tests/integration/test_polymarket_api.py
@@ -91,8 +91,7 @@ class TestDataAPIIntegration:
         assert len(trades) >= 2
         for trade in trades:
             wallet_in_trade = (
-                trade.get("user", "").lower()
-                or trade.get("address", "").lower()
+                trade.get("user", "").lower() or trade.get("address", "").lower()
             )
             assert "wallet1" in wallet_in_trade
 

--- a/tests/test_arb_sidecar.py
+++ b/tests/test_arb_sidecar.py
@@ -4,7 +4,9 @@ from predictcel.models import MarketSnapshot
 
 
 def test_detects_complete_set_underpricing_with_net_metrics() -> None:
-    sidecar = ArbitrageSidecar(ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000))
+    sidecar = ArbitrageSidecar(
+        ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000)
+    )
     markets = {
         "m1": MarketSnapshot(
             market_id="m1",
@@ -34,7 +36,9 @@ def test_detects_complete_set_underpricing_with_net_metrics() -> None:
 
 
 def test_skips_market_when_liquidity_too_low() -> None:
-    sidecar = ArbitrageSidecar(ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000))
+    sidecar = ArbitrageSidecar(
+        ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000)
+    )
     markets = {
         "m1": MarketSnapshot(
             market_id="m1",
@@ -87,10 +91,24 @@ def test_skips_when_min_profitable_position_exceeds_cap() -> None:
 
 
 def test_sorts_by_quality_score_then_net_edge() -> None:
-    sidecar = ArbitrageSidecar(ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000))
+    sidecar = ArbitrageSidecar(
+        ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000)
+    )
     markets = {
-        "fast": MarketSnapshot("fast", "sports", "Fast", 0.46, 0.49, 0.44, 9000, 120, orderbook_ready=True),
-        "slow": MarketSnapshot("slow", "sports", "Slow", 0.45, 0.49, 0.44, 9000, 3000, orderbook_ready=False),
+        "fast": MarketSnapshot(
+            "fast", "sports", "Fast", 0.46, 0.49, 0.44, 9000, 120, orderbook_ready=True
+        ),
+        "slow": MarketSnapshot(
+            "slow",
+            "sports",
+            "Slow",
+            0.45,
+            0.49,
+            0.44,
+            9000,
+            3000,
+            orderbook_ready=False,
+        ),
     }
 
     opportunities = sidecar.scan(markets)

--- a/tests/test_basket_assignment.py
+++ b/tests/test_basket_assignment.py
@@ -12,7 +12,11 @@ from predictcel.config import (
     PositionConfig,
     WalletDiscoveryConfig,
 )
-from predictcel.models import BasketAssignment, WalletDiscoveryCandidate, WalletTopicProfile
+from predictcel.models import (
+    BasketAssignment,
+    WalletDiscoveryCandidate,
+    WalletTopicProfile,
+)
 
 
 def make_config() -> AppConfig:
@@ -28,8 +32,30 @@ def make_config() -> AppConfig:
         arbitrage=ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000),
         wallet_trades_path="",
         market_snapshots_path="",
-        live_data=LiveDataConfig(False, "https://gamma-api.polymarket.com", "https://data-api.polymarket.com", "https://clob.polymarket.com", 10, 10, 15),
-        execution=ExecutionConfig(False, True, 0.7, 1, 10.0, 0.02, "FOK", 137, 0, PositionConfig(0.3, 0.1, 1440), ExposureConfig(100, 10), 3, 1.0),
+        live_data=LiveDataConfig(
+            False,
+            "https://gamma-api.polymarket.com",
+            "https://data-api.polymarket.com",
+            "https://clob.polymarket.com",
+            10,
+            10,
+            15,
+        ),
+        execution=ExecutionConfig(
+            False,
+            True,
+            0.7,
+            1,
+            10.0,
+            0.02,
+            "FOK",
+            137,
+            0,
+            PositionConfig(0.3, 0.1, 1440),
+            ExposureConfig(100, 10),
+            3,
+            1.0,
+        ),
         consensus=ConsensusConfig(),
         wallet_discovery=discovery,
     )
@@ -42,7 +68,9 @@ def make_candidate(score: float = 0.8) -> WalletDiscoveryCandidate:
         total_trades=30,
         recent_trades=10,
         avg_trade_size_usd=20.0,
-        topic_profile=WalletTopicProfile({"sports": 0.8, "crypto": 0.2}, "sports", 0.68),
+        topic_profile=WalletTopicProfile(
+            {"sports": 0.8, "crypto": 0.2}, "sports", 0.68
+        ),
         score=score,
         confidence="HIGH" if score >= 0.7 else "MEDIUM",
         rejected_reasons=[],
@@ -54,7 +82,9 @@ def make_candidate(score: float = 0.8) -> WalletDiscoveryCandidate:
 
 
 def test_assignment_recommends_matching_baskets() -> None:
-    assignment = BasketAssignmentEngine(make_config().wallet_discovery).assign(make_candidate())
+    assignment = BasketAssignmentEngine(make_config().wallet_discovery).assign(
+        make_candidate()
+    )
 
     assert assignment.primary_topic == "sports"
     assert assignment.recommended_baskets == ["sports", "crypto"]
@@ -65,7 +95,9 @@ def test_assignment_recommends_matching_baskets() -> None:
 
 def test_manager_proposes_add_in_auto_update_mode() -> None:
     config = make_config()
-    assignment = BasketAssignmentEngine(config.wallet_discovery).assign(make_candidate())
+    assignment = BasketAssignmentEngine(config.wallet_discovery).assign(
+        make_candidate()
+    )
 
     actions = BasketManagerPlanner(config).plan([assignment])
 
@@ -76,7 +108,9 @@ def test_manager_proposes_add_in_auto_update_mode() -> None:
 
 def test_manager_observes_low_score_assignment() -> None:
     config = make_config()
-    assignment = BasketAssignmentEngine(config.wallet_discovery).assign(make_candidate(score=0.4))
+    assignment = BasketAssignmentEngine(config.wallet_discovery).assign(
+        make_candidate(score=0.4)
+    )
 
     actions = BasketManagerPlanner(config).plan([assignment])
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -58,6 +58,8 @@ def sample_qualities():
     }
 
 
-def test_evaluate_performance(benchmark, sample_config, sample_markets, sample_trades, sample_qualities):
+def test_evaluate_performance(
+    benchmark, sample_config, sample_markets, sample_trades, sample_qualities
+):
     engine = CopyEngine(sample_config)
     benchmark(engine.evaluate, sample_trades, sample_markets, sample_qualities)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,9 @@ def test_example_config_loads() -> None:
 
 
 def test_load_config_rejects_invalid_basket_controller_slot_total(tmp_path) -> None:
-    payload = json.loads(Path("config/predictcel.example.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        Path("config/predictcel.example.json").read_text(encoding="utf-8")
+    )
     payload["basket_controller"] = {
         "tracked_basket_target": 6,
         "core_slots": 3,
@@ -41,7 +43,9 @@ def test_load_config_rejects_invalid_basket_controller_slot_total(tmp_path) -> N
 
 
 def test_load_config_rejects_invalid_wallet_discovery_source(tmp_path) -> None:
-    payload = json.loads(Path("config/predictcel.example.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        Path("config/predictcel.example.json").read_text(encoding="utf-8")
+    )
     payload["wallet_discovery"]["source"] = "unsupported_source"
     config_path = tmp_path / "invalid-wallet-discovery-source.json"
     config_path.write_text(json.dumps(payload), encoding="utf-8")
@@ -51,7 +55,9 @@ def test_load_config_rejects_invalid_wallet_discovery_source(tmp_path) -> None:
 
 
 def test_load_config_rejects_curated_wallet_source_without_path(tmp_path) -> None:
-    payload = json.loads(Path("config/predictcel.example.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        Path("config/predictcel.example.json").read_text(encoding="utf-8")
+    )
     payload["wallet_discovery"]["source"] = "curated_wallet_file"
     payload["wallet_discovery"]["wallet_candidates_path"] = ""
     config_path = tmp_path / "invalid-curated-wallet-source.json"
@@ -62,7 +68,9 @@ def test_load_config_rejects_curated_wallet_source_without_path(tmp_path) -> Non
 
 
 def test_load_config_rejects_invalid_basket_promotion_thresholds(tmp_path) -> None:
-    payload = json.loads(Path("config/predictcel.example.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        Path("config/predictcel.example.json").read_text(encoding="utf-8")
+    )
     payload["basket_promotion"]["min_live_eligible_wallets"] = 6
     payload["basket_promotion"]["min_tracked_wallets"] = 5
     config_path = tmp_path / "invalid-basket-promotion.json"

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -50,10 +50,14 @@ class MembershipStore(CountingStore):
         self.memberships = memberships
         self.registry_entries = registry_entries or []
 
-    def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+    def load_basket_memberships(
+        self, topic: str | None = None
+    ) -> list[BasketMembership]:
         if topic is None:
             return list(self.memberships)
-        return [membership for membership in self.memberships if membership.topic == topic]
+        return [
+            membership for membership in self.memberships if membership.topic == topic
+        ]
 
     def load_wallet_registry_entries(self) -> list[WalletRegistryEntry]:
         return list(self.registry_entries)
@@ -401,7 +405,9 @@ def test_skips_candidate_when_price_is_too_late() -> None:
     assert engine.last_diagnostics["too_late_price"] == 1
 
 
-def test_weighted_consensus_can_reject_raw_quorum_with_stale_low_quality_votes() -> None:
+def test_weighted_consensus_can_reject_raw_quorum_with_stale_low_quality_votes() -> (
+    None
+):
     consensus = ConsensusConfig(
         min_weighted_consensus=0.75,
         min_confidence_score=0.20,
@@ -529,8 +535,12 @@ def test_concentrated_agreement_reduces_confidence_and_position_size() -> None:
         WalletTrade("w3", "geopolitics", "m1", "YES", 0.59, 200, 1500),
     ]
 
-    balanced = engine.evaluate(balanced_trades, {"m1": make_market()}, make_qualities())[0]
-    concentrated = engine.evaluate(concentrated_trades, {"m1": make_market()}, make_qualities())[0]
+    balanced = engine.evaluate(
+        balanced_trades, {"m1": make_market()}, make_qualities()
+    )[0]
+    concentrated = engine.evaluate(
+        concentrated_trades, {"m1": make_market()}, make_qualities()
+    )[0]
 
     assert concentrated.confidence_score < balanced.confidence_score
     assert concentrated.suggested_position_usd < balanced.suggested_position_usd
@@ -593,8 +603,12 @@ def test_market_regime_detects_trend_and_unstable_books() -> None:
             age_seconds=60,
         ),
     ]
-    trend_market = replace(make_market(), yes_ask=0.70, yes_spread=0.02, yes_ask_size=200)
-    unstable_market = replace(make_market(), yes_ask=0.70, yes_spread=0.20, yes_ask_size=1)
+    trend_market = replace(
+        make_market(), yes_ask=0.70, yes_spread=0.02, yes_ask_size=200
+    )
+    unstable_market = replace(
+        make_market(), yes_ask=0.70, yes_spread=0.20, yes_ask_size=1
+    )
 
     trend = engine.evaluate(trades, {"m1": trend_market}, make_qualities())[0]
     unstable = engine.evaluate(trades, {"m1": unstable_market}, make_qualities())[0]
@@ -814,7 +828,9 @@ def test_evaluate_reads_portfolio_summary_once_before_threading() -> None:
     assert all(candidate.suggested_position_usd > 0 for candidate in candidates)
 
 
-def test_evaluate_does_not_pass_store_into_worker_thread_consensus_gate(monkeypatch) -> None:
+def test_evaluate_does_not_pass_store_into_worker_thread_consensus_gate(
+    monkeypatch,
+) -> None:
     engine = CopyEngine(
         make_config(
             wallets=["w1", "w2", "w3"],
@@ -841,7 +857,9 @@ def test_evaluate_does_not_pass_store_into_worker_thread_consensus_gate(monkeypa
             assert threading.get_ident() == owner_thread
             return super().get_portfolio_summary(starting_bankroll_usd)
 
-        def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+        def load_basket_memberships(
+            self, topic: str | None = None
+        ) -> list[BasketMembership]:
             assert threading.get_ident() == owner_thread
             return super().load_basket_memberships(topic)
 
@@ -859,7 +877,9 @@ def test_evaluate_does_not_pass_store_into_worker_thread_consensus_gate(monkeypa
         assert kwargs.get("store") is None
         return original_gate(*args, **kwargs)
 
-    monkeypatch.setattr(copy_engine_module, "evaluate_basket_consensus_gate", wrapped_gate)
+    monkeypatch.setattr(
+        copy_engine_module, "evaluate_basket_consensus_gate", wrapped_gate
+    )
 
     markets = {
         "m1": replace(make_market(), market_id="m1"),
@@ -994,7 +1014,9 @@ def test_basket_controller_rejects_when_same_outcome_ratio_is_below_threshold() 
     assert engine.last_diagnostics["below_basket_participation"] == 1
 
 
-def test_basket_controller_rejects_when_aligned_wallets_do_not_buy_in_tight_price_band() -> None:
+def test_basket_controller_rejects_when_aligned_wallets_do_not_buy_in_tight_price_band() -> (
+    None
+):
     wallets = ["w1", "w2", "w3", "w4", "w5"]
     engine = CopyEngine(
         make_config(
@@ -1034,7 +1056,9 @@ def test_basket_controller_rejects_when_aligned_wallets_do_not_buy_in_tight_pric
     assert engine.last_diagnostics["wide_entry_price_band"] == 1
 
 
-def test_basket_controller_rejects_when_aligned_wallets_are_too_far_apart_in_time() -> None:
+def test_basket_controller_rejects_when_aligned_wallets_are_too_far_apart_in_time() -> (
+    None
+):
     wallets = ["w1", "w2", "w3", "w4", "w5"]
     engine = CopyEngine(
         make_config(
@@ -1158,7 +1182,9 @@ def test_basket_controller_uses_live_selected_core_and_rotating_wallets() -> Non
     assert candidates[0].consensus_ratio == 1.0
 
 
-def test_basket_controller_excludes_stale_seeded_wallets_when_live_roster_has_fresher_replacements() -> None:
+def test_basket_controller_excludes_stale_seeded_wallets_when_live_roster_has_fresher_replacements() -> (
+    None
+):
     engine = CopyEngine(
         make_config(
             wallets=["w1", "w2", "w3"],
@@ -1376,7 +1402,9 @@ def test_basket_controller_live_roster_respects_registry_statuses() -> None:
     assert "w1" not in candidates[0].source_wallets
 
 
-def test_basket_controller_live_roster_excludes_probation_wallets_from_consensus() -> None:
+def test_basket_controller_live_roster_excludes_probation_wallets_from_consensus() -> (
+    None
+):
     engine = CopyEngine(
         make_config(
             wallets=["w1", "w2", "w3"],

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -3,24 +3,73 @@ from predictcel.discovery import score_wallet_candidates
 
 def test_scores_focused_recent_wallet_above_unfocused_wallet() -> None:
     leaderboard = [
-        {"proxyWallet": "0xfocused", "userName": "sports_one", "pnl": 5000, "vol": 20000, "rank": "1"},
-        {"proxyWallet": "0xwide", "userName": "wide_one", "pnl": 8000, "vol": 40000, "rank": "2"},
+        {
+            "proxyWallet": "0xfocused",
+            "userName": "sports_one",
+            "pnl": 5000,
+            "vol": 20000,
+            "rank": "1",
+        },
+        {
+            "proxyWallet": "0xwide",
+            "userName": "wide_one",
+            "pnl": 8000,
+            "vol": 40000,
+            "rank": "2",
+        },
     ]
     trades_by_wallet = {
         "0xfocused": [
-            {"slug": "nba-lal-bos-2026-04-23", "title": "Lakers vs. Celtics", "size": 100, "timestamp": 1777000000},
-            {"slug": "nba-nyk-mia-2026-04-23", "title": "Knicks vs. Heat", "size": 120, "timestamp": 1777000100},
-            {"slug": "nhl-ana-edm-2026-04-23", "title": "Ducks vs. Oilers", "size": 90, "timestamp": 1777000200},
+            {
+                "slug": "nba-lal-bos-2026-04-23",
+                "title": "Lakers vs. Celtics",
+                "size": 100,
+                "timestamp": 1777000000,
+            },
+            {
+                "slug": "nba-nyk-mia-2026-04-23",
+                "title": "Knicks vs. Heat",
+                "size": 120,
+                "timestamp": 1777000100,
+            },
+            {
+                "slug": "nhl-ana-edm-2026-04-23",
+                "title": "Ducks vs. Oilers",
+                "size": 90,
+                "timestamp": 1777000200,
+            },
         ],
         "0xwide": [
-            {"slug": "nba-lal-bos-2026-04-23", "title": "Lakers vs. Celtics", "size": 10, "timestamp": 1777000000},
-            {"slug": "will-btc-hit-100k-april-23", "title": "Bitcoin $100k?", "size": 10, "timestamp": 1777000100},
-            {"slug": "will-it-rain-in-nyc-april-23", "title": "Rain in NYC?", "size": 10, "timestamp": 1777000200},
-            {"slug": "fed-rates-may-2026", "title": "Fed rates", "size": 10, "timestamp": 1777000300},
+            {
+                "slug": "nba-lal-bos-2026-04-23",
+                "title": "Lakers vs. Celtics",
+                "size": 10,
+                "timestamp": 1777000000,
+            },
+            {
+                "slug": "will-btc-hit-100k-april-23",
+                "title": "Bitcoin $100k?",
+                "size": 10,
+                "timestamp": 1777000100,
+            },
+            {
+                "slug": "will-it-rain-in-nyc-april-23",
+                "title": "Rain in NYC?",
+                "size": 10,
+                "timestamp": 1777000200,
+            },
+            {
+                "slug": "fed-rates-may-2026",
+                "title": "Fed rates",
+                "size": 10,
+                "timestamp": 1777000300,
+            },
         ],
     }
 
-    candidates = score_wallet_candidates(leaderboard, trades_by_wallet, min_trade_count=3)
+    candidates = score_wallet_candidates(
+        leaderboard, trades_by_wallet, min_trade_count=3
+    )
 
     assert [candidate.wallet for candidate in candidates] == ["0xfocused", "0xwide"]
     assert candidates[0].dominant_topic == "sports"
@@ -40,7 +89,11 @@ def test_skips_wallets_without_recent_trades() -> None:
 def test_skips_wallets_with_too_few_recent_trades() -> None:
     candidates = score_wallet_candidates(
         [{"proxyWallet": "0xthin", "userName": "thin", "pnl": 100000, "vol": 1000}],
-        {"0xthin": [{"slug": "nba-lal-bos", "title": "Lakers vs. Celtics", "size": 500000}]},
+        {
+            "0xthin": [
+                {"slug": "nba-lal-bos", "title": "Lakers vs. Celtics", "size": 500000}
+            ]
+        },
     )
 
     assert candidates == []

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,7 +1,17 @@
 from datetime import UTC, datetime, timedelta
 
-from predictcel.config import ExecutionConfig, ExposureConfig, LiveDataConfig, PositionConfig
-from predictcel.execution import ExecutionPlanner, ExitRunner, LiveOrderExecutor, retry_delay
+from predictcel.config import (
+    ExecutionConfig,
+    ExposureConfig,
+    LiveDataConfig,
+    PositionConfig,
+)
+from predictcel.execution import (
+    ExecutionPlanner,
+    ExitRunner,
+    LiveOrderExecutor,
+    retry_delay,
+)
 from predictcel.models import CopyCandidate, ExecutionIntent, MarketSnapshot, Position
 
 
@@ -16,8 +26,12 @@ def make_execution_config() -> ExecutionConfig:
         order_type="FOK",
         chain_id=137,
         signature_type=0,
-        position=PositionConfig(take_profit_pct=0.3, stop_loss_pct=0.1, max_hold_minutes=1440),
-        exposure=ExposureConfig(max_total_exposure_usd=75.0, max_single_position_usd=50.0),
+        position=PositionConfig(
+            take_profit_pct=0.3, stop_loss_pct=0.1, max_hold_minutes=1440
+        ),
+        exposure=ExposureConfig(
+            max_total_exposure_usd=75.0, max_single_position_usd=50.0
+        ),
         max_retries=3,
         retry_base_delay_seconds=1.0,
         min_signal_allocation_usd=5.0,
@@ -128,7 +142,9 @@ def test_execution_planner_selects_top_copyable_markets() -> None:
         ),
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=0.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=0.0
+    )
 
     assert len(intents) == 2
     assert intents[0].market_id == "m1"
@@ -145,15 +161,67 @@ def test_execution_planner_uses_suggested_position_size_with_caps() -> None:
     config = make_execution_config()
     planner = ExecutionPlanner(config, config.position)
     candidates = [
-        CopyCandidate("topic", "m1", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok", suggested_position_usd=60.0),
-        CopyCandidate("topic", "m2", "YES", 1.0, 0.5, 0.51, 10000, ["w2"], 1.0, 0.89, "ok", suggested_position_usd=40.0),
+        CopyCandidate(
+            "topic",
+            "m1",
+            "YES",
+            1.0,
+            0.5,
+            0.51,
+            10000,
+            ["w1"],
+            1.0,
+            0.9,
+            "ok",
+            suggested_position_usd=60.0,
+        ),
+        CopyCandidate(
+            "topic",
+            "m2",
+            "YES",
+            1.0,
+            0.5,
+            0.51,
+            10000,
+            ["w2"],
+            1.0,
+            0.89,
+            "ok",
+            suggested_position_usd=40.0,
+        ),
     ]
     markets = {
-        "m1": MarketSnapshot("m1", "topic", "One", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_1", yes_ask_size=200, orderbook_ready=True),
-        "m2": MarketSnapshot("m2", "topic", "Two", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_2", yes_ask_size=200, orderbook_ready=True),
+        "m1": MarketSnapshot(
+            "m1",
+            "topic",
+            "One",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_1",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
+        "m2": MarketSnapshot(
+            "m2",
+            "topic",
+            "Two",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_2",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=10.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=10.0
+    )
 
     assert [intent.amount_usd for intent in intents] == [25.0, 25.0]
 
@@ -162,13 +230,40 @@ def test_execution_planner_applies_minimum_signal_allocation() -> None:
     config = make_execution_config()
     planner = ExecutionPlanner(config, config.position)
     candidates = [
-        CopyCandidate("topic", "m1", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok", suggested_position_usd=1.25),
+        CopyCandidate(
+            "topic",
+            "m1",
+            "YES",
+            1.0,
+            0.5,
+            0.51,
+            10000,
+            ["w1"],
+            1.0,
+            0.9,
+            "ok",
+            suggested_position_usd=1.25,
+        ),
     ]
     markets = {
-        "m1": MarketSnapshot("m1", "topic", "One", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_1", yes_ask_size=200, orderbook_ready=True),
+        "m1": MarketSnapshot(
+            "m1",
+            "topic",
+            "One",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_1",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=0.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=0.0
+    )
 
     assert [intent.amount_usd for intent in intents] == [5.0]
 
@@ -177,15 +272,45 @@ def test_execution_planner_respects_exposure_across_planned_orders() -> None:
     config = make_execution_config()
     planner = ExecutionPlanner(config, config.position)
     candidates = [
-        CopyCandidate("topic", "m1", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok"),
-        CopyCandidate("topic", "m2", "YES", 1.0, 0.5, 0.51, 10000, ["w2"], 1.0, 0.89, "ok"),
+        CopyCandidate(
+            "topic", "m1", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok"
+        ),
+        CopyCandidate(
+            "topic", "m2", "YES", 1.0, 0.5, 0.51, 10000, ["w2"], 1.0, 0.89, "ok"
+        ),
     ]
     markets = {
-        "m1": MarketSnapshot("m1", "topic", "One", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_1", yes_ask_size=100, orderbook_ready=True),
-        "m2": MarketSnapshot("m2", "topic", "Two", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_2", yes_ask_size=100, orderbook_ready=True),
+        "m1": MarketSnapshot(
+            "m1",
+            "topic",
+            "One",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_1",
+            yes_ask_size=100,
+            orderbook_ready=True,
+        ),
+        "m2": MarketSnapshot(
+            "m2",
+            "topic",
+            "Two",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_2",
+            yes_ask_size=100,
+            orderbook_ready=True,
+        ),
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=50.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=50.0
+    )
 
     assert [intent.market_id for intent in intents] == ["m1"]
 
@@ -226,7 +351,9 @@ def test_execution_planner_skips_missing_depth_or_token() -> None:
         )
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=0.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=0.0
+    )
 
     assert intents == []
     assert planner.last_diagnostics["missing_token_id"] == 1
@@ -237,23 +364,120 @@ def test_execution_planner_reports_skip_reasons() -> None:
     config = make_execution_config()
     planner = ExecutionPlanner(config, config.position)
     candidates = [
-        CopyCandidate("topic", "held", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok"),
-        CopyCandidate("topic", "no_book", "YES", 1.0, 0.5, 0.51, 10000, ["w2"], 1.0, 0.9, "ok"),
-        CopyCandidate("topic", "resolving", "YES", 1.0, 0.5, 0.51, 10000, ["w3"], 1.0, 0.9, "ok"),
-        CopyCandidate("topic", "shallow", "YES", 1.0, 0.5, 0.51, 10000, ["w4"], 1.0, 0.9, "ok", suggested_position_usd=10.0),
-        CopyCandidate("topic", "late", "YES", 1.0, 0.5, 0.96, 10000, ["w5"], 1.0, 0.9, "ok"),
-        CopyCandidate("topic", "good", "YES", 1.0, 0.5, 0.51, 10000, ["w6"], 1.0, 0.9, "ok"),
+        CopyCandidate(
+            "topic", "held", "YES", 1.0, 0.5, 0.51, 10000, ["w1"], 1.0, 0.9, "ok"
+        ),
+        CopyCandidate(
+            "topic", "no_book", "YES", 1.0, 0.5, 0.51, 10000, ["w2"], 1.0, 0.9, "ok"
+        ),
+        CopyCandidate(
+            "topic", "resolving", "YES", 1.0, 0.5, 0.51, 10000, ["w3"], 1.0, 0.9, "ok"
+        ),
+        CopyCandidate(
+            "topic",
+            "shallow",
+            "YES",
+            1.0,
+            0.5,
+            0.51,
+            10000,
+            ["w4"],
+            1.0,
+            0.9,
+            "ok",
+            suggested_position_usd=10.0,
+        ),
+        CopyCandidate(
+            "topic", "late", "YES", 1.0, 0.5, 0.96, 10000, ["w5"], 1.0, 0.9, "ok"
+        ),
+        CopyCandidate(
+            "topic", "good", "YES", 1.0, 0.5, 0.51, 10000, ["w6"], 1.0, 0.9, "ok"
+        ),
     ]
     markets = {
-        "held": MarketSnapshot("held", "topic", "Held", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_held", yes_ask_size=200, orderbook_ready=True),
-        "no_book": MarketSnapshot("no_book", "topic", "No Book", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_no_book", yes_ask_size=200, orderbook_ready=False),
-        "resolving": MarketSnapshot("resolving", "topic", "Resolving", 0.51, 0.48, 0.5, 10000, 20, yes_token_id="yes_resolving", yes_ask_size=200, orderbook_ready=True),
-        "shallow": MarketSnapshot("shallow", "topic", "Shallow", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_shallow", yes_ask_size=5, orderbook_ready=True),
-        "late": MarketSnapshot("late", "topic", "Late", 0.96, 0.03, 0.95, 10000, 180, yes_token_id="yes_late", yes_ask_size=200, orderbook_ready=True),
-        "good": MarketSnapshot("good", "topic", "Good", 0.51, 0.48, 0.5, 10000, 180, yes_token_id="yes_good", yes_ask_size=200, orderbook_ready=True),
+        "held": MarketSnapshot(
+            "held",
+            "topic",
+            "Held",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_held",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
+        "no_book": MarketSnapshot(
+            "no_book",
+            "topic",
+            "No Book",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_no_book",
+            yes_ask_size=200,
+            orderbook_ready=False,
+        ),
+        "resolving": MarketSnapshot(
+            "resolving",
+            "topic",
+            "Resolving",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            20,
+            yes_token_id="yes_resolving",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
+        "shallow": MarketSnapshot(
+            "shallow",
+            "topic",
+            "Shallow",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_shallow",
+            yes_ask_size=5,
+            orderbook_ready=True,
+        ),
+        "late": MarketSnapshot(
+            "late",
+            "topic",
+            "Late",
+            0.96,
+            0.03,
+            0.95,
+            10000,
+            180,
+            yes_token_id="yes_late",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
+        "good": MarketSnapshot(
+            "good",
+            "topic",
+            "Good",
+            0.51,
+            0.48,
+            0.5,
+            10000,
+            180,
+            yes_token_id="yes_good",
+            yes_ask_size=200,
+            orderbook_ready=True,
+        ),
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids={"held"}, current_exposure_usd=0.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids={"held"}, current_exposure_usd=0.0
+    )
 
     assert [intent.market_id for intent in intents] == ["good"]
     assert planner.last_diagnostics == {
@@ -306,7 +530,9 @@ def test_execution_planner_skips_markets_resolving_within_30_minutes() -> None:
         )
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=0.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=0.0
+    )
 
     assert intents == []
 
@@ -347,7 +573,9 @@ def test_execution_planner_skips_late_price_entries() -> None:
         )
     }
 
-    intents = planner.plan(candidates, markets, held_market_ids=set(), current_exposure_usd=0.0)
+    intents = planner.plan(
+        candidates, markets, held_market_ids=set(), current_exposure_usd=0.0
+    )
 
     assert intents == []
 
@@ -356,7 +584,8 @@ def test_live_order_executor_returns_dry_run_results() -> None:
     config = make_execution_config()
     executor = LiveOrderExecutor(config, make_live_data())
     intents = [
-        planner_intent for planner_intent in ExecutionPlanner(config, config.position).plan(
+        planner_intent
+        for planner_intent in ExecutionPlanner(config, config.position).plan(
             [
                 CopyCandidate(
                     topic="geopolitics",
@@ -454,20 +683,22 @@ def test_exit_runner_creates_close_intent_without_mutating_status() -> None:
 
 def test_live_executor_dry_run_preserves_close_side() -> None:
     executor = LiveOrderExecutor(make_execution_config(), make_live_data())
-    results = executor.execute([
-        ExecutionIntent(
-            market_id="m1",
-            topic="geopolitics",
-            side="CLOSE",
-            token_id="yes_1",
-            amount_usd=25.0,
-            worst_price=0.54,
-            copyability_score=0.0,
-            order_type="FOK",
-            reason="take profit",
-            market_title="One",
-        )
-    ])
+    results = executor.execute(
+        [
+            ExecutionIntent(
+                market_id="m1",
+                topic="geopolitics",
+                side="CLOSE",
+                token_id="yes_1",
+                amount_usd=25.0,
+                worst_price=0.54,
+                copyability_score=0.0,
+                order_type="FOK",
+                reason="take profit",
+                market_title="One",
+            )
+        ]
+    )
 
     assert results[0].market_title == "One"
     assert results[0].side == "CLOSE"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,10 +83,14 @@ class RegistrySummaryStore:
     def load_wallet_registry_entries(self) -> list[WalletRegistryEntry]:
         return list(self.registry_entries)
 
-    def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+    def load_basket_memberships(
+        self, topic: str | None = None
+    ) -> list[BasketMembership]:
         if topic is None:
             return list(self.memberships)
-        return [membership for membership in self.memberships if membership.topic == topic]
+        return [
+            membership for membership in self.memberships if membership.topic == topic
+        ]
 
     def save_basket_health(self, health_snapshots: list[BasketHealth]) -> None:
         self.saved_health = list(health_snapshots)
@@ -113,10 +117,14 @@ class DiscoveryStore:
     def load_wallet_registry_entries(self) -> list[WalletRegistryEntry]:
         return list(self.registry_entries)
 
-    def load_basket_memberships(self, topic: str | None = None) -> list[BasketMembership]:
+    def load_basket_memberships(
+        self, topic: str | None = None
+    ) -> list[BasketMembership]:
         if topic is None:
             return list(self.memberships)
-        return [membership for membership in self.memberships if membership.topic == topic]
+        return [
+            membership for membership in self.memberships if membership.topic == topic
+        ]
 
 
 class FakeLiveClient:
@@ -214,7 +222,9 @@ def test_submitted_order_does_not_create_position() -> None:
 
 def test_filled_and_dry_run_results_create_positions() -> None:
     assert _creates_or_updates_paper_position(make_result("filled")) is True
-    assert _creates_or_updates_paper_position(make_result("dry_run", order_id="")) is True
+    assert (
+        _creates_or_updates_paper_position(make_result("dry_run", order_id="")) is True
+    )
 
 
 def test_filter_duplicate_candidates_skips_recent_and_same_batch_duplicates() -> None:
@@ -240,7 +250,9 @@ def test_filter_duplicate_candidates_skips_recent_and_same_batch_duplicates() ->
 def test_mark_execution_intents_seen_only_marks_planned_intents() -> None:
     store = FakeStore()
 
-    _mark_execution_intents_seen(store, [make_intent("m2", "YES"), make_intent("m3", "NO")])
+    _mark_execution_intents_seen(
+        store, [make_intent("m2", "YES"), make_intent("m3", "NO")]
+    )
 
     assert store.marked_signals == [
         ("m2", "geopolitics", "YES"),
@@ -276,7 +288,9 @@ def test_wallet_topics_for_live_inputs_prefers_active_registry_memberships() -> 
     static_wallet = "0x2222222222222222222222222222222222222222"
     config = replace(
         load_config(Path("config/predictcel.example.json")),
-        baskets=[BasketRule(topic="sports", wallets=[static_wallet], quorum_ratio=0.66)],
+        baskets=[
+            BasketRule(topic="sports", wallets=[static_wallet], quorum_ratio=0.66)
+        ],
         wallet_registry=replace(
             load_config(Path("config/predictcel.example.json")).wallet_registry,
             enabled=True,
@@ -316,12 +330,16 @@ def test_wallet_topics_for_live_inputs_prefers_active_registry_memberships() -> 
     assert wallet_topics == {registry_wallet: ["sports"]}
 
 
-def test_load_live_inputs_uses_registry_memberships_for_wallet_fetches(monkeypatch) -> None:
+def test_load_live_inputs_uses_registry_memberships_for_wallet_fetches(
+    monkeypatch,
+) -> None:
     registry_wallet = "0x1111111111111111111111111111111111111111"
     static_wallet = "0x2222222222222222222222222222222222222222"
     config = replace(
         load_config(Path("config/predictcel.example.json")),
-        baskets=[BasketRule(topic="sports", wallets=[static_wallet], quorum_ratio=0.66)],
+        baskets=[
+            BasketRule(topic="sports", wallets=[static_wallet], quorum_ratio=0.66)
+        ],
         wallet_registry=replace(
             load_config(Path("config/predictcel.example.json")).wallet_registry,
             enabled=True,
@@ -351,10 +369,16 @@ def test_load_live_inputs_uses_registry_memberships_for_wallet_fetches(monkeypat
         return {wallet: [] for wallet in wallets}
 
     monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FakeLiveClient)
-    monkeypatch.setattr("predictcel.main._fetch_wallet_payloads", fake_fetch_wallet_payloads)
-    monkeypatch.setattr("predictcel.main.build_wallet_trades", lambda payloads, topics: [])
+    monkeypatch.setattr(
+        "predictcel.main._fetch_wallet_payloads", fake_fetch_wallet_payloads
+    )
+    monkeypatch.setattr(
+        "predictcel.main.build_wallet_trades", lambda payloads, topics: []
+    )
     monkeypatch.setattr("predictcel.main.extract_trade_market_ids", lambda payloads: [])
-    monkeypatch.setattr("predictcel.main.extract_trade_market_slugs", lambda payloads: [])
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_slugs", lambda payloads: []
+    )
     monkeypatch.setattr("predictcel.main.build_market_snapshots", lambda rows: {})
 
     trades, markets, diagnostics = _load_live_inputs(config, store)
@@ -415,14 +439,25 @@ def test_run_wallet_discovery_persists_registry_inputs_when_db_is_provided(
             return candidates, assignments, []
 
         def write_reports(self, output_dir, config_path, config_output, results=None):
-            return {"wallet_discovery_report": str(Path(output_dir) / "wallet_discovery_report.json")}
+            return {
+                "wallet_discovery_report": str(
+                    Path(output_dir) / "wallet_discovery_report.json"
+                )
+            }
 
     monkeypatch.setattr("predictcel.main.load_config", lambda _: config)
     monkeypatch.setattr("predictcel.main.WalletDiscoveryPipeline", FakePipeline)
     monkeypatch.setattr("predictcel.main.SignalStore", lambda db_path: store)
 
     _run_wallet_discovery(
-        ["--config", "config/predictcel.example.json", "--db", "predictcel.db", "--output-dir", "data"]
+        [
+            "--config",
+            "config/predictcel.example.json",
+            "--db",
+            "predictcel.db",
+            "--output-dir",
+            "data",
+        ]
     )
 
     output = capsys.readouterr().out
@@ -528,14 +563,25 @@ def test_run_wallet_discovery_skips_existing_and_rejected_wallets(
             return candidates, assignments, []
 
         def write_reports(self, output_dir, config_path, config_output, results=None):
-            return {"wallet_discovery_report": str(Path(output_dir) / "wallet_discovery_report.json")}
+            return {
+                "wallet_discovery_report": str(
+                    Path(output_dir) / "wallet_discovery_report.json"
+                )
+            }
 
     monkeypatch.setattr("predictcel.main.load_config", lambda _: config)
     monkeypatch.setattr("predictcel.main.WalletDiscoveryPipeline", FakePipeline)
     monkeypatch.setattr("predictcel.main.SignalStore", lambda db_path: store)
 
     _run_wallet_discovery(
-        ["--config", "config/predictcel.example.json", "--db", "predictcel.db", "--output-dir", "data"]
+        [
+            "--config",
+            "config/predictcel.example.json",
+            "--db",
+            "predictcel.db",
+            "--output-dir",
+            "data",
+        ]
     )
 
     output = capsys.readouterr().out
@@ -607,14 +653,25 @@ def test_run_wallet_discovery_report_only_does_not_persist_when_db_is_provided(
             return candidates, assignments, []
 
         def write_reports(self, output_dir, config_path, config_output, results=None):
-            return {"wallet_discovery_report": str(Path(output_dir) / "wallet_discovery_report.json")}
+            return {
+                "wallet_discovery_report": str(
+                    Path(output_dir) / "wallet_discovery_report.json"
+                )
+            }
 
     monkeypatch.setattr("predictcel.main.load_config", lambda _: config)
     monkeypatch.setattr("predictcel.main.WalletDiscoveryPipeline", FakePipeline)
     monkeypatch.setattr("predictcel.main.SignalStore", lambda db_path: store)
 
     _run_wallet_discovery(
-        ["--config", "config/predictcel.example.json", "--db", "predictcel.db", "--output-dir", "data"]
+        [
+            "--config",
+            "config/predictcel.example.json",
+            "--db",
+            "predictcel.db",
+            "--output-dir",
+            "data",
+        ]
     )
 
     output = capsys.readouterr().out
@@ -625,7 +682,9 @@ def test_run_wallet_discovery_report_only_does_not_persist_when_db_is_provided(
     assert '"discovered_wallets_ingested": 0' in output
 
 
-def test_auto_feed_wallet_registry_from_discovery_ingests_accepted_candidates(monkeypatch) -> None:
+def test_auto_feed_wallet_registry_from_discovery_ingests_accepted_candidates(
+    monkeypatch,
+) -> None:
     config = replace(
         load_config(Path("config/predictcel.example.json")),
         wallet_registry=replace(
@@ -698,7 +757,9 @@ def test_auto_feed_wallet_registry_from_discovery_ingests_accepted_candidates(mo
     ] == [("geopolitics", "w_new", "explorer")]
 
 
-def test_auto_feed_wallet_registry_from_discovery_skips_report_only_mode(monkeypatch) -> None:
+def test_auto_feed_wallet_registry_from_discovery_skips_report_only_mode(
+    monkeypatch,
+) -> None:
     config = replace(
         load_config(Path("config/predictcel.example.json")),
         wallet_registry=replace(
@@ -740,7 +801,9 @@ def test_auto_feed_wallet_registry_from_discovery_skips_report_only_mode(monkeyp
     assert store.memberships == []
 
 
-def test_auto_feed_wallet_registry_from_discovery_skips_propose_config_mode(monkeypatch) -> None:
+def test_auto_feed_wallet_registry_from_discovery_skips_propose_config_mode(
+    monkeypatch,
+) -> None:
     config = replace(
         load_config(Path("config/predictcel.example.json")),
         wallet_registry=replace(
@@ -782,7 +845,9 @@ def test_auto_feed_wallet_registry_from_discovery_skips_propose_config_mode(monk
     assert store.memberships == []
 
 
-def test_auto_feed_wallet_registry_from_discovery_applies_manager_actions_to_memberships(monkeypatch) -> None:
+def test_auto_feed_wallet_registry_from_discovery_applies_manager_actions_to_memberships(
+    monkeypatch,
+) -> None:
     config = replace(
         load_config(Path("config/predictcel.example.json")),
         wallet_registry=replace(
@@ -1103,7 +1168,9 @@ def test_build_wallet_registry_summary_keeps_memberships_read_only() -> None:
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
-        wallet_registry=replace(config.wallet_registry, enabled=True, seed_from_baskets=False),
+        wallet_registry=replace(
+            config.wallet_registry, enabled=True, seed_from_baskets=False
+        ),
         basket_controller=replace(
             config.basket_controller,
             tracked_basket_target=4,
@@ -1129,7 +1196,13 @@ def test_build_wallet_registry_summary_keeps_memberships_read_only() -> None:
                 demotion_reason="",
             )
             for index, (wallet, tier) in enumerate(
-                [("w1", "core"), ("w2", "core"), ("w3", "rotating"), ("w4", "backup"), ("w5", "explorer")],
+                [
+                    ("w1", "core"),
+                    ("w2", "core"),
+                    ("w3", "rotating"),
+                    ("w4", "backup"),
+                    ("w5", "explorer"),
+                ],
                 start=1,
             )
         ],
@@ -1144,7 +1217,10 @@ def test_build_wallet_registry_summary_keeps_memberships_read_only() -> None:
 
     summary = _build_wallet_registry_summary(config, store, trades)
 
-    assert [(membership.wallet, membership.tier, membership.rank, membership.active) for membership in store.memberships] == [
+    assert [
+        (membership.wallet, membership.tier, membership.rank, membership.active)
+        for membership in store.memberships
+    ] == [
         ("w1", "core", 1, True),
         ("w2", "core", 2, True),
         ("w3", "rotating", 3, True),
@@ -1163,7 +1239,9 @@ def test_build_wallet_registry_summary_does_not_reseed_existing_memberships() ->
     base_config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         base_config,
-        wallet_registry=replace(base_config.wallet_registry, enabled=True, seed_from_baskets=True),
+        wallet_registry=replace(
+            base_config.wallet_registry, enabled=True, seed_from_baskets=True
+        ),
     )
     captured_at = datetime.now(UTC)
     store = RegistrySummaryStore(
@@ -1194,17 +1272,31 @@ def test_build_wallet_registry_summary_does_not_reseed_existing_memberships() ->
 
     _build_wallet_registry_summary(config, store, [])
 
-    assert [(membership.wallet, membership.tier, membership.rank, membership.promotion_reason) for membership in store.memberships] == [
+    assert [
+        (
+            membership.wallet,
+            membership.tier,
+            membership.rank,
+            membership.promotion_reason,
+        )
+        for membership in store.memberships
+    ] == [
         ("w1", "explorer", 7, "manual override"),
     ]
 
 
-def test_build_wallet_registry_summary_bootstraps_static_baskets_after_discovery_auto_feed() -> None:
+def test_build_wallet_registry_summary_bootstraps_static_baskets_after_discovery_auto_feed() -> (
+    None
+):
     base_config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         base_config,
-        baskets=[BasketRule(topic="geopolitics", wallets=["w_seed"], quorum_ratio=0.66)],
-        wallet_registry=replace(base_config.wallet_registry, enabled=True, seed_from_baskets=True),
+        baskets=[
+            BasketRule(topic="geopolitics", wallets=["w_seed"], quorum_ratio=0.66)
+        ],
+        wallet_registry=replace(
+            base_config.wallet_registry, enabled=True, seed_from_baskets=True
+        ),
     )
     captured_at = datetime.now(UTC)
     store = RegistrySummaryStore(
@@ -1236,14 +1328,19 @@ def test_build_wallet_registry_summary_bootstraps_static_baskets_after_discovery
     summary = _build_wallet_registry_summary(config, store, [])
 
     assert {entry.wallet for entry in store.registry_entries} == {"w_new", "w_seed"}
-    assert [(membership.topic, membership.wallet, membership.tier) for membership in store.memberships] == [
+    assert [
+        (membership.topic, membership.wallet, membership.tier)
+        for membership in store.memberships
+    ] == [
         ("geopolitics", "w_seed", "core"),
         ("geopolitics", "w_new", "explorer"),
     ]
     assert summary["registry_wallet_count"] == 2
 
 
-def test_build_wallet_registry_summary_refreshes_registry_statuses_from_trade_freshness() -> None:
+def test_build_wallet_registry_summary_refreshes_registry_statuses_from_trade_freshness() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -1293,7 +1390,9 @@ def test_build_wallet_registry_summary_refreshes_registry_statuses_from_trade_fr
     }
 
 
-def test_build_wallet_registry_summary_flags_bench_depth_when_explorer_wallets_exist_but_live_roster_is_thin() -> None:
+def test_build_wallet_registry_summary_flags_bench_depth_when_explorer_wallets_exist_but_live_roster_is_thin() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -1320,7 +1419,9 @@ def test_build_wallet_registry_summary_flags_bench_depth_when_explorer_wallets_e
             WalletRegistryEntry(
                 wallet=wallet,
                 source_type="wallet_discovery" if wallet == "w3" else "static_basket",
-                source_ref="polymarket_data_api" if wallet == "w3" else "config.baskets",
+                source_ref="polymarket_data_api"
+                if wallet == "w3"
+                else "config.baskets",
                 trust_seed=1.0,
                 status="active",
                 first_seen_at=first_seen_at,
@@ -1380,7 +1481,9 @@ def test_build_wallet_registry_summary_flags_bench_depth_when_explorer_wallets_e
     }
 
 
-def test_build_wallet_registry_summary_includes_basket_promotion_recommendations() -> None:
+def test_build_wallet_registry_summary_includes_basket_promotion_recommendations() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -1425,10 +1528,34 @@ def test_build_wallet_registry_summary_includes_basket_promotion_recommendations
             for wallet in ["w1", "w2", "w3", "w4"]
         ],
         memberships=[
-            BasketMembership("esports", "w1", "core", 1, True, captured_at, None, "discovered", ""),
-            BasketMembership("esports", "w2", "core", 2, True, captured_at, None, "discovered", ""),
-            BasketMembership("esports", "w3", "rotating", 3, True, captured_at, None, "discovered", ""),
-            BasketMembership("esports", "w4", "explorer", 4, True, captured_at, None, "discovered", ""),
+            BasketMembership(
+                "esports", "w1", "core", 1, True, captured_at, None, "discovered", ""
+            ),
+            BasketMembership(
+                "esports", "w2", "core", 2, True, captured_at, None, "discovered", ""
+            ),
+            BasketMembership(
+                "esports",
+                "w3",
+                "rotating",
+                3,
+                True,
+                captured_at,
+                None,
+                "discovered",
+                "",
+            ),
+            BasketMembership(
+                "esports",
+                "w4",
+                "explorer",
+                4,
+                True,
+                captured_at,
+                None,
+                "discovered",
+                "",
+            ),
         ],
     )
     trades = [
@@ -1454,11 +1581,15 @@ def test_build_wallet_registry_summary_includes_basket_promotion_recommendations
     }
 
 
-def test_build_wallet_registry_summary_ignores_static_explorer_bench_depth_for_promotion_watch() -> None:
+def test_build_wallet_registry_summary_ignores_static_explorer_bench_depth_for_promotion_watch() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
-        wallet_registry=replace(config.wallet_registry, enabled=True, seed_from_baskets=False),
+        wallet_registry=replace(
+            config.wallet_registry, enabled=True, seed_from_baskets=False
+        ),
         basket_controller=replace(
             config.basket_controller,
             core_slots=1,

--- a/tests/test_module_exports.py
+++ b/tests/test_module_exports.py
@@ -5,7 +5,11 @@ def test_public_module_exports_match_defined_symbols() -> None:
     expected_exports = {
         "predictcel.basket_manager": ["BasketManagerPlanner"],
         "predictcel.copy_engine": ["CopyEngine"],
-        "predictcel.discovery": ["WalletCandidate", "score_wallet_candidates", "candidates_as_dicts"],
+        "predictcel.discovery": [
+            "WalletCandidate",
+            "score_wallet_candidates",
+            "candidates_as_dicts",
+        ],
         "predictcel.main": ["main"],
         "predictcel.markets": ["load_market_snapshots"],
         "predictcel.wallet_discovery": ["WalletDiscoveryPipeline"],

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -43,7 +43,11 @@ class FakeSlugClient(PolymarketPublicClient):
     def _get_json(self, url: str):
         self.urls.append(url)
         if "/markets/slug/will-event-x-happen" in url:
-            return {"conditionId": "cond_1", "slug": "will-event-x-happen", "outcomePrices": "[0.61, 0.35]"}
+            return {
+                "conditionId": "cond_1",
+                "slug": "will-event-x-happen",
+                "outcomePrices": "[0.61, 0.35]",
+            }
         return {"markets": []}
 
 
@@ -55,7 +59,18 @@ class FakeTradeClient(PolymarketPublicClient):
     def _get_json(self, url: str):
         self.urls.append(url)
         if "user=0xabc" in url and "/trades?" in url:
-            return {"trades": [{"asset": "token_yes", "side": "BUY_YES", "price": "0.54", "sizeUsd": "25", "createdAt": "2025-12-31T23:50:00Z", "user": "0xAbc"}]}
+            return {
+                "trades": [
+                    {
+                        "asset": "token_yes",
+                        "side": "BUY_YES",
+                        "price": "0.54",
+                        "sizeUsd": "25",
+                        "createdAt": "2025-12-31T23:50:00Z",
+                        "user": "0xAbc",
+                    }
+                ]
+            }
         return {"trades": []}
 
 
@@ -66,8 +81,22 @@ class FakeFilteredTradeClient(PolymarketPublicClient):
     def _get_json(self, url: str):
         return {
             "trades": [
-                {"asset": "token_wrong", "side": "BUY_YES", "price": "0.54", "sizeUsd": "25", "createdAt": "2025-12-31T23:50:00Z", "user": "0xdef"},
-                {"asset": "token_right", "side": "BUY_NO", "price": "0.44", "sizeUsd": "30", "createdAt": "2025-12-31T23:52:00Z", "user": "0xabc"},
+                {
+                    "asset": "token_wrong",
+                    "side": "BUY_YES",
+                    "price": "0.54",
+                    "sizeUsd": "25",
+                    "createdAt": "2025-12-31T23:50:00Z",
+                    "user": "0xdef",
+                },
+                {
+                    "asset": "token_right",
+                    "side": "BUY_NO",
+                    "price": "0.44",
+                    "sizeUsd": "30",
+                    "createdAt": "2025-12-31T23:52:00Z",
+                    "user": "0xabc",
+                },
             ]
         }
 
@@ -95,7 +124,7 @@ def test_market_snapshot_from_gamma_parses_string_prices_and_token_ids() -> None
         "liquidityNum": "12000",
         "endDate": "2030-01-01T00:00:00Z",
         "category": "geopolitics",
-        "clobTokenIds": "[\"yes_token\", \"no_token\"]",
+        "clobTokenIds": '["yes_token", "no_token"]',
     }
 
     snapshot = market_snapshot_from_gamma(item)
@@ -124,7 +153,13 @@ def test_fetch_markets_by_slugs_uses_slug_endpoint_and_deduplicates() -> None:
 
     rows = client.fetch_markets_by_slugs(["will-event-x-happen", "will-event-x-happen"])
 
-    assert rows == [{"conditionId": "cond_1", "slug": "will-event-x-happen", "outcomePrices": "[0.61, 0.35]"}]
+    assert rows == [
+        {
+            "conditionId": "cond_1",
+            "slug": "will-event-x-happen",
+            "outcomePrices": "[0.61, 0.35]",
+        }
+    ]
     assert any("/markets/slug/will-event-x-happen" in url for url in client.urls)
 
 
@@ -162,7 +197,7 @@ def test_build_market_snapshots_indexes_common_aliases() -> None:
                 "conditionId": "cond_1",
                 "slug": "will-event-x-happen",
                 "outcomePrices": "[0.61, 0.35]",
-                "clobTokenIds": "[\"yes_token\", \"no_token\"]",
+                "clobTokenIds": '["yes_token", "no_token"]',
             }
         ]
     )
@@ -181,19 +216,27 @@ def test_enrich_market_snapshots_with_orderbooks_adds_spread_and_depth() -> None
         "liquidityNum": "12000",
         "endDate": "2030-01-01T00:00:00Z",
         "category": "geopolitics",
-        "clobTokenIds": "[\"yes_token\", \"no_token\"]",
+        "clobTokenIds": '["yes_token", "no_token"]',
     }
     snapshot = market_snapshot_from_gamma(item)
     assert snapshot is not None
 
     client = FakeClient(
         {
-            "yes_token": {"bids": [{"price": "0.59", "size": "200"}], "asks": [{"price": "0.62", "size": "150"}]},
-            "no_token": {"bids": [{"price": "0.33", "size": "180"}], "asks": [{"price": "0.36", "size": "140"}]},
+            "yes_token": {
+                "bids": [{"price": "0.59", "size": "200"}],
+                "asks": [{"price": "0.62", "size": "150"}],
+            },
+            "no_token": {
+                "bids": [{"price": "0.33", "size": "180"}],
+                "asks": [{"price": "0.36", "size": "140"}],
+            },
         }
     )
 
-    enriched = enrich_market_snapshots_with_orderbooks({"cond_1": snapshot, "yes_token": snapshot}, client)
+    enriched = enrich_market_snapshots_with_orderbooks(
+        {"cond_1": snapshot, "yes_token": snapshot}, client
+    )
 
     assert enriched["cond_1"].yes_bid == 0.59
     assert enriched["cond_1"].no_bid == 0.33
@@ -216,7 +259,7 @@ def test_enrich_market_snapshots_requires_tradable_ask_depth() -> None:
         "liquidityNum": "12000",
         "endDate": "2030-01-01T00:00:00Z",
         "category": "geopolitics",
-        "clobTokenIds": "[\"yes_token\", \"no_token\"]",
+        "clobTokenIds": '["yes_token", "no_token"]',
     }
     snapshot = market_snapshot_from_gamma(item)
     assert snapshot is not None
@@ -237,7 +280,9 @@ def test_enrich_market_snapshots_requires_tradable_ask_depth() -> None:
     assert enriched["cond_1"].orderbook_ready is False
 
 
-def test_fetch_order_book_treats_missing_clob_book_as_empty_payload(monkeypatch) -> None:
+def test_fetch_order_book_treats_missing_clob_book_as_empty_payload(
+    monkeypatch,
+) -> None:
     client = PolymarketPublicClient(max_retries=1)
 
     def fake_urlopen(request, timeout=15):
@@ -257,10 +302,12 @@ def test_missing_clob_book_does_not_block_later_valid_books(monkeypatch) -> None
     def fake_urlopen(request, timeout=15):
         if "missing_token" in request.full_url:
             raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
-        return FakeHTTPResponse({
-            "bids": [{"price": "0.48", "size": "10"}],
-            "asks": [{"price": "0.52", "size": "12"}],
-        })
+        return FakeHTTPResponse(
+            {
+                "bids": [{"price": "0.48", "size": "10"}],
+                "asks": [{"price": "0.52", "size": "12"}],
+            }
+        )
 
     monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
 
@@ -280,10 +327,12 @@ def test_gamma_circuit_breaker_does_not_block_clob_requests(monkeypatch) -> None
         if request.full_url.startswith(client.gamma_base_url):
             raise URLError("gamma down")
         if request.full_url.startswith(client.clob_base_url):
-            return FakeHTTPResponse({
-                "bids": [{"price": "0.48", "size": "10"}],
-                "asks": [{"price": "0.52", "size": "12"}],
-            })
+            return FakeHTTPResponse(
+                {
+                    "bids": [{"price": "0.48", "size": "10"}],
+                    "asks": [{"price": "0.52", "size": "12"}],
+                }
+            )
         raise AssertionError(f"Unexpected URL: {request.full_url}")
 
     monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
@@ -341,10 +390,20 @@ def test_wallet_trade_from_data_accepts_asset_ids_and_buy_yes_side() -> None:
 def test_build_wallet_trades_fans_out_multi_topic_wallets() -> None:
     now = datetime(2026, 1, 1, tzinfo=UTC)
     wallet_payloads = {
-        "wallet_a": [{"conditionId": "cond_1", "outcome": "YES", "price": "0.54", "size": "250", "createdAt": "2025-12-31T23:50:00Z"}]
+        "wallet_a": [
+            {
+                "conditionId": "cond_1",
+                "outcome": "YES",
+                "price": "0.54",
+                "size": "250",
+                "createdAt": "2025-12-31T23:50:00Z",
+            }
+        ]
     }
 
-    trades = build_wallet_trades(wallet_payloads, {"wallet_a": ["sports", "macro"]}, now)
+    trades = build_wallet_trades(
+        wallet_payloads, {"wallet_a": ["sports", "macro"]}, now
+    )
 
     assert len(trades) == 2
     assert {trade.topic for trade in trades} == {"sports", "macro"}
@@ -373,13 +432,18 @@ def test_extract_trade_market_slugs_deduplicates_common_shapes() -> None:
         ]
     }
 
-    assert extract_trade_market_slugs(payloads) == ["another-market", "will-event-x-happen"]
+    assert extract_trade_market_slugs(payloads) == [
+        "another-market",
+        "will-event-x-happen",
+    ]
 
 
 def test_gamma_market_array_filter_uses_repeated_query_params() -> None:
     client = FakeGammaClient()
 
-    rows = client._fetch_markets_by_array_filter("clob_token_ids", ["token_a", "token_b"], 25)
+    rows = client._fetch_markets_by_array_filter(
+        "clob_token_ids", ["token_a", "token_b"], 25
+    )
 
     assert rows == [{"conditionId": "cond_1", "outcomePrices": "[0.61, 0.35]"}]
     assert "clob_token_ids=token_a" in client.urls[0]
@@ -389,8 +453,24 @@ def test_gamma_market_array_filter_uses_repeated_query_params() -> None:
 def test_build_wallet_trades_skips_wallets_without_topic_mapping() -> None:
     now = datetime(2026, 1, 1, tzinfo=UTC)
     wallet_payloads = {
-        "wallet_a": [{"conditionId": "cond_1", "outcome": "YES", "price": "0.54", "size": "250", "createdAt": "2025-12-31T23:50:00Z"}],
-        "wallet_b": [{"conditionId": "cond_2", "outcome": "NO", "price": "0.44", "size": "150", "createdAt": "2025-12-31T23:55:00Z"}],
+        "wallet_a": [
+            {
+                "conditionId": "cond_1",
+                "outcome": "YES",
+                "price": "0.54",
+                "size": "250",
+                "createdAt": "2025-12-31T23:50:00Z",
+            }
+        ],
+        "wallet_b": [
+            {
+                "conditionId": "cond_2",
+                "outcome": "NO",
+                "price": "0.44",
+                "size": "150",
+                "createdAt": "2025-12-31T23:55:00Z",
+            }
+        ],
     }
 
     trades = build_wallet_trades(wallet_payloads, {"wallet_a": "sports"}, now)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,10 @@
 from predictcel.config import FilterConfig
 from predictcel.models import MarketSnapshot, WalletTrade
-from predictcel.scoring import WalletQualityScorer, compute_copyability_score, freshness_decay
+from predictcel.scoring import (
+    WalletQualityScorer,
+    compute_copyability_score,
+    freshness_decay,
+)
 
 
 def make_filters() -> FilterConfig:
@@ -17,8 +21,24 @@ def make_filters() -> FilterConfig:
 def test_wallet_quality_scores_eligible_wallet() -> None:
     scorer = WalletQualityScorer(make_filters())
     trades = [
-        WalletTrade(wallet="w1", topic="sports", market_id="m1", side="YES", price=0.55, size_usd=200, age_seconds=300),
-        WalletTrade(wallet="w1", topic="sports", market_id="m1", side="YES", price=0.56, size_usd=180, age_seconds=600),
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.56,
+            size_usd=180,
+            age_seconds=600,
+        ),
     ]
     markets = {
         "m1": MarketSnapshot(
@@ -49,8 +69,24 @@ def test_wallet_quality_scores_eligible_wallet() -> None:
 def test_scoring_deduplicates_cross_topic_live_trade_copies() -> None:
     scorer = WalletQualityScorer(make_filters())
     trades = [
-        WalletTrade(wallet="w1", topic="sports", market_id="m1", side="YES", price=0.55, size_usd=200, age_seconds=300),
-        WalletTrade(wallet="w1", topic="macro", market_id="m1", side="YES", price=0.55, size_usd=200, age_seconds=300),
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w1",
+            topic="macro",
+            market_id="m1",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        ),
     ]
     markets = {
         "m1": MarketSnapshot("m1", "sports", "Example", 0.57, 0.4, 0.55, 9000, 180)
@@ -64,9 +100,33 @@ def test_scoring_deduplicates_cross_topic_live_trade_copies() -> None:
 def test_scoring_diagnostics_count_rejection_reasons() -> None:
     scorer = WalletQualityScorer(make_filters())
     trades = [
-        WalletTrade(wallet="w1", topic="sports", market_id="missing", side="YES", price=0.55, size_usd=200, age_seconds=300),
-        WalletTrade(wallet="w1", topic="sports", market_id="m1", side="YES", price=0.56, size_usd=20, age_seconds=300),
-        WalletTrade(wallet="w2", topic="sports", market_id="m1", side="YES", price=0.56, size_usd=200, age_seconds=7200),
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="missing",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.56,
+            size_usd=20,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w2",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.56,
+            size_usd=200,
+            age_seconds=7200,
+        ),
     ]
     markets = {
         "m1": MarketSnapshot("m1", "sports", "Example", 0.57, 0.4, 0.55, 9000, 180)
@@ -75,26 +135,47 @@ def test_scoring_diagnostics_count_rejection_reasons() -> None:
     scores = scorer.score(trades, markets)
 
     assert scores == {}
-    assert scorer.last_rejection_counts == {"missing_market": 1, "too_old": 1, "too_small": 1}
-    assert scorer.last_wallet_rejection_counts["w1"] == {"missing_market": 1, "too_small": 1}
+    assert scorer.last_rejection_counts == {
+        "missing_market": 1,
+        "too_old": 1,
+        "too_small": 1,
+    }
+    assert scorer.last_wallet_rejection_counts["w1"] == {
+        "missing_market": 1,
+        "too_small": 1,
+    }
     assert scorer.last_wallet_rejection_counts["w2"] == {"too_old": 1}
     assert scorer.last_missing_market_samples == ["missing"]
 
 
-def test_wallet_quality_prefers_specialist_human_pace_liquid_copy_safe_wallets() -> None:
+def test_wallet_quality_prefers_specialist_human_pace_liquid_copy_safe_wallets() -> (
+    None
+):
     scorer = WalletQualityScorer(make_filters())
     markets = {
         **{
-            f"s{i}": MarketSnapshot(f"s{i}", "sports", "Sports", 0.57, 0.4, 0.55, 20000, 180)
+            f"s{i}": MarketSnapshot(
+                f"s{i}", "sports", "Sports", 0.57, 0.4, 0.55, 20000, 180
+            )
             for i in range(1, 7)
         },
         **{
-            f"g{i}": MarketSnapshot(f"g{i}", "mixed", "Mixed", 0.57, 0.4, 0.55, 6000, 180)
+            f"g{i}": MarketSnapshot(
+                f"g{i}", "mixed", "Mixed", 0.57, 0.4, 0.55, 6000, 180
+            )
             for i in range(1, 13)
         },
     }
     specialist_trades = [
-        WalletTrade(wallet="w_specialist", topic="sports", market_id=f"s{i}", side="YES", price=0.55, size_usd=220, age_seconds=300 + (i * 120))
+        WalletTrade(
+            wallet="w_specialist",
+            topic="sports",
+            market_id=f"s{i}",
+            side="YES",
+            price=0.55,
+            size_usd=220,
+            age_seconds=300 + (i * 120),
+        )
         for i in range(1, 7)
     ]
     generalist_topics = [
@@ -121,24 +202,71 @@ def test_wallet_quality_prefers_specialist_human_pace_liquid_copy_safe_wallets()
     scores = scorer.score(specialist_trades + generalist_trades, markets)
 
     assert scores["w_specialist"].score > scores["w_generalist"].score
-    assert scores["w_specialist"].specialization_score > scores["w_generalist"].specialization_score
-    assert scores["w_specialist"].activity_score >= scores["w_generalist"].activity_score
+    assert (
+        scores["w_specialist"].specialization_score
+        > scores["w_generalist"].specialization_score
+    )
+    assert (
+        scores["w_specialist"].activity_score >= scores["w_generalist"].activity_score
+    )
     assert "specialization" in scores["w_specialist"].reason
 
 
-def test_wallet_quality_penalizes_copy_unsafe_large_size_relative_to_liquidity() -> None:
+def test_wallet_quality_penalizes_copy_unsafe_large_size_relative_to_liquidity() -> (
+    None
+):
     scorer = WalletQualityScorer(make_filters())
     markets = {
-        "m_safe_1": MarketSnapshot("m_safe_1", "sports", "Safe 1", 0.57, 0.4, 0.55, 15000, 180),
-        "m_safe_2": MarketSnapshot("m_safe_2", "sports", "Safe 2", 0.57, 0.4, 0.55, 15000, 180),
-        "m_unsafe_1": MarketSnapshot("m_unsafe_1", "sports", "Unsafe 1", 0.57, 0.4, 0.55, 5500, 180),
-        "m_unsafe_2": MarketSnapshot("m_unsafe_2", "sports", "Unsafe 2", 0.57, 0.4, 0.55, 5500, 180),
+        "m_safe_1": MarketSnapshot(
+            "m_safe_1", "sports", "Safe 1", 0.57, 0.4, 0.55, 15000, 180
+        ),
+        "m_safe_2": MarketSnapshot(
+            "m_safe_2", "sports", "Safe 2", 0.57, 0.4, 0.55, 15000, 180
+        ),
+        "m_unsafe_1": MarketSnapshot(
+            "m_unsafe_1", "sports", "Unsafe 1", 0.57, 0.4, 0.55, 5500, 180
+        ),
+        "m_unsafe_2": MarketSnapshot(
+            "m_unsafe_2", "sports", "Unsafe 2", 0.57, 0.4, 0.55, 5500, 180
+        ),
     }
     trades = [
-        WalletTrade(wallet="w_safe", topic="sports", market_id="m_safe_1", side="YES", price=0.55, size_usd=150, age_seconds=300),
-        WalletTrade(wallet="w_safe", topic="sports", market_id="m_safe_2", side="YES", price=0.56, size_usd=170, age_seconds=450),
-        WalletTrade(wallet="w_unsafe", topic="sports", market_id="m_unsafe_1", side="YES", price=0.55, size_usd=1500, age_seconds=300),
-        WalletTrade(wallet="w_unsafe", topic="sports", market_id="m_unsafe_2", side="YES", price=0.56, size_usd=1600, age_seconds=450),
+        WalletTrade(
+            wallet="w_safe",
+            topic="sports",
+            market_id="m_safe_1",
+            side="YES",
+            price=0.55,
+            size_usd=150,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w_safe",
+            topic="sports",
+            market_id="m_safe_2",
+            side="YES",
+            price=0.56,
+            size_usd=170,
+            age_seconds=450,
+        ),
+        WalletTrade(
+            wallet="w_unsafe",
+            topic="sports",
+            market_id="m_unsafe_1",
+            side="YES",
+            price=0.55,
+            size_usd=1500,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w_unsafe",
+            topic="sports",
+            market_id="m_unsafe_2",
+            side="YES",
+            price=0.56,
+            size_usd=1600,
+            age_seconds=450,
+        ),
     ]
 
     scores = scorer.score(trades, markets)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -130,7 +130,9 @@ def test_update_position_can_close_active_position() -> None:
     try:
         store.save_position(make_position("m1", "open", 25.0))
 
-        store.update_position("m1", current_price=0.6, unrealized_pnl=5.0, status="closed")
+        store.update_position(
+            "m1", current_price=0.6, unrealized_pnl=5.0, status="closed"
+        )
 
         assert store.get_held_market_ids() == set()
         assert store.get_total_exposure() == 0.0
@@ -169,9 +171,15 @@ def test_portfolio_summary_tracks_closed_winrate_and_pnl() -> None:
         store.save_position(make_position("winner", "open", 10.0))
         store.save_position(make_position("loser", "open", 10.0))
         store.save_position(make_position("active", "open", 10.0))
-        store.update_position("winner", current_price=0.7, unrealized_pnl=4.0, status="closed")
-        store.update_position("loser", current_price=0.4, unrealized_pnl=-2.0, status="closed")
-        store.update_position("active", current_price=0.55, unrealized_pnl=1.0, status="open")
+        store.update_position(
+            "winner", current_price=0.7, unrealized_pnl=4.0, status="closed"
+        )
+        store.update_position(
+            "loser", current_price=0.4, unrealized_pnl=-2.0, status="closed"
+        )
+        store.update_position(
+            "active", current_price=0.55, unrealized_pnl=1.0, status="open"
+        )
 
         summary = store.get_portfolio_summary(starting_bankroll_usd=100.0)
 
@@ -195,8 +203,12 @@ def test_portfolio_summary_tracks_breakeven_closed_positions_separately() -> Non
     try:
         store.save_position(make_position("winner", "open", 10.0))
         store.save_position(make_position("flat", "open", 10.0))
-        store.update_position("winner", current_price=0.7, unrealized_pnl=4.0, status="closed")
-        store.update_position("flat", current_price=0.5, unrealized_pnl=0.0, status="closed")
+        store.update_position(
+            "winner", current_price=0.7, unrealized_pnl=4.0, status="closed"
+        )
+        store.update_position(
+            "flat", current_price=0.5, unrealized_pnl=0.0, status="closed"
+        )
 
         summary = store.get_portfolio_summary(starting_bankroll_usd=100.0)
 
@@ -225,7 +237,9 @@ def test_signal_fingerprints_prevent_recent_duplicates() -> None:
         db_path.unlink(missing_ok=True)
 
 
-def test_filter_and_mark_candidates_atomically_skips_recent_and_same_batch_duplicates() -> None:
+def test_filter_and_mark_candidates_atomically_skips_recent_and_same_batch_duplicates() -> (
+    None
+):
     store, db_path = make_store()
     try:
         store.mark_signal_seen("m1", "geopolitics", "YES")
@@ -274,7 +288,9 @@ def test_wallet_registry_tables_round_trip_latest_state() -> None:
                 make_registry_entry("w2", status="probation"),
             ]
         )
-        store.upsert_wallet_registry_entries([make_registry_entry("w1", status="suspended")])
+        store.upsert_wallet_registry_entries(
+            [make_registry_entry("w1", status="suspended")]
+        )
         store.upsert_basket_memberships(
             [
                 make_membership("geopolitics", "w1", tier="core", rank=1),

--- a/tests/test_wallet_discovery.py
+++ b/tests/test_wallet_discovery.py
@@ -17,7 +17,10 @@ from predictcel.config import (
 )
 from predictcel.models import BasketManagerAction, WalletDiscoveryCandidate
 from predictcel.wallet_discovery import WalletDiscoveryPipeline
-from predictcel.wallet_sources import CuratedWalletFileSource, DataApiMarketTradesWalletSource
+from predictcel.wallet_sources import (
+    CuratedWalletFileSource,
+    DataApiMarketTradesWalletSource,
+)
 
 
 class FakeSource:
@@ -30,21 +33,57 @@ class FakeSource:
     def fetch_wallet_trades(self, address: str, limit: int):
         if address == "0xnew":
             return [
-                {"question": "NBA finals winner", "size": "20", "createdAt": "2999-01-01T00:00:00Z"},
-                {"question": "NFL playoff winner", "size": "30", "createdAt": "2999-01-01T00:00:00Z"},
-                {"question": "NBA MVP", "size": "40", "createdAt": "2999-01-01T00:00:00Z"},
+                {
+                    "question": "NBA finals winner",
+                    "size": "20",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
+                {
+                    "question": "NFL playoff winner",
+                    "size": "30",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
+                {
+                    "question": "NBA MVP",
+                    "size": "40",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
             ]
         if address == "0xregistry":
             return [
-                {"question": "NBA playoff seed", "size": "18", "createdAt": "2999-01-01T00:00:00Z"},
-                {"question": "NFL draft pick", "size": "22", "createdAt": "2999-01-01T00:00:00Z"},
-                {"question": "NBA regular season wins", "size": "28", "createdAt": "2999-01-01T00:00:00Z"},
+                {
+                    "question": "NBA playoff seed",
+                    "size": "18",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
+                {
+                    "question": "NFL draft pick",
+                    "size": "22",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
+                {
+                    "question": "NBA regular season wins",
+                    "size": "28",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
             ]
         if address == "0xexisting":
             return [
-                {"question": "NBA regular season wins", "size": "18", "createdAt": "2999-01-01T00:00:00Z"},
-                {"question": "NFL draft pick", "size": "22", "createdAt": "2999-01-01T00:00:00Z"},
-                {"question": "NBA playoff seed", "size": "28", "createdAt": "2999-01-01T00:00:00Z"},
+                {
+                    "question": "NBA regular season wins",
+                    "size": "18",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
+                {
+                    "question": "NFL draft pick",
+                    "size": "22",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
+                {
+                    "question": "NBA playoff seed",
+                    "size": "28",
+                    "createdAt": "2999-01-01T00:00:00Z",
+                },
             ]
         return []
 
@@ -66,8 +105,30 @@ def make_config(mode: str = "auto_update") -> AppConfig:
         arbitrage=ArbitrageConfig(min_gross_edge=0.02, min_liquidity_usd=5000),
         wallet_trades_path="",
         market_snapshots_path="",
-        live_data=LiveDataConfig(False, "https://gamma-api.polymarket.com", "https://data-api.polymarket.com", "https://clob.polymarket.com", 10, 10, 15),
-        execution=ExecutionConfig(False, True, 0.7, 1, 10.0, 0.02, "FOK", 137, 0, PositionConfig(0.3, 0.1, 1440), ExposureConfig(100, 10), 3, 1.0),
+        live_data=LiveDataConfig(
+            False,
+            "https://gamma-api.polymarket.com",
+            "https://data-api.polymarket.com",
+            "https://clob.polymarket.com",
+            10,
+            10,
+            15,
+        ),
+        execution=ExecutionConfig(
+            False,
+            True,
+            0.7,
+            1,
+            10.0,
+            0.02,
+            "FOK",
+            137,
+            0,
+            PositionConfig(0.3, 0.1, 1440),
+            ExposureConfig(100, 10),
+            3,
+            1.0,
+        ),
         consensus=ConsensusConfig(),
         wallet_discovery=discovery,
     )
@@ -76,7 +137,9 @@ def make_config(mode: str = "auto_update") -> AppConfig:
 def make_pipeline(mode: str = "auto_update") -> WalletDiscoveryPipeline:
     pipeline = WalletDiscoveryPipeline(make_config(mode))
     pipeline.source = FakeSource()
-    pipeline.assignment_engine = BasketAssignmentEngine(pipeline.config.wallet_discovery)
+    pipeline.assignment_engine = BasketAssignmentEngine(
+        pipeline.config.wallet_discovery
+    )
     pipeline.manager = BasketManagerPlanner(pipeline.config)
     return pipeline
 
@@ -109,9 +172,14 @@ def test_pipeline_filters_existing_wallets_and_assigns_new_candidate() -> None:
     assert candidates[0].history_score > 0
     assert candidates[0].activity_score > 0
     assert candidates[0].size_band_score > 0
-    new_assignment = next(assignment for assignment in assignments if assignment.wallet_address == "0xnew")
+    new_assignment = next(
+        assignment for assignment in assignments if assignment.wallet_address == "0xnew"
+    )
     assert new_assignment.recommended_baskets == ["sports"]
-    assert any(action.action == "add" and action.wallet_address == "0xnew" for action in actions)
+    assert any(
+        action.action == "add" and action.wallet_address == "0xnew"
+        for action in actions
+    )
 
 
 def test_pipeline_rejects_hyper_fast_wallets() -> None:
@@ -127,7 +195,9 @@ def test_pipeline_rejects_hyper_fast_wallets() -> None:
 
     candidate = pipeline._build_candidate("0xfast", "fake", fast_trades)
 
-    assert "activity cadence looks too fast to copy safely" in candidate.rejected_reasons
+    assert (
+        "activity cadence looks too fast to copy safely" in candidate.rejected_reasons
+    )
     assert candidate.activity_score <= 0.2
 
 
@@ -165,7 +235,9 @@ def test_pipeline_rejects_short_history_wallets() -> None:
         {
             "question": f"NBA prop {index}",
             "size": "25",
-            "createdAt": (base - timedelta(hours=index)).isoformat().replace("+00:00", "Z"),
+            "createdAt": (base - timedelta(hours=index))
+            .isoformat()
+            .replace("+00:00", "Z"),
         }
         for index in range(3)
     ]
@@ -196,7 +268,16 @@ def test_pipeline_can_source_existing_wallets_from_registry_memberships() -> Non
 
 def test_auto_update_mutates_config_path_by_default(tmp_path) -> None:
     config_path = tmp_path / "predictcel.json"
-    config_path.write_text(json.dumps({"baskets": [{"topic": "sports", "wallets": ["0xexisting"], "quorum_ratio": 0.66}]}), encoding="utf-8")
+    config_path.write_text(
+        json.dumps(
+            {
+                "baskets": [
+                    {"topic": "sports", "wallets": ["0xexisting"], "quorum_ratio": 0.66}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
     pipeline = make_pipeline("auto_update")
 
     reports = pipeline.write_reports(tmp_path / "reports", config_path)
@@ -208,14 +289,27 @@ def test_auto_update_mutates_config_path_by_default(tmp_path) -> None:
 
 def test_propose_config_writes_separate_proposal(tmp_path) -> None:
     config_path = tmp_path / "predictcel.json"
-    config_path.write_text(json.dumps({"baskets": [{"topic": "sports", "wallets": ["0xexisting"], "quorum_ratio": 0.66}]}), encoding="utf-8")
+    config_path.write_text(
+        json.dumps(
+            {
+                "baskets": [
+                    {"topic": "sports", "wallets": ["0xexisting"], "quorum_ratio": 0.66}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
     pipeline = make_pipeline("propose_config")
 
     reports = pipeline.write_reports(tmp_path / "reports", config_path)
     original = json.loads(config_path.read_text(encoding="utf-8"))
-    proposed = json.loads((tmp_path / "reports" / "predictcel.proposed.json").read_text(encoding="utf-8"))
+    proposed = json.loads(
+        (tmp_path / "reports" / "predictcel.proposed.json").read_text(encoding="utf-8")
+    )
 
-    assert reports["config_proposal"] == str(tmp_path / "reports" / "predictcel.proposed.json")
+    assert reports["config_proposal"] == str(
+        tmp_path / "reports" / "predictcel.proposed.json"
+    )
     assert original["baskets"][0]["wallets"] == ["0xexisting"]
     assert proposed["baskets"][0]["wallets"] == ["0xexisting", "0xnew"]
 
@@ -224,7 +318,11 @@ def test_build_mutated_config_removes_wallets_for_remove_and_suspend_actions() -
     pipeline = make_pipeline()
     payload = {
         "baskets": [
-            {"topic": "sports", "wallets": ["0xexisting", "0xsuspend", "0xremove"], "quorum_ratio": 0.66}
+            {
+                "topic": "sports",
+                "wallets": ["0xexisting", "0xsuspend", "0xremove"],
+                "quorum_ratio": 0.66,
+            }
         ]
     }
     actions = [
@@ -284,7 +382,11 @@ def test_curated_wallet_file_source_collects_unique_wallet_candidates(tmp_path) 
         {
             "address": "0xaaa",
             "source": "polydata",
-            "raw": {"wallet": "0xAAA", "source": "polydata", "dominant_topic": "sports"},
+            "raw": {
+                "wallet": "0xAAA",
+                "source": "polydata",
+                "dominant_topic": "sports",
+            },
         },
         {
             "address": "0xbbb",
@@ -308,7 +410,9 @@ def test_pipeline_uses_market_trade_source_when_configured(monkeypatch) -> None:
         def fetch_wallet_trades(self, address: str, limit: int):
             return []
 
-    monkeypatch.setattr("predictcel.wallet_discovery.DataApiMarketTradesWalletSource", CapturingSource)
+    monkeypatch.setattr(
+        "predictcel.wallet_discovery.DataApiMarketTradesWalletSource", CapturingSource
+    )
     monkeypatch.setattr(
         WalletDiscoveryPipeline,
         "_discovery_market_ids",
@@ -400,7 +504,9 @@ def test_pipeline_uses_curated_wallet_file_source_when_configured(tmp_path) -> N
     pipeline = WalletDiscoveryPipeline(config)
 
     assert isinstance(pipeline.source, CuratedWalletFileSource)
-    assert [candidate["address"] for candidate in pipeline.source.fetch_candidates(10)] == [
+    assert [
+        candidate["address"] for candidate in pipeline.source.fetch_candidates(10)
+    ] == [
         "0xcurated1",
         "0xcurated2",
     ]

--- a/tests/test_wallet_registry.py
+++ b/tests/test_wallet_registry.py
@@ -41,7 +41,9 @@ class FakeStore:
     def load_basket_memberships(self, topic: str | None = None):
         if topic is None:
             return list(self.memberships)
-        return [membership for membership in self.memberships if membership.topic == topic]
+        return [
+            membership for membership in self.memberships if membership.topic == topic
+        ]
 
     def load_wallet_registry_entries(self):
         return list(self.registry_entries)
@@ -231,7 +233,9 @@ def test_build_live_basket_roster_ranks_recent_wallets_into_live_slots() -> None
         WalletTrade("w4", "geopolitics", "m4", "YES", 0.6, 12.0, 86_000),
     ]
 
-    roster = build_live_basket_roster(config, memberships, trades, captured_at=captured_at)
+    roster = build_live_basket_roster(
+        config, memberships, trades, captured_at=captured_at
+    )
 
     assert roster["geopolitics"]["selected_wallets"] == {
         "core": ["w3", "w2"],
@@ -286,8 +290,22 @@ def test_build_live_basket_roster_uses_trust_seed_as_quality_tiebreaker() -> Non
         ),
     ]
     registry_entries = [
-        WalletRegistryEntry("w_low", "wallet_discovery", "polymarket_data_api", 0.55, "active", captured_at),
-        WalletRegistryEntry("w_high", "wallet_discovery", "polymarket_data_api", 0.85, "active", captured_at),
+        WalletRegistryEntry(
+            "w_low",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.55,
+            "active",
+            captured_at,
+        ),
+        WalletRegistryEntry(
+            "w_high",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.85,
+            "active",
+            captured_at,
+        ),
     ]
     trades = [
         WalletTrade("w_low", "geopolitics", "m1", "YES", 0.5, 20.0, 300),
@@ -316,7 +334,9 @@ def test_build_live_basket_roster_uses_trust_seed_as_quality_tiebreaker() -> Non
     assert decisions["w_low"]["trust_seed"] == 0.55
 
 
-def test_build_live_basket_roster_demotes_low_trust_discovered_wallets_from_live_tiers() -> None:
+def test_build_live_basket_roster_demotes_low_trust_discovered_wallets_from_live_tiers() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     captured_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     config = replace(
@@ -334,14 +354,52 @@ def test_build_live_basket_roster_demotes_low_trust_discovered_wallets_from_live
         ),
     )
     memberships = [
-        BasketMembership("geopolitics", "w_core", "core", 1, True, captured_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w_low", "rotating", 2, True, captured_at, None, "discovered", ""),
-        BasketMembership("geopolitics", "w_high", "explorer", 3, True, captured_at, None, "discovered", ""),
+        BasketMembership(
+            "geopolitics", "w_core", "core", 1, True, captured_at, None, "seeded", ""
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_low",
+            "rotating",
+            2,
+            True,
+            captured_at,
+            None,
+            "discovered",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_high",
+            "explorer",
+            3,
+            True,
+            captured_at,
+            None,
+            "discovered",
+            "",
+        ),
     ]
     registry_entries = [
-        WalletRegistryEntry("w_core", "static_basket", "config.baskets", 1.0, "active", captured_at),
-        WalletRegistryEntry("w_low", "wallet_discovery", "polymarket_data_api", 0.45, "active", captured_at),
-        WalletRegistryEntry("w_high", "wallet_discovery", "polymarket_data_api", 0.8, "active", captured_at),
+        WalletRegistryEntry(
+            "w_core", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w_low",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.45,
+            "active",
+            captured_at,
+        ),
+        WalletRegistryEntry(
+            "w_high",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.8,
+            "active",
+            captured_at,
+        ),
     ]
     trades = [
         WalletTrade("w_core", "geopolitics", "m1", "YES", 0.5, 20.0, 120),
@@ -405,7 +463,9 @@ def test_build_live_basket_roster_flags_refresh_when_core_is_not_fresh_enough() 
         WalletTrade("w2", "geopolitics", "m2", "NO", 0.4, 15.0, 90_000),
     ]
 
-    roster = build_live_basket_roster(config, memberships, trades, captured_at=captured_at)
+    roster = build_live_basket_roster(
+        config, memberships, trades, captured_at=captured_at
+    )
 
     assert roster["geopolitics"]["selected_wallets"]["core"] == ["w1", "w2"]
     assert roster["geopolitics"]["fresh_core_wallet_count"] == 1
@@ -417,7 +477,9 @@ def test_build_live_basket_roster_flags_refresh_when_core_is_not_fresh_enough() 
     ]
 
 
-def test_build_live_basket_roster_limits_high_overlap_wallets_across_live_tiers() -> None:
+def test_build_live_basket_roster_limits_high_overlap_wallets_across_live_tiers() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     captured_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     config = replace(
@@ -460,7 +522,9 @@ def test_build_live_basket_roster_limits_high_overlap_wallets_across_live_tiers(
         WalletTrade("w3", "geopolitics", "m5", "YES", 0.55, 20.0, 45),
     ]
 
-    roster = build_live_basket_roster(config, memberships, trades, captured_at=captured_at)
+    roster = build_live_basket_roster(
+        config, memberships, trades, captured_at=captured_at
+    )
 
     live_wallets = (
         roster["geopolitics"]["selected_wallets"]["core"]
@@ -471,7 +535,9 @@ def test_build_live_basket_roster_limits_high_overlap_wallets_across_live_tiers(
     assert "w1" not in live_wallets
 
 
-def test_build_live_basket_roster_keeps_low_overlap_wallets_together_in_live_tiers() -> None:
+def test_build_live_basket_roster_keeps_low_overlap_wallets_together_in_live_tiers() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     captured_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     config = replace(
@@ -511,7 +577,9 @@ def test_build_live_basket_roster_keeps_low_overlap_wallets_together_in_live_tie
         WalletTrade("w3", "geopolitics", "m4", "YES", 0.54, 20.0, 30),
     ]
 
-    roster = build_live_basket_roster(config, memberships, trades, captured_at=captured_at)
+    roster = build_live_basket_roster(
+        config, memberships, trades, captured_at=captured_at
+    )
 
     live_wallets = (
         roster["geopolitics"]["selected_wallets"]["core"]
@@ -575,7 +643,9 @@ def test_build_live_basket_roster_reports_when_rotation_interval_is_due() -> Non
     assert roster["geopolitics"]["rotation_due"] is True
 
 
-def test_recommend_basket_promotions_flags_taxonomy_topic_ready_for_live_rollout() -> None:
+def test_recommend_basket_promotions_flags_taxonomy_topic_ready_for_live_rollout() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -601,7 +671,17 @@ def test_recommend_basket_promotions_flags_taxonomy_topic_ready_for_live_rollout
     )
     captured_at = datetime(2026, 1, 20, tzinfo=UTC)
     memberships = [
-        BasketMembership("esports", f"w{index}", tier, index, True, captured_at, None, "discovered", "")
+        BasketMembership(
+            "esports",
+            f"w{index}",
+            tier,
+            index,
+            True,
+            captured_at,
+            None,
+            "discovered",
+            "",
+        )
         for index, tier in enumerate(
             ["core", "core", "rotating", "backup", "explorer"],
             start=1,
@@ -615,7 +695,14 @@ def test_recommend_basket_promotions_flags_taxonomy_topic_ready_for_live_rollout
         WalletTrade("w5", "esports", "m5", "YES", 0.55, 20.0, 1_500),
     ]
     registry_entries = [
-        WalletRegistryEntry(f"w{index}", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at)
+        WalletRegistryEntry(
+            f"w{index}",
+            "wallet_discovery",
+            "curated_wallet_file",
+            0.8,
+            "active",
+            captured_at,
+        )
         for index in range(1, 6)
     ]
 
@@ -659,17 +746,29 @@ def test_recommend_basket_promotions_reports_threshold_gaps_for_thin_topic() -> 
     )
     captured_at = datetime(2026, 1, 20, tzinfo=UTC)
     memberships = [
-        BasketMembership("ai", "w1", "core", 1, True, captured_at, None, "discovered", ""),
-        BasketMembership("ai", "w2", "rotating", 2, True, captured_at, None, "discovered", ""),
-        BasketMembership("ai", "w3", "explorer", 3, True, captured_at, None, "discovered", ""),
+        BasketMembership(
+            "ai", "w1", "core", 1, True, captured_at, None, "discovered", ""
+        ),
+        BasketMembership(
+            "ai", "w2", "rotating", 2, True, captured_at, None, "discovered", ""
+        ),
+        BasketMembership(
+            "ai", "w3", "explorer", 3, True, captured_at, None, "discovered", ""
+        ),
     ]
     trades = [
         WalletTrade("w1", "ai", "m1", "YES", 0.51, 20.0, 300),
     ]
     registry_entries = [
-        WalletRegistryEntry("w1", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at),
-        WalletRegistryEntry("w2", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at),
-        WalletRegistryEntry("w3", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at),
+        WalletRegistryEntry(
+            "w1", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w2", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w3", "wallet_discovery", "curated_wallet_file", 0.8, "active", captured_at
+        ),
     ]
 
     recommendations = recommend_basket_promotions(
@@ -759,16 +858,69 @@ def test_build_live_basket_roster_excludes_probation_from_core_and_rotating() ->
     )
     captured_at = datetime(2026, 1, 20, 12, 0, tzinfo=UTC)
     memberships = [
-        BasketMembership("geopolitics", "w_probation", "core", 1, True, captured_at, None, "discovered", ""),
-        BasketMembership("geopolitics", "w_active_1", "core", 2, True, captured_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w_active_2", "rotating", 3, True, captured_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w_active_3", "backup", 4, True, captured_at, None, "seeded", ""),
+        BasketMembership(
+            "geopolitics",
+            "w_probation",
+            "core",
+            1,
+            True,
+            captured_at,
+            None,
+            "discovered",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_active_1",
+            "core",
+            2,
+            True,
+            captured_at,
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_active_2",
+            "rotating",
+            3,
+            True,
+            captured_at,
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_active_3",
+            "backup",
+            4,
+            True,
+            captured_at,
+            None,
+            "seeded",
+            "",
+        ),
     ]
     registry_entries = [
-        WalletRegistryEntry("w_probation", "wallet_discovery", "polymarket_data_api", 0.8, "probation", captured_at),
-        WalletRegistryEntry("w_active_1", "static_basket", "config.baskets", 1.0, "active", captured_at),
-        WalletRegistryEntry("w_active_2", "static_basket", "config.baskets", 1.0, "active", captured_at),
-        WalletRegistryEntry("w_active_3", "static_basket", "config.baskets", 1.0, "active", captured_at),
+        WalletRegistryEntry(
+            "w_probation",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.8,
+            "probation",
+            captured_at,
+        ),
+        WalletRegistryEntry(
+            "w_active_1", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w_active_2", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w_active_3", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
     ]
     trades = [
         WalletTrade("w_probation", "geopolitics", "m1", "YES", 0.58, 20.0, 60),
@@ -813,7 +965,9 @@ def test_build_live_basket_roster_excludes_probation_from_core_and_rotating() ->
     }
 
 
-def test_build_live_basket_roster_excludes_probation_from_backup_when_backup_is_live() -> None:
+def test_build_live_basket_roster_excludes_probation_from_backup_when_backup_is_live() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -830,16 +984,69 @@ def test_build_live_basket_roster_excludes_probation_from_backup_when_backup_is_
     )
     captured_at = datetime(2026, 1, 20, 12, 0, tzinfo=UTC)
     memberships = [
-        BasketMembership("geopolitics", "w_active_1", "core", 1, True, captured_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w_active_2", "rotating", 2, True, captured_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w_probation", "backup", 3, True, captured_at, None, "discovered", ""),
-        BasketMembership("geopolitics", "w_active_3", "explorer", 4, True, captured_at, None, "seeded", ""),
+        BasketMembership(
+            "geopolitics",
+            "w_active_1",
+            "core",
+            1,
+            True,
+            captured_at,
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_active_2",
+            "rotating",
+            2,
+            True,
+            captured_at,
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_probation",
+            "backup",
+            3,
+            True,
+            captured_at,
+            None,
+            "discovered",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w_active_3",
+            "explorer",
+            4,
+            True,
+            captured_at,
+            None,
+            "seeded",
+            "",
+        ),
     ]
     registry_entries = [
-        WalletRegistryEntry("w_active_1", "static_basket", "config.baskets", 1.0, "active", captured_at),
-        WalletRegistryEntry("w_active_2", "static_basket", "config.baskets", 1.0, "active", captured_at),
-        WalletRegistryEntry("w_probation", "wallet_discovery", "polymarket_data_api", 0.8, "probation", captured_at),
-        WalletRegistryEntry("w_active_3", "static_basket", "config.baskets", 1.0, "active", captured_at),
+        WalletRegistryEntry(
+            "w_active_1", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w_active_2", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
+        WalletRegistryEntry(
+            "w_probation",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.8,
+            "probation",
+            captured_at,
+        ),
+        WalletRegistryEntry(
+            "w_active_3", "static_basket", "config.baskets", 1.0, "active", captured_at
+        ),
     ]
     trades = [
         WalletTrade("w_active_1", "geopolitics", "m1", "YES", 0.58, 20.0, 60),
@@ -928,7 +1135,9 @@ def test_build_live_basket_roster_reports_cluster_and_slot_exclusions() -> None:
         WalletTrade("w4", "geopolitics", "m5", "YES", 0.55, 20.0, 180),
     ]
 
-    roster = build_live_basket_roster(config, memberships, trades, captured_at=captured_at)
+    roster = build_live_basket_roster(
+        config, memberships, trades, captured_at=captured_at
+    )
 
     decisions = {
         decision["wallet"]: decision
@@ -948,7 +1157,9 @@ def test_build_live_basket_roster_reports_cluster_and_slot_exclusions() -> None:
     ]
 
 
-def test_rebalance_memberships_from_live_roster_rewrites_tiers_and_deactivates_overflow() -> None:
+def test_rebalance_memberships_from_live_roster_rewrites_tiers_and_deactivates_overflow() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -1041,7 +1252,10 @@ def test_rebalance_memberships_from_live_roster_rewrites_tiers_and_deactivates_o
         "w3",
         "w2",
     ]
-    assert [(membership.wallet, membership.tier, membership.rank) for membership in updated[:4]] == [
+    assert [
+        (membership.wallet, membership.tier, membership.rank)
+        for membership in updated[:4]
+    ] == [
         ("w5", "core", 1),
         ("w4", "core", 2),
         ("w3", "rotating", 3),
@@ -1053,7 +1267,9 @@ def test_rebalance_memberships_from_live_roster_rewrites_tiers_and_deactivates_o
     assert overflow.demotion_reason == "dropped from live roster rebalance"
 
 
-def test_rebalance_memberships_from_live_roster_skips_churn_until_rotation_due() -> None:
+def test_rebalance_memberships_from_live_roster_skips_churn_until_rotation_due() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -1073,13 +1289,29 @@ def test_rebalance_memberships_from_live_roster_skips_churn_until_rotation_due()
     captured_at = datetime(2026, 1, 2, 12, 0, tzinfo=UTC)
     recent_joined_at = datetime(2026, 1, 2, 6, 0, tzinfo=UTC)
     store.registry_entries = [
-        WalletRegistryEntry(wallet, "static_basket", "config.baskets", 1.0, "active", recent_joined_at)
+        WalletRegistryEntry(
+            wallet, "static_basket", "config.baskets", 1.0, "active", recent_joined_at
+        )
         for wallet in ["w1", "w2", "w3"]
     ]
     store.memberships = [
-        BasketMembership("geopolitics", "w1", "core", 1, True, recent_joined_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w2", "rotating", 2, True, recent_joined_at, None, "seeded", ""),
-        BasketMembership("geopolitics", "w3", "backup", 3, True, recent_joined_at, None, "seeded", ""),
+        BasketMembership(
+            "geopolitics", "w1", "core", 1, True, recent_joined_at, None, "seeded", ""
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w2",
+            "rotating",
+            2,
+            True,
+            recent_joined_at,
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics", "w3", "backup", 3, True, recent_joined_at, None, "seeded", ""
+        ),
     ]
     trades = [
         WalletTrade("w3", "geopolitics", "m1", "YES", 0.6, 15.0, 60),
@@ -1095,7 +1327,10 @@ def test_rebalance_memberships_from_live_roster_skips_churn_until_rotation_due()
         captured_at=captured_at,
     )
 
-    assert [(membership.wallet, membership.tier, membership.rank, membership.active) for membership in updated] == [
+    assert [
+        (membership.wallet, membership.tier, membership.rank, membership.active)
+        for membership in updated
+    ] == [
         ("w1", "core", 1, True),
         ("w2", "rotating", 2, True),
         ("w3", "backup", 3, True),
@@ -1120,14 +1355,70 @@ def test_refresh_registry_entries_from_trades_updates_status_from_freshness() ->
     captured_at = datetime(2026, 1, 20, tzinfo=UTC)
     store = FakeStore()
     store.registry_entries = [
-        WalletRegistryEntry("w_active", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w_probation_age", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 18, tzinfo=UTC)),
-        WalletRegistryEntry("w_probation_count", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w_probation_quality", "wallet_discovery", "polymarket_data_api", 0.4, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w_discovered_active", "wallet_discovery", "polymarket_data_api", 0.7, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w_stale", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w_suspended", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w_retired", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
+        WalletRegistryEntry(
+            "w_active",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_probation_age",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 18, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_probation_count",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_probation_quality",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.4,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_discovered_active",
+            "wallet_discovery",
+            "polymarket_data_api",
+            0.7,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_stale",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_suspended",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w_retired",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
     ]
     trades = [
         WalletTrade("w_active", "geopolitics", "m1", "YES", 0.6, 15.0, 300),
@@ -1164,7 +1455,9 @@ def test_refresh_registry_entries_from_trades_updates_status_from_freshness() ->
     }
 
 
-def test_ingest_wallet_discovery_inputs_adds_registry_entries_and_explorer_memberships() -> None:
+def test_ingest_wallet_discovery_inputs_adds_registry_entries_and_explorer_memberships() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     captured_at = datetime(2026, 1, 20, tzinfo=UTC)
     store = FakeStore()
@@ -1247,7 +1540,9 @@ def test_ingest_wallet_discovery_inputs_adds_registry_entries_and_explorer_membe
     assert new_membership.joined_at == captured_at
 
 
-def test_apply_basket_manager_actions_to_memberships_adds_and_deactivates_registry_memberships() -> None:
+def test_apply_basket_manager_actions_to_memberships_adds_and_deactivates_registry_memberships() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     captured_at = datetime(2026, 1, 20, tzinfo=UTC)
     store = FakeStore()
@@ -1275,9 +1570,25 @@ def test_apply_basket_manager_actions_to_memberships_adds_and_deactivates_regist
         )
     ]
     actions = [
-        BasketManagerAction("add", "geopolitics", "w_new", 0.8, "HIGH", "auto-update eligible recommendation"),
-        BasketManagerAction("suspend", "geopolitics", "w_existing", 0.3, "LOW", "existing wallet confidence fell to LOW"),
-        BasketManagerAction("observe", "geopolitics", "w_observe", 0.2, "LOW", "observe only"),
+        BasketManagerAction(
+            "add",
+            "geopolitics",
+            "w_new",
+            0.8,
+            "HIGH",
+            "auto-update eligible recommendation",
+        ),
+        BasketManagerAction(
+            "suspend",
+            "geopolitics",
+            "w_existing",
+            0.3,
+            "LOW",
+            "existing wallet confidence fell to LOW",
+        ),
+        BasketManagerAction(
+            "observe", "geopolitics", "w_observe", 0.2, "LOW", "observe only"
+        ),
     ]
 
     memberships, diagnostics = apply_basket_manager_actions_to_memberships(
@@ -1321,7 +1632,9 @@ def test_apply_basket_manager_actions_to_memberships_adds_and_deactivates_regist
     assert new_membership.promotion_reason == "auto-update eligible recommendation"
 
 
-def test_rebalance_memberships_from_live_roster_demotes_stale_wallets_out_of_live_tiers() -> None:
+def test_rebalance_memberships_from_live_roster_demotes_stale_wallets_out_of_live_tiers() -> (
+    None
+):
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         config,
@@ -1346,16 +1659,84 @@ def test_rebalance_memberships_from_live_roster_demotes_stale_wallets_out_of_liv
     store = FakeStore()
     captured_at = datetime(2026, 1, 20, tzinfo=UTC)
     store.registry_entries = [
-        WalletRegistryEntry("w1", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w2", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w3", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
-        WalletRegistryEntry("w4", "static_basket", "config.baskets", 1.0, "active", datetime(2026, 1, 1, tzinfo=UTC)),
+        WalletRegistryEntry(
+            "w1",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w2",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w3",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w4",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
     ]
     store.memberships = [
-        BasketMembership("geopolitics", "w1", "core", 1, True, datetime(2026, 1, 1, tzinfo=UTC), None, "seeded", ""),
-        BasketMembership("geopolitics", "w2", "core", 2, True, datetime(2026, 1, 1, tzinfo=UTC), None, "seeded", ""),
-        BasketMembership("geopolitics", "w3", "rotating", 3, True, datetime(2026, 1, 1, tzinfo=UTC), None, "seeded", ""),
-        BasketMembership("geopolitics", "w4", "backup", 4, True, datetime(2026, 1, 1, tzinfo=UTC), None, "seeded", ""),
+        BasketMembership(
+            "geopolitics",
+            "w1",
+            "core",
+            1,
+            True,
+            datetime(2026, 1, 1, tzinfo=UTC),
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w2",
+            "core",
+            2,
+            True,
+            datetime(2026, 1, 1, tzinfo=UTC),
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w3",
+            "rotating",
+            3,
+            True,
+            datetime(2026, 1, 1, tzinfo=UTC),
+            None,
+            "seeded",
+            "",
+        ),
+        BasketMembership(
+            "geopolitics",
+            "w4",
+            "backup",
+            4,
+            True,
+            datetime(2026, 1, 1, tzinfo=UTC),
+            None,
+            "seeded",
+            "",
+        ),
     ]
     trades = [
         WalletTrade("w4", "geopolitics", "m1", "YES", 0.6, 15.0, 60),
@@ -1372,7 +1753,10 @@ def test_rebalance_memberships_from_live_roster_demotes_stale_wallets_out_of_liv
         captured_at=captured_at,
     )
 
-    assert [(membership.wallet, membership.tier, membership.rank, membership.active) for membership in updated] == [
+    assert [
+        (membership.wallet, membership.tier, membership.rank, membership.active)
+        for membership in updated
+    ] == [
         ("w4", "core", 1, True),
         ("w3", "core", 2, True),
         ("w2", "rotating", 3, True),


### PR DESCRIPTION
## What changed
- applied `ruff format` with Ruff `0.15.12` across the tracked Python files under `src/` and `tests/`
- keeps the earlier lint fixes in `src/predictcel/railway.py` and `tests/test_main.py` aligned with the formatter baseline GitHub is enforcing

## Why
- `ruff check` is now green, but GitHub CI still blocks on `ruff format --check src/ tests/`
- the latest `main` lint log showed 38 tracked files that would be reformatted, so the remaining deploy blocker is formatter drift rather than logic or test failures

## Validation
- `.
.tools\ruff\ruff-0.15.12\ruff.exe check src/ tests/`
- `.
.tools\ruff\ruff-0.15.12\ruff.exe format --check src/ tests/`
- `py -3 -m pytest tests/test_main.py tests/test_config.py::test_example_config_loads tests/test_wallet_registry.py -p no:cacheprovider`