### PR TITLE
Fix live roster and market scoring attrition

### DIFF
--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -248,6 +248,8 @@ class CopyEngine:
     ) -> str:
         market = markets.get(market_id)
         if market is None:
+            market = markets.get(str(market_id).strip().lower())
+        if market is None:
             return market_id
         return market.market_id
 

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -40,6 +40,7 @@ from .wallet_registry import (
     build_live_basket_roster,
     compute_basket_health_from_static_memberships,
     ingest_wallet_discovery_inputs,
+    rebalance_memberships_from_live_roster,
     recommend_basket_promotions,
     refresh_registry_entries_from_trades,
 )
@@ -180,7 +181,12 @@ def main() -> None:
     wallet_discovery_auto_feed = _auto_feed_wallet_registry_from_discovery(
         config, store
     )
-    wallet_registry_summary = _build_wallet_registry_summary(config, store, trades)
+    wallet_registry_summary = _build_wallet_registry_summary(
+        config,
+        store,
+        trades,
+        persist_rebalance=True,
+    )
     wallet_registry_summary["auto_feed"] = wallet_discovery_auto_feed
     open_positions_at_start = store.get_open_positions()
     db_diagnostics = {
@@ -210,6 +216,8 @@ def main() -> None:
         "rejection_counts": scorer.last_rejection_counts,
         "wallet_rejection_counts": scorer.last_wallet_rejection_counts,
         "missing_market_samples": scorer.last_missing_market_samples,
+        "missing_market_breakdown": scorer.last_missing_market_breakdown,
+        "wallet_attrition": scorer.last_wallet_attrition,
     }
     timings["wallet_scoring_ms"] = _elapsed_ms(started)
 
@@ -607,17 +615,32 @@ def _wallet_topics_for_live_inputs(
         and hasattr(store, "load_basket_memberships")
     ):
         memberships = store.load_basket_memberships()
+        registry_status_by_wallet = {}
+        if hasattr(store, "load_wallet_registry_entries"):
+            registry_status_by_wallet = {
+                entry.wallet: str(entry.status).strip().lower() or "active"
+                for entry in store.load_wallet_registry_entries()
+            }
         raw_topic_by_wallet: dict[str, list[str]] = {}
+        saw_registry_membership = False
         for membership in memberships:
             if not getattr(membership, "active", False):
                 continue
             wallet = str(membership.wallet).strip()
             if not _is_evm_address(wallet):
                 continue
+            saw_registry_membership = True
+            registry_status = registry_status_by_wallet.get(wallet, "active")
+            if registry_status in {"suspended", "retired"}:
+                continue
+            if registry_status == "stale" and str(
+                getattr(membership, "tier", "")
+            ).strip().lower() in {"core", "rotating"}:
+                continue
             topics = raw_topic_by_wallet.setdefault(wallet, [])
             if membership.topic not in topics:
                 topics.append(membership.topic)
-        if raw_topic_by_wallet:
+        if raw_topic_by_wallet or saw_registry_membership:
             return raw_topic_by_wallet, "registry_memberships"
 
     raw_topic_by_wallet = {}
@@ -636,6 +659,7 @@ def _build_wallet_registry_summary(
     config: Any,
     store: SignalStore,
     trades: list[Any],
+    persist_rebalance: bool = False,
 ) -> dict[str, Any]:
     """Build compact wallet registry diagnostics without changing trading behavior."""
     if not getattr(config.wallet_registry, "enabled", False):
@@ -676,10 +700,22 @@ def _build_wallet_registry_summary(
         or existing_registry_entries
     )
     memberships = store.load_basket_memberships() or existing_memberships
+    if persist_rebalance:
+        memberships = (
+            rebalance_memberships_from_live_roster(
+                config,
+                store,
+                trades,
+                captured_at=captured_at,
+            )
+            or memberships
+        )
+        memberships = store.load_basket_memberships() or memberships
     basket_health = compute_basket_health_from_static_memberships(
         config,
         memberships,
         trades,
+        registry_entries=registry_entries,
         captured_at=captured_at,
     )
     live_roster = build_live_basket_roster(
@@ -1470,6 +1506,15 @@ def _compact_scoring_diagnostics(diagnostics: dict[str, Any]) -> dict[str, Any]:
         "rejection_counts": diagnostics.get("rejection_counts", {}),
         "wallets_with_rejections": len(wallet_rejection_counts),
     }
