### PR TITLE
Normalize trade market ids and add wallet diagnostics

### DIFF
--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -31,6 +31,7 @@ from .polymarket import (
     enrich_market_snapshots_with_orderbooks,
     extract_trade_market_ids,
     extract_trade_market_slugs,
+    _trade_market_id_source,
 )
 from .scoring import WalletQualityScorer
 from .storage import SignalStore
@@ -218,6 +219,8 @@ def main() -> None:
         "wallet_rejection_counts": scorer.last_wallet_rejection_counts,
         "missing_market_samples": scorer.last_missing_market_samples,
         "missing_market_breakdown": scorer.last_missing_market_breakdown,
+        "missing_market_by_wallet": scorer.last_missing_market_by_wallet,
+        "missing_market_samples_by_wallet": scorer.last_missing_market_samples_by_wallet,
         "wallet_attrition": scorer.last_wallet_attrition,
         "analysis_trade_count": len(analysis_trades),
         "pre_scoring_too_old_filtered": max(0, len(trades) - len(analysis_trades)),
@@ -1013,6 +1016,19 @@ def _portfolio_summary(store: SignalStore, config: Any) -> dict:
     )
 
 
+def _trade_market_id_source_breakdown(
+    wallet_payloads: dict[str, list[dict[str, Any]]],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for items in wallet_payloads.values():
+        for item in items:
+            source = _trade_market_id_source(item)
+            if not source:
+                continue
+            counts[source] = counts.get(source, 0) + 1
+    return dict(sorted(counts.items()))
+
+
 def _load_live_inputs(config, store: SignalStore | None = None):
     if config.live_data is None:
         raise ValueError("--live-data was requested but live_data is not configured.")
@@ -1044,9 +1060,16 @@ def _load_live_inputs(config, store: SignalStore | None = None):
     trades = build_wallet_trades(wallet_payloads, raw_topic_by_wallet)
     trade_market_ids = extract_trade_market_ids(wallet_payloads)
     trade_market_slugs = extract_trade_market_slugs(wallet_payloads)
+    trade_market_id_source_breakdown = _trade_market_id_source_breakdown(
+        wallet_payloads
+    )
 
     active_market_rows = client.fetch_active_markets(config.live_data.market_limit)
     markets = build_market_snapshots(active_market_rows)
+    token_aliases_added_from_rows = _index_market_row_token_aliases(
+        markets,
+        active_market_rows,
+    )
 
     missing_trade_market_ids = [
         market_id for market_id in trade_market_ids if market_id not in markets
@@ -1054,18 +1077,10 @@ def _load_live_inputs(config, store: SignalStore | None = None):
     supplemental_rows = client.fetch_markets_by_identifiers(missing_trade_market_ids)
     if supplemental_rows:
         markets.update(build_market_snapshots(supplemental_rows))
-
-    unresolved_trade_market_ids = [
-        market_id for market_id in missing_trade_market_ids if market_id not in markets
-    ]
-    token_probe_rows, token_probe_stats, unresolved_token_samples = (
-        _recover_unresolved_token_market_rows(
-            client,
-            unresolved_trade_market_ids,
+        token_aliases_added_from_rows += _index_market_row_token_aliases(
+            markets,
+            supplemental_rows,
         )
-    )
-    if token_probe_rows:
-        markets.update(build_market_snapshots(token_probe_rows))
 
     missing_trade_market_slugs = [
         market_slug for market_slug in trade_market_slugs if market_slug not in markets
@@ -1073,6 +1088,37 @@ def _load_live_inputs(config, store: SignalStore | None = None):
     supplemental_slug_rows = client.fetch_markets_by_slugs(missing_trade_market_slugs)
     if supplemental_slug_rows:
         markets.update(build_market_snapshots(supplemental_slug_rows))
+        token_aliases_added_from_rows += _index_market_row_token_aliases(
+            markets,
+            supplemental_slug_rows,
+        )
+
+    unresolved_trade_market_ids = [
+        market_id for market_id in missing_trade_market_ids if market_id not in markets
+    ]
+    unresolved_token_trade_market_ids = [
+        market_id
+        for market_id in unresolved_trade_market_ids
+        if _looks_like_unresolved_token_id(market_id)
+    ]
+    token_probe_rows, token_probe_stats, unresolved_token_samples = (
+        _recover_unresolved_token_market_rows(
+            client,
+            unresolved_token_trade_market_ids,
+        )
+    )
+    unmatched_token_diagnostics = _classify_unmatched_token_ids(
+        unresolved_token_trade_market_ids,
+        [*active_market_rows, *supplemental_rows, *supplemental_slug_rows],
+        markets,
+        token_probe_rows,
+    )
+    if token_probe_rows:
+        markets.update(build_market_snapshots(token_probe_rows))
+        token_aliases_added_from_rows += _index_market_row_token_aliases(
+            markets,
+            token_probe_rows,
+        )
 
     relevant_market_keys = {
         market_key
@@ -1138,13 +1184,20 @@ def _load_live_inputs(config, store: SignalStore | None = None):
         "active_market_rows_loaded": len(active_market_rows),
         "trade_market_ids_seen": len(trade_market_ids),
         "trade_market_slugs_seen": len(trade_market_slugs),
+        "trade_market_id_source_breakdown": trade_market_id_source_breakdown,
         "supplemental_market_ids_requested": len(missing_trade_market_ids),
         "supplemental_market_rows_loaded": len(supplemental_rows),
         "unresolved_market_ids_after_supplemental": len(unresolved_trade_market_ids),
+        "unresolved_token_ids_after_supplemental": len(
+            unresolved_token_trade_market_ids
+        ),
         "token_probe_requested": token_probe_stats["requested"],
         "token_probe_rows_loaded": len(token_probe_rows),
         "token_probe_tokens_matched": token_probe_stats["matched"],
         "token_probe_tokens_unmatched": token_probe_stats["unmatched"],
+        "token_aliases_added_from_rows": token_aliases_added_from_rows,
+        "unmatched_token_breakdown": unmatched_token_diagnostics["breakdown"],
+        "sample_unmatched_tokens_by_class": unmatched_token_diagnostics["samples"],
         "sample_unresolved_token_ids": unresolved_token_samples,
         "supplemental_market_slugs_requested": len(missing_trade_market_slugs),
         "supplemental_slug_rows_loaded": len(supplemental_slug_rows),
@@ -1359,29 +1412,169 @@ def _summarize_market_lookup_rows(
     }
 
 
-def _market_row_token_ids(row: dict[str, Any]) -> list[str]:
-    raw = row.get("clobTokenIds") or row.get("tokenIds")
-    if isinstance(raw, list):
-        return [str(token) for token in raw[:2] if str(token).strip()]
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError:
-            parsed = None
-        if isinstance(parsed, list):
-            return [str(token) for token in parsed[:2] if str(token).strip()]
+def _looks_like_unresolved_token_id(value: Any) -> bool:
+    token_id = str(value).strip().lower()
+    return bool(token_id) and (token_id.startswith("0x") or "token" in token_id)
 
-    tokens = row.get("tokens")
-    if isinstance(tokens, list):
-        token_ids: list[str] = []
-        for token in tokens[:2]:
-            if not isinstance(token, dict):
-                continue
-            token_id = token.get("token_id") or token.get("id") or token.get("tokenId")
-            if token_id and str(token_id).strip():
-                token_ids.append(str(token_id))
-        return token_ids
-    return []
+
+def _market_row_lookup_keys(row: dict[str, Any]) -> list[str]:
+    keys: list[str] = []
+    for field in (
+        "conditionId",
+        "condition_id",
+        "conditionID",
+        "condition",
+        "id",
+        "market_id",
+        "marketId",
+        "slug",
+        "marketSlug",
+    ):
+        value = row.get(field)
+        if value is None or isinstance(value, dict):
+            continue
+        normalized = str(value).strip()
+        if normalized:
+            keys.append(normalized)
+    return list(dict.fromkeys(keys))
+
+
+def _append_market_row_token_candidate(
+    token_ids: list[str],
+    raw_value: Any,
+) -> None:
+    if raw_value is None:
+        return
+    if isinstance(raw_value, str):
+        value = raw_value.strip()
+        if not value:
+            return
+        if value.startswith("[") or value.startswith("{"):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                parsed = None
+            if parsed is not None:
+                _append_market_row_token_candidate(token_ids, parsed)
+                return
+        token_ids.append(value)
+        return
+    if isinstance(raw_value, list):
+        for item in raw_value:
+            _append_market_row_token_candidate(token_ids, item)
+        return
+    if isinstance(raw_value, dict):
+        for field in (
+            "token_id",
+            "tokenId",
+            "tokenID",
+            "clobTokenId",
+            "clob_token_id",
+            "asset",
+            "asset_id",
+            "assetId",
+            "id",
+        ):
+            if field in raw_value:
+                _append_market_row_token_candidate(token_ids, raw_value.get(field))
+
+
+def _market_row_token_ids(row: dict[str, Any]) -> list[str]:
+    token_ids: list[str] = []
+    for field in (
+        "clobTokenIds",
+        "tokenIds",
+        "token_ids",
+        "clobTokenId",
+        "clob_token_id",
+        "tokenId",
+        "tokenID",
+        "token_id",
+        "tokens",
+        "outcomes",
+        "outcomeTokens",
+    ):
+        if field in row:
+            _append_market_row_token_candidate(token_ids, row.get(field))
+    return [token_id for token_id in dict.fromkeys(token_ids) if token_id]
+
+
+def _index_market_row_token_aliases(
+    markets: dict[str, Any],
+    rows: list[dict[str, Any]],
+) -> int:
+    added = 0
+    for row in rows:
+        snapshot = None
+        for key in _market_row_lookup_keys(row):
+            snapshot = markets.get(key)
+            if snapshot is not None:
+                break
+        if snapshot is None:
+            continue
+        for token_id in _market_row_token_ids(row):
+            if token_id not in markets:
+                markets[token_id] = snapshot
+                added += 1
+    return added
+
+
+def _classify_unmatched_token_ids(
+    token_ids: list[str],
+    loaded_market_rows: list[dict[str, Any]],
+    markets: dict[str, Any],
+    token_probe_rows: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    unique_token_ids = sorted(
+        {str(token_id).strip() for token_id in token_ids if str(token_id).strip()}
+    )
+    if not unique_token_ids:
+        return {"breakdown": {}, "samples": {}}
+
+    loaded_market_ids = {
+        str(getattr(snapshot, "market_id", "")).strip()
+        for snapshot in markets.values()
+        if str(getattr(snapshot, "market_id", "")).strip()
+    }
+    loaded_row_market_by_token: dict[str, str] = {}
+    for row in loaded_market_rows:
+        market_keys = _market_row_lookup_keys(row)
+        market_id = market_keys[0] if market_keys else ""
+        if not market_id:
+            continue
+        for token_id in _market_row_token_ids(row):
+            loaded_row_market_by_token.setdefault(token_id, market_id)
+
+    probed_market_by_token: dict[str, str] = {}
+    for row in token_probe_rows:
+        market_keys = _market_row_lookup_keys(row)
+        market_id = market_keys[0] if market_keys else ""
+        if not market_id:
+            continue
+        for token_id in _market_row_token_ids(row):
+            probed_market_by_token.setdefault(token_id, market_id)
+
+    breakdown: dict[str, int] = {}
+    samples: dict[str, list[str]] = {}
+    for token_id in unique_token_ids:
+        if token_id in loaded_row_market_by_token and token_id not in markets:
+            category = "present_on_loaded_row_missing_crossref"
+        elif token_id in probed_market_by_token:
+            if probed_market_by_token[token_id] in loaded_market_ids:
+                category = "present_on_loaded_row_missing_crossref"
+            else:
+                category = "market_outside_loaded_universe"
+        else:
+            category = "absent_from_loaded_market_rows"
+        breakdown[category] = breakdown.get(category, 0) + 1
+        bucket = samples.setdefault(category, [])
+        if len(bucket) < 5:
+            bucket.append(token_id)
+
+    return {
+        "breakdown": dict(sorted(breakdown.items())),
+        "samples": dict(sorted(samples.items())),
+    }
 
 
 def _fetch_wallet_payloads(
@@ -1536,6 +1729,10 @@ def _compact_live_input_diagnostics(diagnostics: dict[str, Any]) -> dict[str, An
         "active_market_rows_loaded": diagnostics.get("active_market_rows_loaded", 0),
         "trade_market_ids_seen": diagnostics.get("trade_market_ids_seen", 0),
         "trade_market_slugs_seen": diagnostics.get("trade_market_slugs_seen", 0),
+        "trade_market_id_source_breakdown": diagnostics.get(
+            "trade_market_id_source_breakdown",
+            {},
+        ),
         "supplemental_market_ids_requested": diagnostics.get(
             "supplemental_market_ids_requested",
             0,
@@ -1560,6 +1757,10 @@ def _compact_live_input_diagnostics(diagnostics: dict[str, Any]) -> dict[str, An
         ),
         "token_probe_tokens_unmatched": diagnostics.get(
             "token_probe_tokens_unmatched",
+            0,
+        ),
+        "token_aliases_added_from_rows": diagnostics.get(
+            "token_aliases_added_from_rows",
             0,
         ),
         "supplemental_market_slugs_requested": diagnostics.get(
@@ -1589,6 +1790,14 @@ def _compact_live_input_diagnostics(diagnostics: dict[str, Any]) -> dict[str, An
     unresolved_token_samples = diagnostics.get("sample_unresolved_token_ids", [])
     if unresolved_token_samples:
         compact["sample_unresolved_token_ids"] = unresolved_token_samples[:5]
+    unmatched_token_breakdown = diagnostics.get("unmatched_token_breakdown", {})
+    if unmatched_token_breakdown:
+        compact["unmatched_token_breakdown"] = unmatched_token_breakdown
+    sample_unmatched_tokens = diagnostics.get("sample_unmatched_tokens_by_class", {})
+    if sample_unmatched_tokens:
+        compact["sample_unmatched_tokens_by_class"] = {
+            key: values[:3] for key, values in sample_unmatched_tokens.items()
+        }
     return compact
 
 
@@ -1629,6 +1838,24 @@ def _compact_scoring_diagnostics(diagnostics: dict[str, Any]) -> dict[str, Any]:
     missing_market_samples = diagnostics.get("missing_market_samples", [])
     if missing_market_samples:
         compact["missing_market_samples"] = missing_market_samples
+    missing_market_by_wallet = diagnostics.get("missing_market_by_wallet", {})
+    if missing_market_by_wallet:
+        top_missing_wallets = sorted(
+            missing_market_by_wallet.items(),
+            key=lambda item: item[1],
+            reverse=True,
+        )[:3]
+        compact["missing_market_by_wallet"] = dict(top_missing_wallets)
+    missing_market_samples_by_wallet = diagnostics.get(
+        "missing_market_samples_by_wallet",
+        {},
+    )
+    if missing_market_samples_by_wallet and missing_market_by_wallet:
+        compact["missing_market_samples_by_wallet"] = {
+            wallet: missing_market_samples_by_wallet.get(wallet, [])[:3]
+            for wallet in compact.get("missing_market_by_wallet", {})
+            if missing_market_samples_by_wallet.get(wallet)
+        }
     if top_wallet_rejections:
         compact["top_wallet_rejections"] = top_wallet_rejections
     return compact

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -854,6 +854,31 @@ def _extract_list(payload: Any) -> list[dict[str, Any]]:
 
 
 def _trade_market_id(item: dict[str, Any]) -> str:
+    market_id, _ = _trade_market_id_with_source(item)
+    return market_id
+
+
+def _trade_market_id_source(item: dict[str, Any]) -> str:
+    _, source = _trade_market_id_with_source(item)
+    return source
+
+
+def _trade_market_id_with_source(item: dict[str, Any]) -> tuple[str, str]:
+    nested_market = item.get("market")
+    if isinstance(nested_market, dict):
+        for key in (
+            "conditionId",
+            "condition_id",
+            "conditionID",
+            "condition",
+            "market_id",
+            "marketId",
+            "id",
+        ):
+            value = nested_market.get(key)
+            if value is not None and str(value).strip():
+                return str(value).strip(), f"market.{key}"
+
     for key in (
         "conditionId",
         "condition_id",
@@ -874,37 +899,21 @@ def _trade_market_id(item: dict[str, Any]) -> str:
         if isinstance(value, dict):
             continue
         if value is not None and str(value).strip():
-            return str(value).strip()
-
-    nested_market = item.get("market")
-    if isinstance(nested_market, dict):
-        for key in (
-            "conditionId",
-            "condition_id",
-            "conditionID",
-            "condition",
-            "market_id",
-            "marketId",
-            "id",
-        ):
-            value = nested_market.get(key)
-            if value is not None and str(value).strip():
-                return str(value).strip()
-    return ""
+            return str(value).strip(), key
+    return "", ""
 
 
 def _trade_market_slug(item: dict[str, Any]) -> str:
-    for key in ("marketSlug", "slug"):
-        value = item.get(key)
-        if value is not None and str(value).strip():
-            return str(value).strip()
-
     nested_market = item.get("market")
     if isinstance(nested_market, dict):
         value = nested_market.get("slug") or nested_market.get("marketSlug")
         if value is not None and str(value).strip():
             return str(value).strip()
 
+    for key in ("marketSlug", "slug"):
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
     return ""
 
 

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -46,6 +46,8 @@ class WalletQualityScorer:
         self.last_wallet_rejection_counts: dict[str, dict[str, int]] = {}
         self.last_missing_market_samples: list[str] = []
         self.last_missing_market_breakdown: dict[str, int] = {}
+        self.last_missing_market_by_wallet: dict[str, int] = {}
+        self.last_missing_market_samples_by_wallet: dict[str, list[str]] = {}
         self.last_wallet_attrition: dict[str, int] = {}
 
     def score(
@@ -68,6 +70,8 @@ class WalletQualityScorer:
         wallet_rejections: dict[str, Counter[str]] = defaultdict(Counter)
         missing_market_samples: list[str] = []
         missing_market_breakdown: Counter[str] = Counter()
+        missing_market_by_wallet: Counter[str] = Counter()
+        missing_market_samples_by_wallet: dict[str, list[str]] = defaultdict(list)
         market_lookup = _build_market_lookup(markets)
 
         for trade in trades:
@@ -95,6 +99,15 @@ class WalletQualityScorer:
                         missing_market_breakdown[
                             _classify_missing_market_id(trade.market_id)
                         ] += 1
+                        missing_market_by_wallet[wallet] += 1
+                        if (
+                            trade.market_id
+                            not in missing_market_samples_by_wallet[wallet]
+                            and len(missing_market_samples_by_wallet[wallet]) < 5
+                        ):
+                            missing_market_samples_by_wallet[wallet].append(
+                                trade.market_id
+                            )
 
             if not eligible:
                 continue
@@ -164,6 +177,14 @@ class WalletQualityScorer:
         self.last_missing_market_breakdown = dict(
             sorted(missing_market_breakdown.items())
         )
+        self.last_missing_market_by_wallet = dict(
+            sorted(missing_market_by_wallet.items())
+        )
+        self.last_missing_market_samples_by_wallet = {
+            wallet: samples
+            for wallet, samples in sorted(missing_market_samples_by_wallet.items())
+            if samples
+        }
         self.last_wallet_attrition = {
             "wallets_seen": len(grouped),
             "wallets_scored": len(scores),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,8 +9,10 @@ from predictcel.main import (
     _analysis_trades,
     _auto_feed_wallet_registry_from_discovery,
     _build_wallet_registry_summary,
-    _compact_scoring_diagnostics,
     _compact_cycle_output,
+    _compact_live_input_diagnostics,
+    _compact_scoring_diagnostics,
+    _classify_unmatched_token_ids,
     _creates_or_updates_paper_position,
     _filter_duplicate_candidates,
     _load_live_inputs,
@@ -447,6 +449,73 @@ def test_load_live_inputs_uses_registry_memberships_for_wallet_fetches(
     assert diagnostics["requested_wallets"] == 1
 
 
+def test_load_live_inputs_tracks_trade_market_id_source_breakdown(monkeypatch) -> None:
+    registry_wallet = "0x1111111111111111111111111111111111111111"
+    config = replace(
+        load_config(Path("config/predictcel.example.json")),
+        wallet_registry=replace(
+            load_config(Path("config/predictcel.example.json")).wallet_registry,
+            enabled=True,
+            seed_from_baskets=False,
+        ),
+    )
+    store = DiscoveryStore(
+        memberships=[
+            BasketMembership(
+                topic="sports",
+                wallet=registry_wallet,
+                tier="core",
+                rank=1,
+                active=True,
+                joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+                effective_until=None,
+                promotion_reason="seeded",
+                demotion_reason="",
+            )
+        ]
+    )
+
+    def fake_fetch_wallet_payloads(client, wallets, limit):
+        del client, limit
+        return {
+            wallets[0]: [
+                {
+                    "asset": "token_yes",
+                    "market": {"id": "market_123", "slug": "will-x-happen"},
+                },
+                {
+                    "clobTokenId": "token_no",
+                    "market": {"conditionId": "cond_1"},
+                },
+                {"asset": "token_fallback"},
+            ]
+        }
+
+    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FakeLiveClient)
+    monkeypatch.setattr(
+        "predictcel.main._fetch_wallet_payloads", fake_fetch_wallet_payloads
+    )
+    monkeypatch.setattr(
+        "predictcel.main.build_wallet_trades", lambda payloads, topics: []
+    )
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_ids",
+        lambda payloads: ["market_123", "cond_1", "token_fallback"],
+    )
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_slugs", lambda payloads: ["will-x-happen"]
+    )
+    monkeypatch.setattr("predictcel.main.build_market_snapshots", lambda rows: {})
+
+    _, _, diagnostics = _load_live_inputs(config, store)
+
+    assert diagnostics["trade_market_id_source_breakdown"] == {
+        "asset": 1,
+        "market.conditionId": 1,
+        "market.id": 1,
+    }
+
+
 def test_load_live_inputs_recovers_unresolved_token_markets(monkeypatch) -> None:
     registry_wallet = "0x1111111111111111111111111111111111111111"
     config = replace(
@@ -537,6 +606,138 @@ def test_load_live_inputs_recovers_unresolved_token_markets(monkeypatch) -> None
     assert diagnostics["token_probe_tokens_matched"] == 1
     assert diagnostics["token_probe_tokens_unmatched"] == 0
     assert diagnostics["token_probe_rows_loaded"] == 1
+
+
+def test_load_live_inputs_indexes_token_aliases_from_loaded_market_rows(
+    monkeypatch,
+) -> None:
+    registry_wallet = "0x1111111111111111111111111111111111111111"
+    config = replace(
+        load_config(Path("config/predictcel.example.json")),
+        wallet_registry=replace(
+            load_config(Path("config/predictcel.example.json")).wallet_registry,
+            enabled=True,
+            seed_from_baskets=False,
+        ),
+    )
+    store = DiscoveryStore(
+        memberships=[
+            BasketMembership(
+                topic="sports",
+                wallet=registry_wallet,
+                tier="core",
+                rank=1,
+                active=True,
+                joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+                effective_until=None,
+                promotion_reason="seeded",
+                demotion_reason="",
+            )
+        ]
+    )
+
+    class AliasRichClient(FakeLiveClient):
+        def fetch_active_markets(self, limit: int):
+            del limit
+            return [
+                {
+                    "conditionId": "cond_1",
+                    "question": "Recovered From Active Rows",
+                    "tokens": [
+                        {"asset_id": "token_yes"},
+                        {"assetId": "token_no"},
+                    ],
+                    "outcomePrices": "[0.55, 0.41]",
+                    "active": True,
+                    "closed": False,
+                    "liquidity": 9000,
+                    "endDate": "2026-12-31T00:00:00Z",
+                }
+            ]
+
+    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", AliasRichClient)
+    monkeypatch.setattr(
+        "predictcel.main._fetch_wallet_payloads",
+        lambda client, wallets, limit: {wallets[0]: [{"asset": "token_yes"}]},
+    )
+    monkeypatch.setattr(
+        "predictcel.main.build_wallet_trades",
+        lambda payloads, topics: [
+            WalletTrade(
+                registry_wallet,
+                "sports",
+                "token_yes",
+                "YES",
+                0.55,
+                25.0,
+                300,
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_ids", lambda payloads: ["token_yes"]
+    )
+    monkeypatch.setattr(
+        "predictcel.main.extract_trade_market_slugs", lambda payloads: []
+    )
+
+    trades, markets, diagnostics = _load_live_inputs(config, store)
+
+    assert len(trades) == 1
+    assert "cond_1" in markets
+    assert "token_yes" in markets
+    assert diagnostics["supplemental_market_ids_requested"] == 0
+    assert diagnostics["token_probe_requested"] == 0
+    assert diagnostics["token_aliases_added_from_rows"] >= 2
+
+
+def test_classify_unmatched_token_ids_breaks_down_gap_types() -> None:
+    loaded_market_rows = [
+        {
+            "conditionId": "cond_present",
+            "question": "Present In Loaded Rows",
+            "tokens": [
+                {"asset_id": "token_present"},
+                {"assetId": "token_present_no"},
+            ],
+            "outcomePrices": "[0.60, 0.35]",
+            "active": True,
+            "closed": False,
+            "liquidity": 5000,
+            "endDate": "2026-12-31T00:00:00Z",
+        }
+    ]
+    markets = {"cond_present": make_snapshot("cond_present")}
+    token_probe_rows = [
+        {
+            "conditionId": "cond_outside",
+            "question": "Outside Loaded Universe",
+            "clobTokenIds": ["token_outside", "token_outside_no"],
+            "outcomePrices": "[0.62, 0.31]",
+            "active": True,
+            "closed": False,
+            "liquidity": 7000,
+            "endDate": "2026-12-31T00:00:00Z",
+        }
+    ]
+
+    diagnostics = _classify_unmatched_token_ids(
+        ["token_present", "token_outside", "token_absent"],
+        loaded_market_rows,
+        markets,
+        token_probe_rows,
+    )
+
+    assert diagnostics["breakdown"] == {
+        "absent_from_loaded_market_rows": 1,
+        "market_outside_loaded_universe": 1,
+        "present_on_loaded_row_missing_crossref": 1,
+    }
+    assert diagnostics["samples"] == {
+        "absent_from_loaded_market_rows": ["token_absent"],
+        "market_outside_loaded_universe": ["token_outside"],
+        "present_on_loaded_row_missing_crossref": ["token_present"],
+    }
 
 
 def test_run_wallet_discovery_persists_registry_inputs_when_db_is_provided(
@@ -1172,6 +1373,59 @@ def test_compact_cycle_output_includes_wallet_registry_summary() -> None:
     }
 
 
+def test_compact_live_input_diagnostics_includes_unmatched_token_breakdown() -> None:
+    diagnostics = _compact_live_input_diagnostics(
+        {
+            "requested_wallets": 3,
+            "valid_wallets": 3,
+            "wallet_payloads_loaded": 12,
+            "wallets_with_parsed_trades": 2,
+            "parsed_trade_count": 9,
+            "active_market_rows_loaded": 4,
+            "trade_market_ids_seen": 5,
+            "trade_market_slugs_seen": 2,
+            "supplemental_market_ids_requested": 1,
+            "supplemental_market_rows_loaded": 1,
+            "unresolved_market_ids_after_supplemental": 2,
+            "unresolved_token_ids_after_supplemental": 2,
+            "token_probe_requested": 2,
+            "token_probe_rows_loaded": 1,
+            "token_probe_tokens_matched": 1,
+            "token_probe_tokens_unmatched": 1,
+            "supplemental_market_slugs_requested": 0,
+            "supplemental_slug_rows_loaded": 0,
+            "market_cache_entries": 6,
+            "relevant_markets_enriched": 3,
+            "orderbook_ready_markets": 2,
+            "markets_with_yes_depth": 2,
+            "markets_with_no_depth": 1,
+            "market_crossref": {"matched_count": 4},
+            "trade_market_id_source_breakdown": {"asset": 1, "market.id": 2},
+            "token_aliases_added_from_rows": 3,
+            "unmatched_token_breakdown": {
+                "absent_from_loaded_market_rows": 1,
+                "market_outside_loaded_universe": 1,
+            },
+            "sample_unmatched_tokens_by_class": {
+                "absent_from_loaded_market_rows": ["token_absent"],
+            },
+        }
+    )
+
+    assert diagnostics["token_aliases_added_from_rows"] == 3
+    assert diagnostics["unmatched_token_breakdown"] == {
+        "absent_from_loaded_market_rows": 1,
+        "market_outside_loaded_universe": 1,
+    }
+    assert diagnostics["trade_market_id_source_breakdown"] == {
+        "asset": 1,
+        "market.id": 2,
+    }
+    assert diagnostics["sample_unmatched_tokens_by_class"] == {
+        "absent_from_loaded_market_rows": ["token_absent"]
+    }
+
+
 def test_compact_scoring_diagnostics_includes_attrition_and_missing_breakdown() -> None:
     diagnostics = _compact_scoring_diagnostics(
         {
@@ -1189,6 +1443,11 @@ def test_compact_scoring_diagnostics_includes_attrition_and_missing_breakdown() 
             "pre_scoring_too_old_filtered": 4,
             "missing_market_breakdown": {"token_id_like": 2, "slug_like": 1},
             "missing_market_samples": ["0xabc", "slug-1"],
+            "missing_market_by_wallet": {"w_hot": 4, "w_mid": 2, "w_low": 1},
+            "missing_market_samples_by_wallet": {
+                "w_hot": ["0xabc", "0xdef"],
+                "w_mid": ["slug-1"],
+            },
         }
     )
 
@@ -1206,6 +1465,15 @@ def test_compact_scoring_diagnostics_includes_attrition_and_missing_breakdown() 
         "slug_like": 1,
     }
     assert diagnostics["missing_market_samples"] == ["0xabc", "slug-1"]
+    assert diagnostics["missing_market_by_wallet"] == {
+        "w_hot": 4,
+        "w_mid": 2,
+        "w_low": 1,
+    }
+    assert diagnostics["missing_market_samples_by_wallet"] == {
+        "w_hot": ["0xabc", "0xdef"],
+        "w_mid": ["slug-1"],
+    }
 
 
 def test_analysis_trades_filters_too_old_rows() -> None:

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -455,6 +455,24 @@ def test_extract_trade_market_ids_deduplicates_common_shapes() -> None:
     ]
 
 
+def test_extract_trade_market_ids_prefers_nested_market_id_over_token_fields() -> None:
+    payloads = {
+        "wallet_a": [
+            {
+                "asset": "token_yes",
+                "tokenId": "token_yes",
+                "market": {"id": "market_123", "slug": "will-x-happen"},
+            },
+            {
+                "clobTokenId": "token_no",
+                "market": {"conditionId": "cond_1"},
+            },
+        ]
+    }
+
+    assert extract_trade_market_ids(payloads) == ["cond_1", "market_123"]
+
+
 def test_extract_trade_market_slugs_deduplicates_common_shapes() -> None:
     payloads = {
         "wallet_a": [
@@ -468,6 +486,20 @@ def test_extract_trade_market_slugs_deduplicates_common_shapes() -> None:
         "another-market",
         "will-event-x-happen",
     ]
+
+
+def test_extract_trade_market_slugs_prefers_nested_market_slug() -> None:
+    payloads = {
+        "wallet_a": [
+            {
+                "asset": "token_yes",
+                "marketSlug": "stale-slug",
+                "market": {"conditionId": "cond_1", "slug": "canonical-slug"},
+            }
+        ]
+    }
+
+    assert extract_trade_market_slugs(payloads) == ["canonical-slug"]
 
 
 def test_gamma_market_array_filter_uses_repeated_query_params() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -147,6 +147,8 @@ def test_scoring_diagnostics_count_rejection_reasons() -> None:
     assert scorer.last_wallet_rejection_counts["w2"] == {"too_old": 1}
     assert scorer.last_missing_market_samples == ["missing"]
     assert scorer.last_missing_market_breakdown == {"other": 1}
+    assert scorer.last_missing_market_by_wallet == {"w1": 1}
+    assert scorer.last_missing_market_samples_by_wallet == {"w1": ["missing"]}
     assert scorer.last_wallet_attrition == {
         "wallets_seen": 2,
         "wallets_scored": 0,
@@ -208,6 +210,60 @@ def test_scoring_diagnostics_classify_token_like_missing_market_ids() -> None:
     assert scores == {}
     assert scorer.last_rejection_counts == {"missing_market": 1}
     assert scorer.last_missing_market_breakdown == {"token_id_like": 1}
+
+
+def test_scoring_tracks_missing_markets_by_wallet_with_deduped_samples() -> None:
+    scorer = WalletQualityScorer(make_filters())
+    trades = [
+        WalletTrade(
+            wallet="w_sports",
+            topic="sports",
+            market_id="missing_a",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        ),
+        WalletTrade(
+            wallet="w_sports",
+            topic="sports",
+            market_id="missing_a",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=310,
+        ),
+        WalletTrade(
+            wallet="w_sports",
+            topic="sports",
+            market_id="missing_b",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=320,
+        ),
+        WalletTrade(
+            wallet="w_crypto",
+            topic="crypto",
+            market_id="0xTOKEN",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        ),
+    ]
+
+    scores = scorer.score(trades, {})
+
+    assert scores == {}
+    assert scorer.last_missing_market_by_wallet == {
+        "w_crypto": 1,
+        "w_sports": 3,
+    }
+    assert scorer.last_missing_market_samples_by_wallet == {
+        "w_crypto": ["0xTOKEN"],
+        "w_sports": ["missing_a", "missing_b"],
+    }
 
 
 def test_wallet_quality_scoring_keeps_too_close_resolution_trades_for_scoring() -> None:


### PR DESCRIPTION
## Summary
- Prefer canonical nested market ids and slugs over token-like trade fields during payload normalization.
- Add wallet-level missing-market diagnostics and compact output for the top affected wallets.
- Add live-input trade market-id source breakdown diagnostics to track which payload path won extraction.

## Test Plan
- Focused pytest regression selection passed.
- Ruff check passed.
- Ruff format check passed.