### PR TITLE
Recover unresolved live trades, tighten analysis filtering, and relax wallet scoring gates

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -187,6 +187,7 @@ def main() -> None:
         trades,
         persist_rebalance=True,
     )
+    analysis_trades = _analysis_trades(trades, config.filters.max_trade_age_seconds)
     wallet_registry_summary["auto_feed"] = wallet_discovery_auto_feed
     open_positions_at_start = store.get_open_positions()
     db_diagnostics = {
@@ -211,19 +212,26 @@ def main() -> None:
         config.filters,
         config.consensus.recency_half_life_seconds,
     )
-    wallet_qualities = scorer.score(trades, markets)
+    wallet_qualities = scorer.score(analysis_trades, markets)
     scoring_diagnostics = {
         "rejection_counts": scorer.last_rejection_counts,
         "wallet_rejection_counts": scorer.last_wallet_rejection_counts,
         "missing_market_samples": scorer.last_missing_market_samples,
         "missing_market_breakdown": scorer.last_missing_market_breakdown,
         "wallet_attrition": scorer.last_wallet_attrition,
+        "analysis_trade_count": len(analysis_trades),
+        "pre_scoring_too_old_filtered": max(0, len(trades) - len(analysis_trades)),
     }
     timings["wallet_scoring_ms"] = _elapsed_ms(started)
 
     started = time.perf_counter()
     copy_engine = CopyEngine(config)
-    copy_candidates = copy_engine.evaluate(trades, markets, wallet_qualities, store)
+    copy_candidates = copy_engine.evaluate(
+        analysis_trades,
+        markets,
+        wallet_qualities,
+        store,
+    )
     copy_engine_diagnostics = getattr(copy_engine, "last_diagnostics", {})
     timings["copy_engine_ms"] = _elapsed_ms(started)
 
@@ -1047,6 +1055,18 @@ def _load_live_inputs(config, store: SignalStore | None = None):
     if supplemental_rows:
         markets.update(build_market_snapshots(supplemental_rows))
 
+    unresolved_trade_market_ids = [
+        market_id for market_id in missing_trade_market_ids if market_id not in markets
+    ]
+    token_probe_rows, token_probe_stats, unresolved_token_samples = (
+        _recover_unresolved_token_market_rows(
+            client,
+            unresolved_trade_market_ids,
+        )
+    )
+    if token_probe_rows:
+        markets.update(build_market_snapshots(token_probe_rows))
+
     missing_trade_market_slugs = [
         market_slug for market_slug in trade_market_slugs if market_slug not in markets
     ]
@@ -1120,6 +1140,12 @@ def _load_live_inputs(config, store: SignalStore | None = None):
         "trade_market_slugs_seen": len(trade_market_slugs),
         "supplemental_market_ids_requested": len(missing_trade_market_ids),
         "supplemental_market_rows_loaded": len(supplemental_rows),
+        "unresolved_market_ids_after_supplemental": len(unresolved_trade_market_ids),
+        "token_probe_requested": token_probe_stats["requested"],
+        "token_probe_rows_loaded": len(token_probe_rows),
+        "token_probe_tokens_matched": token_probe_stats["matched"],
+        "token_probe_tokens_unmatched": token_probe_stats["unmatched"],
+        "sample_unresolved_token_ids": unresolved_token_samples,
         "supplemental_market_slugs_requested": len(missing_trade_market_slugs),
         "supplemental_slug_rows_loaded": len(supplemental_slug_rows),
         "market_cache_entries": len(markets),