+    wallet_attrition = diagnostics.get("wallet_attrition", {})
+    if wallet_attrition:
+        compact["wallet_attrition"] = wallet_attrition
+    missing_market_breakdown = diagnostics.get("missing_market_breakdown", {})
+    if missing_market_breakdown:
+        compact["missing_market_breakdown"] = missing_market_breakdown
+    missing_market_samples = diagnostics.get("missing_market_samples", [])
+    if missing_market_samples:
+        compact["missing_market_samples"] = missing_market_samples
     if top_wallet_rejections:
         compact["top_wallet_rejections"] = top_wallet_rejections
     return compact

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -174,6 +174,16 @@ class PolymarketPublicClient:
         )
         return payload if isinstance(payload, dict) else {}
 
+    def fetch_event_by_slug(self, slug: str) -> dict[str, Any]:
+        """Fetch event by slug."""
+        normalized_slug = str(slug).strip()
+        if not normalized_slug:
+            return {}
+        payload = self._get_json(
+            f"{self.gamma_base_url}/events/slug/{quote(normalized_slug, safe='')}"
+        )
+        return payload if isinstance(payload, dict) else {}
+
     def fetch_markets_by_slugs(
         self, slugs: list[str], max_workers: int = 8
     ) -> list[dict[str, Any]]:
@@ -194,17 +204,30 @@ class PolymarketPublicClient:
                 for slug in unique_slugs
             }
             for future in as_completed(futures):
+                slug = futures[future]
                 try:
                     payload = future.result()
                 except Exception as e:
-                    logger.debug(
-                        f"Failed to fetch market for slug {futures[future]}: {e}"
-                    )
+                    logger.debug(f"Failed to fetch market for slug {slug}: {e}")
                     continue
 
                 rows = _extract_list(payload)
-                if not rows and payload:
+                if (
+                    not rows
+                    and isinstance(payload, dict)
+                    and any(
+                        payload.get(key) is not None and str(payload.get(key)).strip()
+                        for key in ("conditionId", "condition_id", "id", "slug")
+                    )
+                ):
                     rows = [payload]
+                if not rows:
+                    try:
+                        event_payload = self.fetch_event_by_slug(slug)
+                    except Exception as e:
+                        logger.debug(f"Failed to fetch event for slug {slug}: {e}")
+                    else:
+                        rows = _extract_list(event_payload)
 
                 for row in rows:
                     key = str(
@@ -848,8 +871,25 @@ def _trade_market_id(item: dict[str, Any]) -> str:
         "clob_token_id",
     ):
         value = item.get(key)
+        if isinstance(value, dict):
+            continue
         if value is not None and str(value).strip():
             return str(value).strip()
+
+    nested_market = item.get("market")
+    if isinstance(nested_market, dict):
+        for key in (
+            "conditionId",
+            "condition_id",
+            "conditionID",
+            "condition",
+            "market_id",
+            "marketId",
+            "id",
+        ):
+            value = nested_market.get(key)
+            if value is not None and str(value).strip():
+                return str(value).strip()
     return ""
 
 

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -45,6 +45,8 @@ class WalletQualityScorer:
         self.last_rejection_counts: dict[str, int] = {}
         self.last_wallet_rejection_counts: dict[str, dict[str, int]] = {}
         self.last_missing_market_samples: list[str] = []
+        self.last_missing_market_breakdown: dict[str, int] = {}
+        self.last_wallet_attrition: dict[str, int] = {}
 
     def score(
         self, trades: list[WalletTrade], markets: dict[str, MarketSnapshot]
@@ -65,6 +67,8 @@ class WalletQualityScorer:
         rejection_counts: Counter[str] = Counter()
         wallet_rejections: dict[str, Counter[str]] = defaultdict(Counter)
         missing_market_samples: list[str] = []
+        missing_market_breakdown: Counter[str] = Counter()
+        market_lookup = _build_market_lookup(markets)
 
         for trade in trades:
             grouped[trade.wallet].append(trade)
@@ -73,7 +77,9 @@ class WalletQualityScorer:
         for wallet, wallet_trades in grouped.items():
             eligible = []
             for trade in _dedupe_wallet_trades(wallet_trades):
-                reason = self.rejection_reason(trade, markets)
+                reason = self.rejection_reason(
+                    trade, markets, market_lookup=market_lookup
+                )
                 if reason is None:
                     eligible.append(trade)
                 else:
@@ -85,6 +91,10 @@ class WalletQualityScorer:
                         and len(missing_market_samples) < 10
                     ):
                         missing_market_samples.append(trade.market_id)
