### PR TITLE
Fix audit reliability and validation issues

### DIFF
--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -63,7 +63,12 @@ class CopyEngine:
         try:
             with open(model_path, "rb") as f:
                 self._ml_model = pickle.load(f)
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "Failed to load ML position sizing model from %s: %s",
+                model_path,
+                exc,
+            )
             self._ml_model = None
         self._ml_model_loaded = True
         return self._ml_model

--- a/src/predictcel/execution.py
+++ b/src/predictcel/execution.py
@@ -123,6 +123,7 @@ class ExecutionPlanner:
             if candidate.suggested_position_usd > 0
             else self.config.buy_amount_usd
         )
+        suggested_amount = max(suggested_amount, 0.0)
         amount_usd = max(suggested_amount, self.config.min_signal_allocation_usd)
         amount_usd = min(amount_usd, self.config.buy_amount_usd)
         if self.config.exposure is not None:

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -17,6 +17,11 @@ from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import Any
 
+try:
+    from Crypto.Hash import keccak
+except ImportError:  # pragma: no cover - optional dependency at runtime
+    keccak = None
+
 from .arb_sidecar import ArbitrageSidecar
 from .basket_manager import BasketManagerPlanner
 from .config import load_config
@@ -1637,13 +1642,33 @@ def _creates_or_updates_paper_position(result) -> bool:
     ).strip().lower() == "dry_run" or _is_trusted_execution_result(result)
 
 
+def _checksummed_evm_address(value: str) -> str | None:
+    if keccak is None:
+        return None
+    normalized = value[2:].lower()
+    digest = keccak.new(digest_bits=256)
+    digest.update(normalized.encode("ascii"))
+    address_hash = digest.hexdigest()
+    checksummed = "".join(
+        char.upper() if char.isalpha() and int(address_hash[index], 16) >= 8 else char
+        for index, char in enumerate(normalized)
+    )
+    return f"0x{checksummed}"
+
+
 def _is_evm_address(value: str) -> bool:
     value = str(value).strip()
-    return (
+    if not (
         len(value) == 42
         and value.startswith("0x")
         and all(char in HEX_CHARS for char in value[2:])
-    )
+    ):
+        return False
+    body = value[2:]
+    if body == body.lower() or body == body.upper():
+        return True
+    checksummed = _checksummed_evm_address(value)
+    return checksummed is not None and value == checksummed
 
 
 def _decorate_positions_with_titles(

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -111,6 +111,7 @@ class PolymarketPublicClient:
         self.redis_client = None
         self._request_cache: dict[str, Any] = {}
         self._cache_lock = threading.Lock()
+        self._inflight_requests: dict[str, dict[str, Any]] = {}
         self._gamma_circuit_breaker = CircuitBreaker()
         self._data_circuit_breaker = CircuitBreaker()
         self._clob_circuit_breaker = CircuitBreaker()
@@ -381,39 +382,47 @@ class PolymarketPublicClient:
     ) -> None:
         """Subscribe to real-time market updates via WebSocket."""
         ws_url = "wss://ws.polymarket.com"
-        logger.info(
-            f"Connecting to WebSocket at {ws_url} for {len(market_ids)} markets"
-        )
+        reconnect_attempt = 0
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.ws_connect(ws_url) as ws:
-                    logger.info("WebSocket connected successfully")
-                    subscribe_msg = {"type": "subscribe", "markets": market_ids}
-                    await ws.send_json(subscribe_msg)
-                    logger.info(f"Subscribed to market updates for {market_ids}")
+        while True:
+            logger.info(
+                f"Connecting to WebSocket at {ws_url} for {len(market_ids)} markets"
+            )
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(ws_url) as ws:
+                        logger.info("WebSocket connected successfully")
+                        subscribe_msg = {"type": "subscribe", "markets": market_ids}
+                        await ws.send_json(subscribe_msg)
+                        logger.info(f"Subscribed to market updates for {market_ids}")
 