@@ -1159,6 +1185,66 @@ def _propagate_canonical_market_updates(
         canonical_snapshot = canonical_updates.get(getattr(snapshot, "market_id", ""))
         if canonical_snapshot is not None:
             markets[market_key] = canonical_snapshot
+
+
+def _recover_unresolved_token_market_rows(
+    client: PolymarketPublicClient,
+    token_ids: list[str],
+    max_workers: int = 8,
+) -> tuple[list[dict[str, Any]], dict[str, int], list[str]]:
+    unique_token_ids = sorted(
+        {str(token_id).strip() for token_id in token_ids if str(token_id).strip()}
+    )
+    if not unique_token_ids:
+        return [], {"requested": 0, "matched": 0, "unmatched": 0}, []
+
+    rows: list[dict[str, Any]] = []
+    recovered_token_ids: set[str] = set()
+    unresolved_samples: list[str] = []
+    workers = max(1, min(max_workers, len(unique_token_ids)))
+
+    def fetch_one(token_id: str) -> list[dict[str, Any]]:
+        probe_client = _make_probe_client(client)
+        return probe_client.fetch_markets_by_clob_token_ids([token_id], chunk_size=1)
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(fetch_one, token_id): token_id
+            for token_id in unique_token_ids
+        }
+        for future in as_completed(futures):
+            token_id = futures[future]
+            try:
+                token_rows = future.result()
+            except Exception:
+                token_rows = []
+            if token_rows:
+                rows.extend(token_rows)
+                recovered_token_ids.add(token_id)
+            elif len(unresolved_samples) < 10:
+                unresolved_samples.append(token_id)
+
+    return (
+        rows,
+        {
+            "requested": len(unique_token_ids),
+            "matched": len(recovered_token_ids),
+            "unmatched": max(0, len(unique_token_ids) - len(recovered_token_ids)),
+        },
+        unresolved_samples,
+    )
+
+
+def _analysis_trades(
+    trades: list[Any],
+    max_trade_age_seconds: int,
+) -> list[Any]:
+    return [
+        trade
+        for trade in trades
+        if getattr(trade, "age_seconds", max_trade_age_seconds + 1)
+        <= max_trade_age_seconds
+    ]
 
 
 def _build_orderbook_probe_samples(
@@ -1458,6 +1544,24 @@ def _compact_live_input_diagnostics(diagnostics: dict[str, Any]) -> dict[str, An
             "supplemental_market_rows_loaded",
             0,
         ),
+        "unresolved_market_ids_after_supplemental": diagnostics.get(
+            "unresolved_market_ids_after_supplemental",
+            0,
+        ),
+        "unresolved_token_ids_after_supplemental": diagnostics.get(
+            "unresolved_token_ids_after_supplemental",
+            0,
+        ),
+        "token_probe_requested": diagnostics.get("token_probe_requested", 0),
+        "token_probe_rows_loaded": diagnostics.get("token_probe_rows_loaded", 0),
+        "token_probe_tokens_matched": diagnostics.get(
+            "token_probe_tokens_matched",
+            0,
+        ),
+        "token_probe_tokens_unmatched": diagnostics.get(
+            "token_probe_tokens_unmatched",
+            0,
+        ),
         "supplemental_market_slugs_requested": diagnostics.get(
             "supplemental_market_slugs_requested",
             0,
@@ -1482,6 +1586,9 @@ def _compact_live_input_diagnostics(diagnostics: dict[str, Any]) -> dict[str, An
             "sample_skipped_invalid_wallets",
             [],
         )[:3]
+    unresolved_token_samples = diagnostics.get("sample_unresolved_token_ids", [])
+    if unresolved_token_samples:
+        compact["sample_unresolved_token_ids"] = unresolved_token_samples[:5]
     return compact
 
 
@@ -1509,6 +1616,13 @@ def _compact_scoring_diagnostics(diagnostics: dict[str, Any]) -> dict[str, Any]:
     wallet_attrition = diagnostics.get("wallet_attrition", {})
     if wallet_attrition:
         compact["wallet_attrition"] = wallet_attrition
+    if "analysis_trade_count" in diagnostics:
+        compact["analysis_trade_count"] = diagnostics.get("analysis_trade_count", 0)
+    if "pre_scoring_too_old_filtered" in diagnostics:
+        compact["pre_scoring_too_old_filtered"] = diagnostics.get(
+            "pre_scoring_too_old_filtered",
+            0,
+        )
     missing_market_breakdown = diagnostics.get("missing_market_breakdown", {})
     if missing_market_breakdown:
         compact["missing_market_breakdown"] = missing_market_breakdown

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -201,10 +201,6 @@ class WalletQualityScorer:
             return "too_small"
         if market.liquidity_usd < self.filters.min_liquidity_usd:
             return "low_liquidity"
-        if market.minutes_to_resolution < self.filters.min_minutes_to_resolution:
-            return "too_close_to_resolution"
-        if market.minutes_to_resolution > self.filters.max_minutes_to_resolution:
-            return "too_far_from_resolution"
         return None
 
     def _is_eligible_trade(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from predictcel.config import BasketRule, load_config
 from predictcel import discover_wallets
 from predictcel.main import (
+    _analysis_trades,
     _auto_feed_wallet_registry_from_discovery,
     _build_wallet_registry_summary,
     _compact_scoring_diagnostics,
@@ -17,6 +18,7 @@ from predictcel.main import (
     _probe_token_lookup,
     _probe_token_orderbook,
     _propagate_canonical_market_updates,
+    _recover_unresolved_token_market_rows,
     _run_wallet_discovery,
     _wallet_topics_for_live_inputs,
 )
@@ -142,6 +144,14 @@ class FakeLiveClient:
 
     def fetch_markets_by_slugs(self, slugs):
         del slugs
+        return []
+
+    def fetch_markets_by_clob_token_ids(
+        self,
+        token_ids: list[str],
+        chunk_size: int = 25,
+    ):
+        del token_ids, chunk_size
         return []
 
 
@@ -435,6 +445,98 @@ def test_load_live_inputs_uses_registry_memberships_for_wallet_fetches(
     assert observed["wallets"] == [registry_wallet]
     assert diagnostics["wallet_source"] == "registry_memberships"
     assert diagnostics["requested_wallets"] == 1
+
+
+def test_load_live_inputs_recovers_unresolved_token_markets(monkeypatch) -> None:
+    registry_wallet = "0x1111111111111111111111111111111111111111"
+    config = replace(
+        load_config(Path("config/predictcel.example.json")),
+        wallet_registry=replace(
+            load_config(Path("config/predictcel.example.json")).wallet_registry,
+            enabled=True,
+            seed_from_baskets=False,
+        ),
+    )
+    store = DiscoveryStore(
+        memberships=[
+            BasketMembership(
+                topic="sports",
+                wallet=registry_wallet,
+                tier="core",
+                rank=1,
+                active=True,
+                joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+                effective_until=None,
+                promotion_reason="seeded",
+                demotion_reason="",
+            )
+        ]
+    )
+
+    class TokenProbeClient(FakeLiveClient):
+        gamma_base_url = "https://gamma-api.polymarket.com"
+        data_base_url = "https://data-api.polymarket.com"
+        clob_base_url = "https://clob.polymarket.com"
+        timeout_seconds = 15
+        max_retries = 1
+        retry_base_delay_seconds = 0.5
+
+        def fetch_markets_by_clob_token_ids(
+            self,
+            token_ids: list[str],
+            chunk_size: int = 25,
+        ):
+            assert chunk_size == 1
+            if token_ids == ["token_yes"]:
+                return [
+                    {
+                        "conditionId": "cond_1",
+                        "question": "Recovered Question",
+                        "clobTokenIds": ["token_yes", "token_no"],
+                        "outcomePrices": "[0.55, 0.41]",
+                        "active": True,
+                        "closed": False,
+                        "liquidity": 9000,
+                        "endDate": "2026-12-31T00:00:00Z",
+                    }
+                ]
+            return []
+
+    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", TokenProbeClient)
+    monkeypatch.setattr(
+        "predictcel.main._fetch_wallet_payloads",
+        lambda client, wallets, limit: {wallets[0]: [{"asset": "token_yes"}]},
+    )
+    monkeypatch.setattr(
+        "predictcel.main.build_wallet_trades",
+        lambda payloads, topics: [
+            WalletTrade(
+                registry_wallet,
+                "sports",
+                "token_yes",
+                "YES",
+                0.55,
+                25.0,
+                300,
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_ids", lambda payloads: ["token_yes"]
+    )
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_slugs", lambda payloads: []
+    )
+
+    trades, markets, diagnostics = _load_live_inputs(config, store)
+
+    assert len(trades) == 1
+    assert "cond_1" in markets
+    assert "token_yes" in markets
+    assert diagnostics["token_probe_requested"] == 1
+    assert diagnostics["token_probe_tokens_matched"] == 1
+    assert diagnostics["token_probe_tokens_unmatched"] == 0
+    assert diagnostics["token_probe_rows_loaded"] == 1
 
 
 def test_run_wallet_discovery_persists_registry_inputs_when_db_is_provided(
@@ -1083,6 +1185,8 @@ def test_compact_scoring_diagnostics_includes_attrition_and_missing_breakdown() 
                 "wallets_scored": 2,
                 "wallets_fully_rejected": 3,
             },
+            "analysis_trade_count": 7,
+            "pre_scoring_too_old_filtered": 4,
             "missing_market_breakdown": {"token_id_like": 2, "slug_like": 1},
             "missing_market_samples": ["0xabc", "slug-1"],
         }
@@ -1095,11 +1199,25 @@ def test_compact_scoring_diagnostics_includes_attrition_and_missing_breakdown() 
         "wallets_scored": 2,
         "wallets_fully_rejected": 3,
     }
+    assert diagnostics["analysis_trade_count"] == 7
+    assert diagnostics["pre_scoring_too_old_filtered"] == 4
     assert diagnostics["missing_market_breakdown"] == {
         "token_id_like": 2,
         "slug_like": 1,
     }
     assert diagnostics["missing_market_samples"] == ["0xabc", "slug-1"]
+
+
+def test_analysis_trades_filters_too_old_rows() -> None:
+    trades = [
+        WalletTrade("w1", "sports", "m1", "YES", 0.5, 10.0, 300),
+        WalletTrade("w1", "sports", "m2", "YES", 0.5, 10.0, 3600),
+        WalletTrade("w1", "sports", "m3", "YES", 0.5, 10.0, 3601),
+    ]
+
+    filtered = _analysis_trades(trades, 3600)
+
+    assert [trade.market_id for trade in filtered] == ["m1", "m2"]
 
 
 def test_build_wallet_registry_summary_includes_live_roster() -> None:
@@ -2087,6 +2205,47 @@ def test_probe_token_lookup_uses_fresh_client(monkeypatch) -> None:
         "token_ids": ["token_yes", "token_no"],
         "matched_input_token": True,
     }
+
+
+def test_recover_unresolved_token_market_rows_uses_single_token_probes(
+    monkeypatch,
+) -> None:
+    class FreshProbeClient:
+        def __init__(self, *args):
+            pass
+
+        def fetch_markets_by_clob_token_ids(
+            self,
+            token_ids: list[str],
+            chunk_size: int = 25,
+        ):
+            assert chunk_size == 1
+            if token_ids == ["token_yes"]:
+                return [
+                    {
+                        "conditionId": "cond_1",
+                        "question": "Question",
+                        "clobTokenIds": ["token_yes", "token_no"],
+                    }
+                ]
+            return []
+
+    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FreshProbeClient)
+
+    rows, stats, unresolved = _recover_unresolved_token_market_rows(
+        ProbeSourceClient(),
+        ["token_yes", "token_missing"],
+    )
+
+    assert rows == [
+        {
+            "conditionId": "cond_1",
+            "question": "Question",
+            "clobTokenIds": ["token_yes", "token_no"],
+        }
+    ]
+    assert stats == {"requested": 2, "matched": 1, "unmatched": 1}
+    assert unresolved == ["token_missing"]
 
 
 def test_propagate_canonical_market_updates_rebinds_stale_aliases() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -210,6 +210,70 @@ def test_scoring_diagnostics_classify_token_like_missing_market_ids() -> None:
     assert scorer.last_missing_market_breakdown == {"token_id_like": 1}
 
 
+def test_wallet_quality_scoring_keeps_too_close_resolution_trades_for_scoring() -> None:
+    scorer = WalletQualityScorer(make_filters())
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        )
+    ]
+    markets = {
+        "m1": MarketSnapshot(
+            market_id="m1",
+            topic="sports",
+            title="Example",
+            yes_ask=0.57,
+            no_ask=0.4,
+            best_bid=0.55,
+            liquidity_usd=9000,
+            minutes_to_resolution=30,
+        )
+    }
+
+    scores = scorer.score(trades, markets)
+
+    assert "w1" in scores
+    assert scorer.last_rejection_counts == {}
+
+
+def test_wallet_quality_scoring_keeps_too_far_resolution_trades_for_scoring() -> None:
+    scorer = WalletQualityScorer(make_filters())
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        )
+    ]
+    markets = {
+        "m1": MarketSnapshot(
+            market_id="m1",
+            topic="sports",
+            title="Example",
+            yes_ask=0.57,
+            no_ask=0.4,
+            best_bid=0.55,
+            liquidity_usd=9000,
+            minutes_to_resolution=2880,
+        )
+    }
+
+    scores = scorer.score(trades, markets)
+
+    assert "w1" in scores
+    assert scorer.last_rejection_counts == {}
+
+
 def test_wallet_quality_prefers_specialist_human_pace_liquid_copy_safe_wallets() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Add second-pass single-token market recovery for unresolved live trades.
- Filter too-old trades before wallet scoring and copy-engine analysis.
- Stop hard-rejecting near/far-resolution trades during wallet scoring.

## Test Plan
- Focused pytest regression selection passed.
- Ruff check passed.
- Ruff format check passed.