### PR TITLE
[codex] keep static basket wallets live eligible

### DIFF
--- a/src/predictcel/wallet_registry.py
+++ b/src/predictcel/wallet_registry.py
@@ -949,6 +949,8 @@ def _registry_status_from_freshness(
         return "suspended"
     if freshest_age_seconds > config.wallet_registry.stale_after_hours * 3_600:
         return "stale"
+    if entry.source_type == "static_basket":
+        return "active"
 
     probation_age_days = (captured_at - entry.first_seen_at).total_seconds() / 86_400
     if (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1397,7 +1397,7 @@ def test_build_wallet_registry_summary_refreshes_registry_statuses_from_trade_fr
 
     assert {entry.wallet: entry.status for entry in store.registry_entries} == {
         "w_active": "active",
-        "w_probation": "probation",
+        "w_probation": "active",
         "w_stale": "stale",
     }
 

--- a/tests/test_wallet_registry.py
+++ b/tests/test_wallet_registry.py
@@ -1445,8 +1445,8 @@ def test_refresh_registry_entries_from_trades_updates_status_from_freshness() ->
     statuses = {entry.wallet: entry.status for entry in updated}
     assert statuses == {
         "w_active": "active",
-        "w_probation_age": "probation",
-        "w_probation_count": "probation",
+        "w_probation_age": "active",
+        "w_probation_count": "active",
         "w_probation_quality": "probation",
         "w_discovered_active": "active",
         "w_stale": "stale",


### PR DESCRIPTION
## What changed
- keep fresh static_basket registry entries ctive instead of forcing them through discovery-style probation gates
- update registry summary and status-refresh regression expectations to match the seeded-live basket policy

## Why
The deployment backfilled the new basket config correctly, but live rosters still had empty core and otating slots because freshly seeded config wallets were being marked probation. That blocked them from live consensus immediately after deploy.

## Validation
- py -3 -m pytest tests/test_wallet_registry.py tests/test_main.py -k 'wallet_registry or build_live_basket_roster' -p no:cacheprovider
- .\\.tools\\ruff\\ruff-0.15.12\\ruff.exe check src/ tests/
- .\\.tools\\ruff\\ruff-0.15.12\\ruff.exe format --check src/ tests/