+                    if reason == "missing_market":
+                        missing_market_breakdown[
+                            _classify_missing_market_id(trade.market_id)
+                        ] += 1
 
             if not eligible:
                 continue
@@ -92,9 +102,11 @@ class WalletQualityScorer:
             topic = Counter(trade.topic for trade in eligible).most_common(1)[0][0]
             average_age = sum(trade.age_seconds for trade in eligible) / len(eligible)
             drifts = [
-                self._trade_drift(trade, markets[trade.market_id])
+                self._trade_drift(
+                    trade, _resolve_market(trade.market_id, market_lookup)
+                )
                 for trade in eligible
-                if trade.market_id in markets
+                if _resolve_market(trade.market_id, market_lookup) is not None
             ]
             average_drift = (
                 sum(drifts) / len(drifts) if drifts else self.filters.max_price_drift
@@ -149,10 +161,22 @@ class WalletQualityScorer:
             for wallet, counts in sorted(wallet_rejections.items())
         }
         self.last_missing_market_samples = missing_market_samples
+        self.last_missing_market_breakdown = dict(
+            sorted(missing_market_breakdown.items())
+        )
+        self.last_wallet_attrition = {
+            "wallets_seen": len(grouped),
+            "wallets_scored": len(scores),
+            "wallets_fully_rejected": max(0, len(grouped) - len(scores)),
+        }
         return scores
 
     def rejection_reason(
-        self, trade: WalletTrade, markets: dict[str, MarketSnapshot]
+        self,
+        trade: WalletTrade,
+        markets: dict[str, MarketSnapshot],
+        *,
+        market_lookup: dict[str, MarketSnapshot] | None = None,
     ) -> str | None:
         """Determine why a trade is ineligible, if it is.
 
@@ -163,7 +187,12 @@ class WalletQualityScorer:
         Returns:
             Rejection reason string, or None if trade is eligible
         """
-        market = markets.get(trade.market_id)
+        market = _resolve_market(
+            trade.market_id,
+            market_lookup
+            if market_lookup is not None
+            else _build_market_lookup(markets),
+        )
         if market is None:
             return "missing_market"
         if trade.age_seconds > self.filters.max_trade_age_seconds:
@@ -292,6 +321,51 @@ def compute_copyability_score(
         + depth_score * 0.05
     )
     return round(score, 4)
+
+
+def _normalize_market_lookup_key(value: str) -> str:
+    return str(value).strip().lower()
+
+
+def _build_market_lookup(
+    markets: dict[str, MarketSnapshot],
+) -> dict[str, MarketSnapshot]:
+    lookup: dict[str, MarketSnapshot] = {}
+    for market_id, snapshot in markets.items():
+        normalized_key = _normalize_market_lookup_key(market_id)
+        if normalized_key:
+            lookup.setdefault(normalized_key, snapshot)
+        canonical_key = _normalize_market_lookup_key(snapshot.market_id)
+        if canonical_key:
+            lookup.setdefault(canonical_key, snapshot)
+    return lookup
+
+
+def _resolve_market(
+    market_id: str,
+    market_lookup: dict[str, MarketSnapshot],
+) -> MarketSnapshot | None:
+    normalized_key = _normalize_market_lookup_key(market_id)
+    if not normalized_key:
+        return None
+    return market_lookup.get(normalized_key)
+
+
+def _classify_missing_market_id(market_id: str) -> str:
+    normalized = _normalize_market_lookup_key(market_id)
+    if not normalized:
+        return "empty"
+    if normalized.startswith("0x") or "token" in normalized:
+        return "token_id_like"
+    if "-" in normalized:
+        return "slug_like"
+    if (
+        normalized.startswith("cond")
+        or normalized.startswith("condition")
+        or "_" in normalized
+    ):
+        return "condition_id_like"
+    return "other"
 
 
 def _dedupe_wallet_trades(trades: list[WalletTrade]) -> list[WalletTrade]:

--- a/src/predictcel/wallet_registry.py
+++ b/src/predictcel/wallet_registry.py
@@ -186,6 +186,7 @@ def compute_basket_health_from_static_memberships(
     config: AppConfig,
     memberships: Iterable[BasketMembership],
     trades: Iterable[WalletTrade],
+    registry_entries: Iterable[WalletRegistryEntry] | None = None,
     captured_at: datetime | None = None,
 ) -> list[BasketHealth]:
     """Compute lightweight health diagnostics for seeded basket memberships."""
@@ -199,6 +200,11 @@ def compute_basket_health_from_static_memberships(
     for trade in trades:
         trades_by_topic_wallet[(trade.topic, trade.wallet)].append(trade)
 
+    registry_status_by_wallet = {
+        entry.wallet: str(entry.status).strip().lower() or "active"
+        for entry in (registry_entries or [])
+    }
+
     health_snapshots: list[BasketHealth] = []
     for topic in sorted(active_memberships_by_topic):
         topic_memberships = active_memberships_by_topic[topic]
@@ -211,20 +217,22 @@ def compute_basket_health_from_static_memberships(
 
         for membership in topic_memberships:
             wallet_trades = trades_by_topic_wallet.get((topic, membership.wallet), [])
+            registry_status = registry_status_by_wallet.get(membership.wallet, "active")
             has_trade_24h = any(trade.age_seconds <= 86_400 for trade in wallet_trades)
             has_trade_7d = any(trade.age_seconds <= 604_800 for trade in wallet_trades)
             has_eligible_trade = any(
                 trade.age_seconds <= config.filters.max_trade_age_seconds
                 for trade in wallet_trades
             )
+            is_live_eligible_status = registry_status == "active"
 
-            if membership.tier == "core" and has_trade_24h:
+            if membership.tier == "core" and is_live_eligible_status and has_trade_24h:
                 fresh_core_wallets_24h += 1
-            if has_trade_7d:
+            if is_live_eligible_status and has_trade_7d:
                 fresh_active_wallets_7d += 1
             else:
                 stale_wallet_count += 1
-            if has_eligible_trade:
+            if is_live_eligible_status and has_eligible_trade:
                 active_eligible_wallet_count += 1
 
             eligible_trades_7d += sum(

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -286,6 +286,42 @@ def test_mixed_market_aliases_share_one_consensus_bucket() -> None:
     assert engine.last_diagnostics["candidates_returned"] == 1
 
 
+def test_market_alias_matching_is_case_insensitive_for_token_ids() -> None:
+    engine = CopyEngine(make_config())
+    market = replace(make_market(), market_id="cond_1", yes_token_id="token_yes")
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="geopolitics",
+            market_id="TOKEN_YES",
+            side="YES",
+            price=0.58,
+            size_usd=200,
+            age_seconds=600,
+        ),
+        WalletTrade(
+            wallet="w2",
+            topic="geopolitics",
+            market_id="cond_1",
+            side="YES",
+            price=0.6,
+            size_usd=220,
+            age_seconds=800,
+        ),
+    ]
+
+    candidates = engine.evaluate(
+        trades,
+        {"cond_1": market, "token_yes": market},
+        make_qualities(),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].market_id == "cond_1"
+    assert engine.last_diagnostics["markets_evaluated"] == 1
+    assert engine.last_diagnostics["market_not_found"] == 0
+
+
 def test_skips_candidate_when_drift_is_too_large() -> None:
     engine = CopyEngine(make_config())
     trades = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ from predictcel import discover_wallets
 from predictcel.main import (
     _auto_feed_wallet_registry_from_discovery,
     _build_wallet_registry_summary,
+    _compact_scoring_diagnostics,
     _compact_cycle_output,
     _creates_or_updates_paper_position,
     _filter_duplicate_candidates,
@@ -328,6 +329,52 @@ def test_wallet_topics_for_live_inputs_prefers_active_registry_memberships() -> 
 
     assert source == "registry_memberships"
     assert wallet_topics == {registry_wallet: ["sports"]}
+
+
+def test_wallet_topics_for_live_inputs_skips_ineligible_registry_statuses() -> None:
+    registry_wallet = "0x1111111111111111111111111111111111111111"
+    static_wallet = "0x2222222222222222222222222222222222222222"
+    config = replace(
+        load_config(Path("config/predictcel.example.json")),
+        baskets=[
+            BasketRule(topic="sports", wallets=[static_wallet], quorum_ratio=0.66)
+        ],
+        wallet_registry=replace(
+            load_config(Path("config/predictcel.example.json")).wallet_registry,
+            enabled=True,
+            seed_from_baskets=False,
+        ),
+    )
+    store = DiscoveryStore(
+        registry_entries=[
+            WalletRegistryEntry(
+                wallet=registry_wallet,
+                source_type="static_basket",
+                source_ref="config.baskets",
+                trust_seed=1.0,
+                status="suspended",
+                first_seen_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        ],
+        memberships=[
+            BasketMembership(
+                topic="sports",
+                wallet=registry_wallet,
+                tier="core",
+                rank=1,
+                active=True,
+                joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+                effective_until=None,
+                promotion_reason="seeded",
+                demotion_reason="",
+            )
+        ],
+    )
+
+    wallet_topics, source = _wallet_topics_for_live_inputs(config, store)
+
+    assert source == "registry_memberships"
+    assert wallet_topics == {}
 
 
 def test_load_live_inputs_uses_registry_memberships_for_wallet_fetches(
@@ -1023,6 +1070,38 @@ def test_compact_cycle_output_includes_wallet_registry_summary() -> None:
     }
 
 
+def test_compact_scoring_diagnostics_includes_attrition_and_missing_breakdown() -> None:
+    diagnostics = _compact_scoring_diagnostics(
+        {
+            "rejection_counts": {"missing_market": 3, "too_old": 1},
+            "wallet_rejection_counts": {
+                "w1": {"missing_market": 2},
+                "w2": {"missing_market": 1, "too_old": 1},
+            },
+            "wallet_attrition": {
+                "wallets_seen": 5,
+                "wallets_scored": 2,
+                "wallets_fully_rejected": 3,
+            },
+            "missing_market_breakdown": {"token_id_like": 2, "slug_like": 1},
+            "missing_market_samples": ["0xabc", "slug-1"],
+        }
+    )
+
+    assert diagnostics["rejection_counts"] == {"missing_market": 3, "too_old": 1}
+    assert diagnostics["wallets_with_rejections"] == 2
+    assert diagnostics["wallet_attrition"] == {
+        "wallets_seen": 5,
+        "wallets_scored": 2,
+        "wallets_fully_rejected": 3,
+    }
+    assert diagnostics["missing_market_breakdown"] == {
+        "token_id_like": 2,
+        "slug_like": 1,
+    }
+    assert diagnostics["missing_market_samples"] == ["0xabc", "slug-1"]
+
+
 def test_build_wallet_registry_summary_includes_live_roster() -> None:
     config = load_config(Path("config/predictcel.example.json"))
     config = replace(
@@ -1226,6 +1305,82 @@ def test_build_wallet_registry_summary_keeps_memberships_read_only() -> None:
         ("w3", "rotating", 3, True),
         ("w4", "backup", 4, True),
         ("w5", "explorer", 5, True),
+    ]
+    assert summary["live_roster_by_topic"]["geopolitics"]["selected_wallets"] == {
+        "core": ["w5", "w4"],
+        "rotating": ["w3"],
+        "backup": ["w2"],
+        "explorer": [],
+    }
+
+
+def test_build_wallet_registry_summary_persists_rebalance_when_requested() -> None:
+    config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        config,
+        wallet_registry=replace(
+            config.wallet_registry, enabled=True, seed_from_baskets=False
+        ),
+        basket_controller=replace(
+            config.basket_controller,
+            tracked_basket_target=4,
+            core_slots=2,
+            rotating_slots=1,
+            backup_slots=1,
+            explorer_slots=0,
+        ),
+    )
+    captured_at = datetime.now(UTC)
+    store = RegistrySummaryStore(
+        registry_entries=[],
+        memberships=[
+            BasketMembership(
+                topic="geopolitics",
+                wallet=wallet,
+                tier=tier,
+                rank=index,
+                active=True,
+                joined_at=captured_at,
+                effective_until=None,
+                promotion_reason="seeded",
+                demotion_reason="",
+            )
+            for index, (wallet, tier) in enumerate(
+                [
+                    ("w1", "core"),
+                    ("w2", "core"),
+                    ("w3", "rotating"),
+                    ("w4", "backup"),
+                    ("w5", "explorer"),
+                ],
+                start=1,
+            )
+        ],
+    )
+    trades = [
+        WalletTrade("w5", "geopolitics", "m1", "YES", 0.6, 15.0, 60),
+        WalletTrade("w5", "geopolitics", "m2", "YES", 0.59, 15.0, 120),
+        WalletTrade("w4", "geopolitics", "m3", "YES", 0.58, 15.0, 180),
+        WalletTrade("w3", "geopolitics", "m4", "YES", 0.57, 15.0, 240),
+        WalletTrade("w2", "geopolitics", "m5", "YES", 0.56, 15.0, 300),
+    ]
+
+    summary = _build_wallet_registry_summary(
+        config,
+        store,
+        trades,
+        persist_rebalance=True,
+    )
+
+    assert [
+        (membership.wallet, membership.tier, membership.rank, membership.active)
+        for membership in store.memberships
+    ] == [
+        ("w5", "core", 1, True),
+        ("w4", "core", 2, True),
+        ("w3", "rotating", 3, True),
+        ("w2", "backup", 4, True),
+        ("w1", "core", 5, False),
     ]
     assert summary["live_roster_by_topic"]["geopolitics"]["selected_wallets"] == {
         "core": ["w5", "w4"],

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -48,6 +48,16 @@ class FakeSlugClient(PolymarketPublicClient):
                 "slug": "will-event-x-happen",
                 "outcomePrices": "[0.61, 0.35]",
             }
+        if "/events/slug/event-slug-only" in url:
+            return {
+                "markets": [
+                    {
+                        "conditionId": "cond_event",
+                        "slug": "market-from-event",
+                        "outcomePrices": "[0.55, 0.41]",
+                    }
+                ]
+            }
         return {"markets": []}
 
 
@@ -161,6 +171,22 @@ def test_fetch_markets_by_slugs_uses_slug_endpoint_and_deduplicates() -> None:
         }
     ]
     assert any("/markets/slug/will-event-x-happen" in url for url in client.urls)
