### PR TITLE
[codex] backfill missing static basket bootstrap

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -727,9 +727,6 @@ def _ensure_static_registry_bootstrap(
     *,
     captured_at: datetime,
 ) -> list[WalletRegistryEntry]:
-    if any(entry.source_type == "static_basket" for entry in existing_entries):
-        return existing_entries
-
     entries_by_wallet = {entry.wallet: entry for entry in existing_entries}
     updated_entries = list(existing_entries)
     for basket in config.baskets:
@@ -765,18 +762,24 @@ def _ensure_static_membership_bootstrap(
     *,
     captured_at: datetime,
 ) -> list[BasketMembership]:
-    if existing_memberships and any(
-        membership.promotion_reason != "wallet discovery assignment"
+    locked_topics = {
+        membership.topic
         for membership in existing_memberships
-    ):
-        return existing_memberships
-
+        if membership.promotion_reason
+        not in {
+            "",
+            "seeded from static basket config",
+            "wallet discovery assignment",
+        }
+    }
     memberships_by_key = {
         (membership.topic, membership.wallet): membership
         for membership in existing_memberships
     }
     updated_memberships = list(existing_memberships)
     for basket in config.baskets:
+        if basket.topic in locked_topics:
+            continue
         for rank, wallet in enumerate(basket.wallets, start=1):
             normalized_wallet = str(wallet).strip()
             membership_key = (basket.topic, normalized_wallet)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1235,9 +1235,7 @@ def test_build_wallet_registry_summary_keeps_memberships_read_only() -> None:
     }
 
 
-def test_build_wallet_registry_summary_does_not_reseed_manually_curated_topic() -> (
-    None
-):
+def test_build_wallet_registry_summary_does_not_reseed_manually_curated_topic() -> None:
     base_config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         base_config,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1235,10 +1235,16 @@ def test_build_wallet_registry_summary_keeps_memberships_read_only() -> None:
     }
 
 
-def test_build_wallet_registry_summary_does_not_reseed_existing_memberships() -> None:
+def test_build_wallet_registry_summary_does_not_reseed_manually_curated_topic() -> (
+    None
+):
     base_config = load_config(Path("config/predictcel.example.json"))
     config = replace(
         base_config,
+        baskets=[
+            BasketRule("geopolitics", ["w1", "w2"], 0.8, 0.5),
+            BasketRule("macro-financial", ["w3"], 0.8, 0.5),
+        ],
         wallet_registry=replace(
             base_config.wallet_registry, enabled=True, seed_from_baskets=True
         ),
@@ -1274,6 +1280,7 @@ def test_build_wallet_registry_summary_does_not_reseed_existing_memberships() ->
 
     assert [
         (
+            membership.topic,
             membership.wallet,
             membership.tier,
             membership.rank,
@@ -1281,7 +1288,14 @@ def test_build_wallet_registry_summary_does_not_reseed_existing_memberships() ->
         )
         for membership in store.memberships
     ] == [
-        ("w1", "explorer", 7, "manual override"),
+        ("geopolitics", "w1", "explorer", 7, "manual override"),
+        (
+            "macro-financial",
+            "w3",
+            "core",
+            1,
+            "seeded from static basket config",
+        ),
     ]
 
 
@@ -1387,6 +1401,76 @@ def test_build_wallet_registry_summary_refreshes_registry_statuses_from_trade_fr
         "w_active": "active",
         "w_probation": "probation",
         "w_stale": "stale",
+    }
+
+
+def test_build_wallet_registry_summary_backfills_missing_static_baskets_into_existing_store() -> (
+    None
+):
+    config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        config,
+        baskets=[
+            BasketRule("geopolitics", ["w1", "w2"], 0.8, 0.5),
+            BasketRule("macro-financial", ["w3"], 0.8, 0.5),
+        ],
+        wallet_registry=replace(
+            config.wallet_registry,
+            enabled=True,
+            seed_from_baskets=True,
+        ),
+    )
+    first_seen_at = datetime(2026, 1, 1, tzinfo=UTC)
+    store = RegistrySummaryStore(
+        registry_entries=[
+            WalletRegistryEntry(
+                wallet="w1",
+                source_type="static_basket",
+                source_ref="config.baskets",
+                trust_seed=1.0,
+                status="active",
+                first_seen_at=first_seen_at,
+            )
+        ],
+        memberships=[
+            BasketMembership(
+                topic="geopolitics",
+                wallet="w1",
+                tier="core",
+                rank=1,
+                active=True,
+                joined_at=first_seen_at,
+                effective_until=None,
+                promotion_reason="seeded from static basket config",
+                demotion_reason="",
+            )
+        ],
+    )
+
+    summary = _build_wallet_registry_summary(config, store, [])
+
+    assert {entry.wallet for entry in store.registry_entries} == {"w1", "w2", "w3"}
+    assert [
+        (membership.topic, membership.wallet, membership.tier, membership.rank)
+        for membership in store.memberships
+    ] == [
+        ("geopolitics", "w1", "core", 1),
+        ("geopolitics", "w2", "core", 2),
+        ("macro-financial", "w3", "core", 1),
+    ]
+    assert summary["memberships_by_topic"] == {
+        "geopolitics": {
+            "core": 2,
+            "rotating": 0,
+            "backup": 0,
+            "explorer": 0,
+        },
+        "macro-financial": {
+            "core": 1,
+            "rotating": 0,
+            "backup": 0,
+            "explorer": 0,
+        },
     }
 
 


### PR DESCRIPTION
## What changed
- backfill missing static basket registry entries from config even when a persistent DB already has older seeded rows
- backfill missing static basket memberships for unseeded topics without overwriting manually curated topics
- add regression coverage for persistent-store backfill and manual topic preservation

## Why
A persistent production DB could keep the older basket roster forever because bootstrap stopped as soon as it saw any existing static seed. That prevented newer basket config from taking effect after deploy.

## Validation
- py -3 -m pytest tests/test_wallet_registry.py tests/test_config.py::test_example_config_loads tests/test_main.py -k wallet_registry -p no:cacheprovider