### PR TITLE
[codex] promote config basket wallets into static registry

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -729,28 +729,55 @@ def _ensure_static_registry_bootstrap(
 ) -> list[WalletRegistryEntry]:
     entries_by_wallet = {entry.wallet: entry for entry in existing_entries}
     updated_entries = list(existing_entries)
+    updated = False
     for basket in config.baskets:
         for wallet in basket.wallets:
             normalized_wallet = str(wallet).strip()
-            if not normalized_wallet or normalized_wallet in entries_by_wallet:
+            if not normalized_wallet:
                 continue
-            updated_entries.append(
-                WalletRegistryEntry(
-                    wallet=normalized_wallet,
-                    source_type="static_basket",
-                    source_ref="config.baskets",
-                    trust_seed=1.0,
-                    status="active",
-                    first_seen_at=captured_at,
-                    last_seen_trade_at=None,
-                    last_scored_at=None,
-                    notes="seeded from static basket config",
+            existing_entry = entries_by_wallet.get(normalized_wallet)
+            if existing_entry is None:
+                updated_entries.append(
+                    WalletRegistryEntry(
+                        wallet=normalized_wallet,
+                        source_type="static_basket",
+                        source_ref="config.baskets",
+                        trust_seed=1.0,
+                        status="active",
+                        first_seen_at=captured_at,
+                        last_seen_trade_at=None,
+                        last_scored_at=None,
+                        notes="seeded from static basket config",
+                    )
                 )
+                entries_by_wallet[normalized_wallet] = updated_entries[-1]
+                updated = True
+                continue
+
+            if (
+                existing_entry.source_type == "static_basket"
+                and existing_entry.source_ref == "config.baskets"
+                and existing_entry.trust_seed == 1.0
+            ):
+                continue
+
+            entries_by_wallet[normalized_wallet] = WalletRegistryEntry(
+                wallet=existing_entry.wallet,
+                source_type="static_basket",
+                source_ref="config.baskets",
+                trust_seed=1.0,
+                status=existing_entry.status,
+                first_seen_at=existing_entry.first_seen_at,
+                last_seen_trade_at=existing_entry.last_seen_trade_at,
+                last_scored_at=existing_entry.last_scored_at,
+                notes=existing_entry.notes,
             )
-            entries_by_wallet[normalized_wallet] = updated_entries[-1]
-    if len(updated_entries) == len(existing_entries):
+            updated = True
+
+    if not updated:
         return existing_entries
-    updated_entries.sort(key=lambda entry: entry.wallet)
+
+    updated_entries = sorted(entries_by_wallet.values(), key=lambda entry: entry.wallet)
     store.upsert_wallet_registry_entries(updated_entries)
     return updated_entries
 
@@ -776,17 +803,18 @@ def _ensure_static_membership_bootstrap(
         (membership.topic, membership.wallet): membership
         for membership in existing_memberships
     }
-    updated_memberships = list(existing_memberships)
+    updated = False
     for basket in config.baskets:
         if basket.topic in locked_topics:
             continue
         for rank, wallet in enumerate(basket.wallets, start=1):
             normalized_wallet = str(wallet).strip()
             membership_key = (basket.topic, normalized_wallet)
-            if not normalized_wallet or membership_key in memberships_by_key:
+            if not normalized_wallet:
                 continue
-            updated_memberships.append(
-                BasketMembership(
+            existing_membership = memberships_by_key.get(membership_key)
+            if existing_membership is None:
+                memberships_by_key[membership_key] = BasketMembership(
                     topic=basket.topic,
                     wallet=normalized_wallet,
                     tier="core",
@@ -797,12 +825,31 @@ def _ensure_static_membership_bootstrap(
                     promotion_reason="seeded from static basket config",
                     demotion_reason="",
                 )
+                updated = True
+                continue
+
+            normalized_membership = BasketMembership(
+                topic=existing_membership.topic,
+                wallet=existing_membership.wallet,
+                tier="core",
+                rank=rank,
+                active=True,
+                joined_at=existing_membership.joined_at,
+                effective_until=None,
+                promotion_reason="seeded from static basket config",
+                demotion_reason="",
             )
-            memberships_by_key[membership_key] = updated_memberships[-1]
-    if len(updated_memberships) == len(existing_memberships):
+            if normalized_membership == existing_membership:
+                continue
+            memberships_by_key[membership_key] = normalized_membership
+            updated = True
+
+    if not updated:
         return existing_memberships
-    updated_memberships.sort(
-        key=lambda membership: (membership.topic, membership.rank, membership.wallet)
+
+    updated_memberships = sorted(
+        memberships_by_key.values(),
+        key=lambda membership: (membership.topic, membership.rank, membership.wallet),
     )
     store.upsert_basket_memberships(updated_memberships)
     return updated_memberships

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1472,6 +1472,123 @@ def test_build_wallet_registry_summary_backfills_missing_static_baskets_into_exi
     }
 
 
+def test_build_wallet_registry_summary_promotes_discovery_registry_entry_into_static_basket() -> (
+    None
+):
+    base_config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        base_config,
+        baskets=[
+            BasketRule(topic="geopolitics", wallets=["w_promoted"], quorum_ratio=0.66)
+        ],
+        wallet_registry=replace(
+            base_config.wallet_registry,
+            enabled=True,
+            seed_from_baskets=True,
+        ),
+        filters=replace(base_config.filters, max_trade_age_seconds=3600),
+    )
+    first_seen_at = datetime(2026, 1, 1, tzinfo=UTC)
+    store = RegistrySummaryStore(
+        registry_entries=[
+            WalletRegistryEntry(
+                wallet="w_promoted",
+                source_type="wallet_discovery",
+                source_ref="polymarket_data_api",
+                trust_seed=0.62,
+                status="probation",
+                first_seen_at=first_seen_at,
+            )
+        ],
+        memberships=[],
+    )
+
+    _build_wallet_registry_summary(
+        config,
+        store,
+        [WalletTrade("w_promoted", "geopolitics", "m1", "YES", 0.6, 10.0, 300)],
+    )
+
+    assert len(store.registry_entries) == 1
+    entry = store.registry_entries[0]
+    assert entry.wallet == "w_promoted"
+    assert entry.source_type == "static_basket"
+    assert entry.source_ref == "config.baskets"
+    assert entry.trust_seed == 1.0
+    assert entry.first_seen_at == first_seen_at
+    assert entry.status == "active"
+    assert entry.last_scored_at is not None
+    assert entry.last_seen_trade_at is not None
+
+
+def test_build_wallet_registry_summary_reactivates_config_membership_from_discovery_assignment() -> (
+    None
+):
+    base_config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        base_config,
+        baskets=[BasketRule(topic="geopolitics", wallets=["w1"], quorum_ratio=0.66)],
+        wallet_registry=replace(
+            base_config.wallet_registry,
+            enabled=True,
+            seed_from_baskets=True,
+        ),
+    )
+    first_seen_at = datetime(2026, 1, 1, tzinfo=UTC)
+    store = RegistrySummaryStore(
+        registry_entries=[
+            WalletRegistryEntry(
+                wallet="w1",
+                source_type="wallet_discovery",
+                source_ref="polymarket_data_api",
+                trust_seed=0.8,
+                status="probation",
+                first_seen_at=first_seen_at,
+            )
+        ],
+        memberships=[
+            BasketMembership(
+                topic="geopolitics",
+                wallet="w1",
+                tier="explorer",
+                rank=9,
+                active=False,
+                joined_at=first_seen_at,
+                effective_until=first_seen_at,
+                promotion_reason="wallet discovery assignment",
+                demotion_reason="aged out",
+            )
+        ],
+    )
+
+    _build_wallet_registry_summary(config, store, [])
+
+    assert [
+        (
+            membership.topic,
+            membership.wallet,
+            membership.tier,
+            membership.rank,
+            membership.active,
+            membership.promotion_reason,
+            membership.demotion_reason,
+            membership.effective_until,
+        )
+        for membership in store.memberships
+    ] == [
+        (
+            "geopolitics",
+            "w1",
+            "core",
+            1,
+            True,
+            "seeded from static basket config",
+            "",
+            None,
+        )
+    ]
+
+
 def test_build_wallet_registry_summary_flags_bench_depth_when_explorer_wallets_exist_but_live_roster_is_thin() -> (
     None
 ):


### PR DESCRIPTION
## What changed
- when a wallet already exists in the registry but is now explicitly present in config.baskets, normalize its registry identity to static_basket / config.baskets
- reactivate and normalize existing topic memberships back to active core when config now explicitly seeds that wallet, unless the topic is manually locked
- add regression coverage for config promotion of discovery entries and inactive discovery memberships

## Why
After the earlier live-eligibility patch, several baskets were still thin because promoted wallets kept discovery identity and probation-style behavior even after being added to the static live basket config.

## Validation
- py -3 -m pytest tests/test_wallet_registry.py tests/test_main.py -k 'wallet_registry or build_live_basket_roster' -p no:cacheprovider
- .\\.tools\\ruff\\ruff-0.15.12\\ruff.exe check src/ tests/
- .\\.tools\\ruff\\ruff-0.15.12\\ruff.exe format --check src/ tests/