-                    async for msg in ws:
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            data = msg.json()
-                            if data.get("type") == "update":
-                                logger.debug(f"Received market update: {data}")
-                                callback(data)
-                        elif msg.type == aiohttp.WSMsgType.ERROR:
-                            logger.error("WebSocket error encountered")
-                            break
-                        elif msg.type == aiohttp.WSMsgType.CLOSED:
-                            logger.info("WebSocket connection closed")
-                            break
-        except aiohttp.ClientError as e:
-            logger.error(f"WebSocket client error: {e}")
-            raise
-        except asyncio.TimeoutError:
-            logger.error("WebSocket connection timeout")
-            raise
-        except Exception as e:
-            logger.error(f"WebSocket unexpected error: {e}")
-            raise
+                        async for msg in ws:
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                data = msg.json()
+                                if data.get("type") == "update":
+                                    reconnect_attempt = 0
+                                    logger.debug(f"Received market update: {data}")
+                                    callback(data)
+                            elif msg.type == aiohttp.WSMsgType.ERROR:
+                                logger.error("WebSocket error encountered")
+                                break
+                            elif msg.type == aiohttp.WSMsgType.CLOSED:
+                                logger.info("WebSocket connection closed")
+                                break
+            except asyncio.CancelledError:
+                raise
+            except aiohttp.ClientError as e:
+                logger.error(f"WebSocket client error: {e}")
+            except asyncio.TimeoutError:
+                logger.error("WebSocket connection timeout")
+            except Exception as e:
+                logger.error(f"WebSocket unexpected error: {e}")
+                raise
+
+            delay = _retry_delay(self.retry_base_delay_seconds, reconnect_attempt)
+            reconnect_attempt += 1
+            logger.info(f"Reconnecting WebSocket after {delay:.2f}s")
+            await asyncio.sleep(delay)
 
     def _fetch_markets_by_array_filter(
         self, filter_name: str, values: list[str], chunk_size: int
@@ -453,37 +462,85 @@ class PolymarketPublicClient:
 
         def _fetch_url():
             metrics = _get_metrics()
-            metrics["requests"] += 1
 
             cached = self._get_cached(url)
             if cached is not None:
                 return cached
 
+            with self._cache_lock:
+                inflight = self._inflight_requests.get(url)
+                if inflight is None:
+                    inflight = {
+                        "event": threading.Event(),
+                        "followers": 0,
+                        "result": None,
+                        "error": None,
+                    }
+                    self._inflight_requests[url] = inflight
+                    is_leader = True
+                else:
+                    inflight["followers"] += 1
+                    is_leader = False
+
+            if not is_leader:
+                inflight["event"].wait()
+                try:
+                    error = inflight["error"]
+                    if error is not None:
+                        raise error
+                    cached_result = self._get_cached(url)
+                    if cached_result is not None:
+                        return cached_result
+                    return inflight["result"]
+                finally:
+                    with self._cache_lock:
+                        inflight["followers"] -= 1
+                        if inflight["followers"] <= 0 and inflight["event"].is_set():
+                            self._inflight_requests.pop(url, None)
+
+            metrics["requests"] += 1
             request = Request(url, headers={"User-Agent": "PredictCel/0.1"})
 
-            for attempt in range(self.max_retries):
-                try:
-                    with urlopen(request, timeout=self.timeout_seconds) as response:
-                        payload = json.loads(response.read().decode("utf-8"))
-                        self._validate_response(payload, url)
-                        self._set_cached(url, payload)
-                        return payload
-                except HTTPError as error:
-                    if self._is_missing_clob_order_book(url, error):
-                        return {}
-                    metrics["errors"] += 1
-                    if attempt >= self.max_retries - 1:
-                        raise
-                    delay = _retry_delay(self.retry_base_delay_seconds, attempt)
-                    time.sleep(delay)
-                except (URLError, TimeoutError, OSError, json.JSONDecodeError):
-                    metrics["errors"] += 1
-                    if attempt >= self.max_retries - 1:
-                        raise
-                    delay = _retry_delay(self.retry_base_delay_seconds, attempt)
-                    time.sleep(delay)
+            try:
+                for attempt in range(self.max_retries):
+                    try:
+                        with urlopen(request, timeout=self.timeout_seconds) as response:
+                            payload = json.loads(response.read().decode("utf-8"))
+                            self._validate_response(payload, url)
+                            self._set_cached(url, payload)
+                            result = payload
+                            break
+                    except HTTPError as error:
+                        if self._is_missing_clob_order_book(url, error):
+                            result = {}
+                            break
+                        metrics["errors"] += 1
+                        if attempt >= self.max_retries - 1:
+                            raise
+                        delay = _retry_delay(self.retry_base_delay_seconds, attempt)
+                        time.sleep(delay)
+                    except (URLError, TimeoutError, OSError, json.JSONDecodeError):
+                        metrics["errors"] += 1
+                        if attempt >= self.max_retries - 1:
+                            raise
+                        delay = _retry_delay(self.retry_base_delay_seconds, attempt)
+                        time.sleep(delay)
+                else:
+                    raise RuntimeError(f"Request retries exhausted for {url}")
+            except BaseException as error:
+                with self._cache_lock:
+                    inflight["error"] = error
+                    inflight["event"].set()
+                    if inflight["followers"] <= 0:
+                        self._inflight_requests.pop(url, None)
+                raise
 
-            return None
+            with self._cache_lock:
+                inflight["result"] = result
+                inflight["event"].set()
+                if inflight["followers"] <= 0:
+                    self._inflight_requests.pop(url, None)
+            return result
 
         return self._breaker_for_url(url).call(_fetch_url)
 

--- a/src/predictcel/scoring.py
+++ b/src/predictcel/scoring.py
@@ -128,13 +128,7 @@ class WalletQualityScorer:
             freshness_score = freshness_decay(
                 average_age, self.recency_half_life_seconds
             )
-            drift_score = (
-                max(0.0, 1.0 - (average_drift / self.filters.max_price_drift))
-                if self.filters.max_price_drift > 0
-                else 1.0
-                if self.filters.max_price_drift
-                else 0.0
-            )
+            drift_score = _drift_score(average_drift, self.filters.max_price_drift)
             sample_score = min(len(eligible) / 5.0, 1.0)
             specialization_score = _topic_specialization_score(eligible)
             activity_score = _human_pace_activity_score(eligible)
@@ -273,6 +267,12 @@ def freshness_decay(age_seconds: float, half_life_seconds: int | float) -> float
     )
 
 