+
+
+def test_fetch_markets_by_slugs_falls_back_to_event_slug() -> None:
+    client = FakeSlugClient()
+
+    rows = client.fetch_markets_by_slugs(["event-slug-only"])
+
+    assert rows == [
+        {
+            "conditionId": "cond_event",
+            "slug": "market-from-event",
+            "outcomePrices": "[0.55, 0.41]",
+        }
+    ]
+    assert any("/markets/slug/event-slug-only" in url for url in client.urls)
+    assert any("/events/slug/event-slug-only" in url for url in client.urls)
 
 
 def test_fetch_wallet_trades_accepts_asset_backed_trade_rows() -> None:
@@ -416,11 +442,17 @@ def test_extract_trade_market_ids_deduplicates_common_shapes() -> None:
             {"condition_id": "cond_1"},
             {"marketSlug": "ignored"},
             {"market": "market_2"},
+            {"market": {"slug": "ignored-nested-slug", "id": "market_3"}},
             {"asset": "token_yes"},
         ]
     }
 
-    assert extract_trade_market_ids(payloads) == ["cond_1", "market_2", "token_yes"]
+    assert extract_trade_market_ids(payloads) == [
+        "cond_1",
+        "market_2",
+        "market_3",
+        "token_yes",
+    ]
 
 
 def test_extract_trade_market_slugs_deduplicates_common_shapes() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -146,6 +146,68 @@ def test_scoring_diagnostics_count_rejection_reasons() -> None:
     }
     assert scorer.last_wallet_rejection_counts["w2"] == {"too_old": 1}
     assert scorer.last_missing_market_samples == ["missing"]