+def _drift_score(drift: float, max_price_drift: float) -> float:
+    if max_price_drift == 0:
+        return 1.0 if drift <= 0 else 0.0
+    return max(0.0, 1.0 - (drift / max_price_drift))
+
+
 def compute_copyability_score(
     consensus_ratio: float,
     wallet_quality_score: float,
@@ -313,13 +313,7 @@ def compute_copyability_score(
         average_age_seconds,
         recency_half_life_seconds or max(filters.max_trade_age_seconds // 2, 1),
     )
-    drift_score = (
-        max(0.0, 1.0 - (drift / filters.max_price_drift))
-        if filters.max_price_drift > 0
-        else 1.0
-        if filters.max_price_drift
-        else 0.0
-    )
+    drift_score = _drift_score(drift, filters.max_price_drift)
     liquidity_score = (
         min(liquidity_usd / (filters.min_liquidity_usd * 3), 1.0)
         if filters.min_liquidity_usd

--- a/src/predictcel/wallet_registry.py
+++ b/src/predictcel/wallet_registry.py
@@ -249,7 +249,7 @@ def compute_basket_health_from_static_memberships(
         elif active_eligible_wallet_count < 3:
             health_state = "thin"
         else:
-            health_state = "thin"
+            health_state = "healthy"
 
         health_snapshots.append(
             BasketHealth(

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -969,6 +969,34 @@ def test_copy_engine_ignores_cwd_pickle_fallback(monkeypatch) -> None:
     assert loaded["called"] is False
 
 
+def test_copy_engine_logs_pickle_load_failures(monkeypatch, caplog) -> None:
+    model_path = copy_engine_module.os.path.join(
+        copy_engine_module.os.path.dirname(copy_engine_module.__file__),
+        "position_sizing_model.pkl",
+    )
+
+    def fake_exists(path: str) -> bool:
+        return path == model_path
+
+    def fake_load(handle):
+        del handle
+        raise ValueError("corrupt model")
+
+    monkeypatch.setattr(copy_engine_module.os.path, "exists", fake_exists)
+    monkeypatch.setattr(copy_engine_module.pickle, "load", fake_load)
+    monkeypatch.setattr(
+        builtins,
+        "open",
+        lambda *args, **kwargs: BytesIO(b"pickle-bytes"),
+    )
+
+    with caplog.at_level("WARNING"):
+        engine = CopyEngine(make_config())
+
+    assert engine._ml_model is None
+    assert "Failed to load ML position sizing model" in caplog.text
+
+
 def test_basket_controller_requires_80_percent_same_outcome() -> None:
     wallets = ["w1", "w2", "w3", "w4", "w5"]
     engine = CopyEngine(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from predictcel.config import (
@@ -266,6 +267,31 @@ def test_execution_planner_applies_minimum_signal_allocation() -> None:
     )
 
     assert [intent.amount_usd for intent in intents] == [5.0]
+
+
+def test_execution_planned_amount_clamps_negative_amounts_to_zero() -> None:
+    config = replace(
+        make_execution_config(),
+        buy_amount_usd=-10.0,
+        min_signal_allocation_usd=-5.0,
+    )
+    planner = ExecutionPlanner(config, config.position)
+    candidate = CopyCandidate(
+        "topic",
+        "m1",
+        "YES",
+        1.0,
+        0.5,
+        0.51,
+        10000,
+        ["w1"],
+        1.0,
+        0.9,
+        "ok",
+        suggested_position_usd=-1.0,
+    )
+
+    assert planner._planned_amount_usd(candidate, planned_exposure_usd=0.0) == 0.0
 
 
 def test_execution_planner_respects_exposure_across_planned_orders() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ from predictcel.main import (
     _classify_unmatched_token_ids,
     _creates_or_updates_paper_position,
     _filter_duplicate_candidates,
+    _is_evm_address,
     _load_live_inputs,
     _mark_execution_intents_seen,
     _probe_token_lookup,
@@ -238,6 +239,12 @@ def test_filled_and_dry_run_results_create_positions() -> None:
     assert (
         _creates_or_updates_paper_position(make_result("dry_run", order_id="")) is True
     )
+
+
+def test_is_evm_address_accepts_lowercase_and_valid_checksum_only() -> None:
+    assert _is_evm_address("0xde709f2102306220921060314715629080e2fb77") is True
+    assert _is_evm_address("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed") is True
+    assert _is_evm_address("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAEd") is False
 
 
 def test_filter_duplicate_candidates_skips_recent_and_same_batch_duplicates() -> None:

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -1,8 +1,12 @@
+import asyncio
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from urllib.error import HTTPError, URLError
 
 import pytest
+import aiohttp
 
 from predictcel.polymarket import (
     PolymarketPublicClient,
@@ -123,6 +127,61 @@ class FakeHTTPResponse:
 
     def __exit__(self, exc_type, exc, tb) -> bool:
         return False
+
+
+class FakeWSMessage:
+    def __init__(self, message_type, payload=None):
+        self.type = message_type
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeWebSocket:
+    def __init__(self, messages):
+        self._messages = iter(messages)
+        self.sent_messages = []
+
+    async def send_json(self, payload) -> None:
+        self.sent_messages.append(payload)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._messages)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeWebSocketContext:
+    def __init__(self, websocket: FakeWebSocket):
+        self.websocket = websocket
+
+    async def __aenter__(self) -> FakeWebSocket:
+        return self.websocket
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakeClientSession:
+    def __init__(self, websockets: list[FakeWebSocket]):
+        self._websockets = list(websockets)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def ws_connect(self, url: str):
+        assert url == "wss://ws.polymarket.com"
+        if not self._websockets:
+            raise AssertionError("No fake websockets remaining")
+        return FakeWebSocketContext(self._websockets.pop(0))
 
 
 def test_market_snapshot_from_gamma_parses_string_prices_and_token_ids() -> None:
@@ -372,6 +431,76 @@ def test_gamma_circuit_breaker_does_not_block_clob_requests(monkeypatch) -> None
 
     with pytest.raises(Exception, match="Circuit breaker is OPEN"):
         client.fetch_active_markets(1)
+
+
+def test_subscribe_market_updates_reconnects_after_closed_socket(monkeypatch) -> None:
+    client = PolymarketPublicClient()
+    first_socket = FakeWebSocket([FakeWSMessage(aiohttp.WSMsgType.CLOSED)])
+    second_socket = FakeWebSocket(
+        [
+            FakeWSMessage(
+                aiohttp.WSMsgType.TEXT,
+                {"type": "update", "market": "m1"},
+            )
+        ]
+    )
+    sleep_calls = []
+    updates = []
+    queued_sockets = [first_socket, second_socket]
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    def fake_client_session():
+        return FakeClientSession([queued_sockets.pop(0)])
+
+    def callback(payload) -> None:
+        updates.append(payload)
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr("predictcel.polymarket.aiohttp.ClientSession", fake_client_session)
+    monkeypatch.setattr("predictcel.polymarket._retry_delay", lambda base, attempt: 0.25)
+    monkeypatch.setattr("predictcel.polymarket.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(client.subscribe_market_updates(["m1"], callback))
+
+    assert sleep_calls == [0.25]
+    assert first_socket.sent_messages == [{"type": "subscribe", "markets": ["m1"]}]
+    assert second_socket.sent_messages == [{"type": "subscribe", "markets": ["m1"]}]
+    assert updates == [{"type": "update", "market": "m1"}]
+
+
+def test_get_json_deduplicates_inflight_requests(monkeypatch) -> None:
+    client = PolymarketPublicClient(max_retries=1)
+    started = threading.Event()
+    release = threading.Event()
+    calls = {"count": 0}
+
+    def fake_urlopen(request, timeout=15):
+        del timeout
+        calls["count"] += 1
+        started.set()
+        release.wait(timeout=1)
+        return FakeHTTPResponse({"markets": [{"conditionId": "cond_1"}]})
+
+    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+
+    def fetch():
+        return client._get_json(f"{client.gamma_base_url}/markets?limit=1")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(fetch)
+        assert started.wait(timeout=1)
+        second = executor.submit(fetch)
+        release.set()
+        results = [first.result(), second.result()]
+
+    assert calls["count"] == 1
+    assert results == [
+        {"markets": [{"conditionId": "cond_1"}]},
+        {"markets": [{"conditionId": "cond_1"}]},
+    ]
 
 
 def test_wallet_trade_from_data_uses_outcome_and_timestamp() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from predictcel.config import FilterConfig
 from predictcel.models import MarketSnapshot, WalletTrade
 from predictcel.scoring import (
@@ -64,6 +66,37 @@ def test_wallet_quality_scores_eligible_wallet() -> None:
     assert scores["w1"].sample_score > 0
     assert scorer.last_rejection_counts == {}
     assert scorer.last_missing_market_samples == []
+
+
+def test_wallet_quality_zero_max_price_drift_keeps_perfect_matches_at_full_score() -> None:
+    scorer = WalletQualityScorer(replace(make_filters(), max_price_drift=0.0))
+    trades = [
+        WalletTrade(
+            wallet="w1",
+            topic="sports",
+            market_id="m1",
+            side="YES",
+            price=0.55,
+            size_usd=200,
+            age_seconds=300,
+        )
+    ]
+    markets = {
+        "m1": MarketSnapshot(
+            market_id="m1",
+            topic="sports",
+            title="Example",
+            yes_ask=0.55,
+            no_ask=0.4,
+            best_bid=0.55,
+            liquidity_usd=9000,
+            minutes_to_resolution=180,
+        )
+    }
+
+    scores = scorer.score(trades, markets)
+
+    assert scores["w1"].drift_score == 1.0
 
 
 def test_scoring_deduplicates_cross_topic_live_trade_copies() -> None:
@@ -482,6 +515,33 @@ def test_compute_copyability_score_rewards_better_inputs() -> None:
     )
 
     assert strong > weak
+
+
+def test_compute_copyability_score_handles_zero_max_price_drift() -> None:
+    filters = replace(make_filters(), max_price_drift=0.0)
+
+    zero_drift = compute_copyability_score(
+        consensus_ratio=0.8,
+        wallet_quality_score=0.9,
+        average_age_seconds=300,
+        drift=0.0,
+        liquidity_usd=15000,
+        side_spread=0.01,
+        side_depth_usd=250,
+        filters=filters,
+    )
+    non_zero_drift = compute_copyability_score(
+        consensus_ratio=0.8,
+        wallet_quality_score=0.9,
+        average_age_seconds=300,
+        drift=0.01,
+        liquidity_usd=15000,
+        side_spread=0.01,
+        side_depth_usd=250,
+        filters=filters,
+    )
+
+    assert zero_drift > non_zero_drift
 
 
 def test_freshness_decay_uses_true_half_life() -> None:

--- a/tests/test_wallet_registry.py
+++ b/tests/test_wallet_registry.py
@@ -164,6 +164,66 @@ def test_compute_basket_health_from_static_memberships() -> None:
     assert health[0].health_state == "thin"
 
 
+def test_compute_basket_health_marks_stable_active_topic_as_healthy() -> None:
+    base_config = load_config(Path("config/predictcel.example.json"))
+    config = replace(
+        base_config,
+        filters=replace(base_config.filters, max_trade_age_seconds=604800),
+    )
+    memberships = [
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w1",
+            tier="core",
+            rank=1,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w2",
+            tier="core",
+            rank=2,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+        BasketMembership(
+            topic="geopolitics",
+            wallet="w3",
+            tier="rotating",
+            rank=3,
+            active=True,
+            joined_at=datetime(2026, 1, 1, tzinfo=UTC),
+            effective_until=None,
+            promotion_reason="seeded",
+            demotion_reason="",
+        ),
+    ]
+    trades = [
+        WalletTrade("w1", "geopolitics", "m1", "YES", 0.5, 10.0, 3600),
+        WalletTrade("w2", "geopolitics", "m2", "NO", 0.4, 12.0, 172800),
+        WalletTrade("w3", "geopolitics", "m3", "YES", 0.6, 14.0, 7200),
+    ]
+
+    health = compute_basket_health_from_static_memberships(
+        config,
+        memberships,
+        trades,
+        captured_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    assert health[0].fresh_core_wallets_24h == 1
+    assert health[0].active_eligible_wallet_count == 3
+    assert health[0].stale_ratio == 0.0
+    assert health[0].health_state == "healthy"
+
+
 def test_compute_basket_health_respects_registry_statuses() -> None:
     config = load_config(Path("config/predictcel.example.json"))
     memberships = [


### PR DESCRIPTION
## Summary
- add websocket reconnect and in-flight request dedupe in the Polymarket client
- log optional ML model load failures, fix wallet health classification, and tighten drift scoring
- harden EVM address validation and cover the audit fixes with focused regression tests

## Testing
- py -3 -m pytest tests/test_polymarket.py tests/test_copy_engine.py tests/test_wallet_registry.py tests/test_scoring.py tests/test_main.py tests/test_execution.py
- py -3 -m pytest tests