+    assert scorer.last_missing_market_breakdown == {"other": 1}
+    assert scorer.last_wallet_attrition == {
+        "wallets_seen": 2,
+        "wallets_scored": 0,
+        "wallets_fully_rejected": 2,
+    }
+
+
+def test_wallet_quality_matches_token_ids_case_insensitively() -> None:
+    scorer = WalletQualityScorer(make_filters())
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="TOKEN_YES",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        )
+    ]
+    market = MarketSnapshot(
+        market_id="cond_1",
+        topic="sports",
+        title="Example",
+        yes_ask=0.57,
+        no_ask=0.4,
+        best_bid=0.55,
+        liquidity_usd=9000,
+        minutes_to_resolution=180,
+        yes_token_id="token_yes",
+    )
+    markets = {
+        "cond_1": market,
+        "token_yes": market,
+    }
+
+    scores = scorer.score(trades, markets)
+
+    assert "w1" in scores
+    assert scorer.last_rejection_counts == {}
+
+
+def test_scoring_diagnostics_classify_token_like_missing_market_ids() -> None:
+    scorer = WalletQualityScorer(make_filters())
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="0xABC123",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        )
+    ]
+
+    scores = scorer.score(trades, {})
+
+    assert scores == {}
+    assert scorer.last_rejection_counts == {"missing_market": 1}
+    assert scorer.last_missing_market_breakdown == {"token_id_like": 1}
 
 
 def test_wallet_quality_prefers_specialist_human_pace_liquid_copy_safe_wallets() -> (

--- a/tests/test_wallet_registry.py
+++ b/tests/test_wallet_registry.py
@@ -164,6 +164,116 @@ def test_compute_basket_health_from_static_memberships() -> None:
     assert health[0].health_state == "thin"
 
 
+def test_compute_basket_health_respects_registry_statuses() -> None:
+    config = load_config(Path("config/predictcel.example.json"))
+    memberships = [
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w1",
+            tier="core",
+            rank=1,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w2",
+            tier="core",
+            rank=2,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w3",
+            tier="rotating",
+            rank=3,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+    ]
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="geopolitics",
+            market_id="m1",
+            side="YES",
+            price=0.5,
+            size_usd=20.0,
+            age_seconds=3600,
+        ),
+        WalletTrade(
+            wallet="w2",
+            topic="geopolitics",
+            market_id="m2",
+            side="NO",
+            price=0.4,
+            size_usd=15.0,
+            age_seconds=172800,
+        ),
+        WalletTrade(
+            wallet="w3",
+            topic="geopolitics",
+            market_id="m3",
+            side="YES",
+            price=0.6,
+            size_usd=12.0,
+            age_seconds=691200,
+        ),
+    ]
+    registry_entries = [
+        WalletRegistryEntry(
+            "w1",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "active",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w2",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "stale",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        WalletRegistryEntry(
+            "w3",
+            "static_basket",
+            "config.baskets",
+            1.0,
+            "retired",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    ]
+
+    health = compute_basket_health_from_static_memberships(
+        config,
+        memberships,
+        trades,
+        registry_entries=registry_entries,
+        captured_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    assert len(health) == 1
+    assert health[0].fresh_core_wallets_24h == 1
+    assert health[0].fresh_active_wallets_7d == 1
+    assert health[0].active_eligible_wallet_count == 1
+    assert health[0].eligible_trades_7d == 2
+    assert health[0].stale_ratio == pytest.approx(2 / 3, rel=1e-3)
+    assert health[0].health_state == "stale"
+
+
 def test_build_live_basket_roster_ranks_recent_wallets_into_live_slots() -> None:
     config = load_config(Path("config/predictcel.example.json"))
     captured_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary
- persist live-roster rebalance into the main cycle and tighten registry membership filtering for live inputs
- improve market matching with slug-to-event fallback plus safer nested market identifier parsing
- reduce scoring attrition with case-insensitive market alias resolution and add missing-market breakdown diagnostics

## Test Plan
- py -3 -m pytest tests/test_main.py tests/test_wallet_registry.py tests/test_polymarket.py -k 'wallet_topics_for_live_inputs or build_wallet_registry_summary or compute_basket_health or slug or market_id' -p no:cacheprovider
- py -3 -m pytest tests/test_scoring.py tests/test_main.py tests/test_copy_engine.py tests/test_polymarket.py -k 'scoring or compact_scoring or market_alias or token_ids_case_insensitively or slug or market_id' -p no:cacheprovider
- .tools\\ruff\\ruff-0.15.12\\ruff.exe check src/predictcel/main.py src/predictcel/wallet_registry.py src/predictcel/polymarket.py src/predictcel/scoring.py src/predictcel/copy_engine.py tests/test_main.py tests/test_wallet_registry.py tests/test_polymarket.py tests/test_scoring.py tests/test_copy_engine.py
- .tools\\ruff\\ruff-0.15.12\\ruff.exe format --check src/predictcel/main.py src/predictcel/wallet_registry.py src/predictcel/polymarket.py src/predictcel/scoring.py src/predictcel/copy_engine.py tests/test_main.py tests/test_wallet_registry.py tests/test_polymarket.py tests/test_scoring.py tests/test_copy_engine.py