### PR TITLE
Reduce live cycle latency hotspots

### DIFF
--- a/src/predictcel/copy_engine.py
+++ b/src/predictcel/copy_engine.py
@@ -10,7 +10,7 @@ import logging
 import os
 import pickle
 from collections import Counter, defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from typing import Any
 
 from .basket_controller import evaluate_basket_consensus_gate
@@ -23,6 +23,7 @@ from .models import (
     WalletTrade,
 )
 from .scoring import compute_copyability_score
+from .runtime import shared_compute_executor
 from .wallet_registry import build_live_basket_roster
 
 __all__ = ["CopyEngine"]
@@ -207,12 +208,17 @@ class CopyEngine:
                 local_no_valid_trade_reason_counts,
             )
 
-        with ThreadPoolExecutor(max_workers=max(1, min(8, len(grouped)))) as executor:
-            futures = {
-                executor.submit(process_market, market_id, market_trades): market_id
-                for market_id, market_trades in grouped.items()
-            }
-            for future in as_completed(futures):
+        workers = max(1, min(8, len(grouped)))
+        executor = shared_compute_executor()
+        grouped_items = list(grouped.items())
+        futures = {
+            executor.submit(process_market, market_id, market_trades): market_id
+            for market_id, market_trades in grouped_items[:workers]
+        }
+        pending_items = iter(grouped_items[workers:])
+        while futures:
+            for future in as_completed(tuple(futures)):
+                futures.pop(future)
                 (
                     local_candidates,
                     local_market_not_found,
@@ -225,6 +231,15 @@ class CopyEngine:
                 basket_not_found += local_basket_not_found
                 rejection_counts.update(local_rejection_counts)
                 no_valid_trade_reason_counts.update(local_no_valid_trade_reason_counts)
+
+                next_item = next(pending_items, None)
+                if next_item is not None:
+                    next_market_id, next_market_trades = next_item
+                    futures[
+                        executor.submit(
+                            process_market, next_market_id, next_market_trades
+                        )
+                    ] = next_market_id
 
         filtered_at_evaluate = sum(
             count

--- a/src/predictcel/main.py
+++ b/src/predictcel/main.py
@@ -12,7 +12,7 @@ import logging
 import sys
 import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import Any
@@ -40,6 +40,7 @@ from .polymarket import (
 )
 from .scoring import WalletQualityScorer
 from .storage import SignalStore
+from .runtime import shared_io_executor
 from .wallet_discovery import WalletDiscoveryPipeline
 from .wallet_registry import (
     apply_basket_manager_actions_to_memberships,
@@ -1265,13 +1266,15 @@ def _recover_unresolved_token_market_rows(
         probe_client = _make_probe_client(client)
         return probe_client.fetch_markets_by_clob_token_ids([token_id], chunk_size=1)
 
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {
-            executor.submit(fetch_one, token_id): token_id
-            for token_id in unique_token_ids
-        }
-        for future in as_completed(futures):
-            token_id = futures[future]
+    executor = shared_io_executor()
+    futures = {
+        executor.submit(fetch_one, token_id): token_id
+        for token_id in unique_token_ids[:workers]
+    }
+    pending_token_ids = iter(unique_token_ids[workers:])
+    while futures:
+        for future in as_completed(tuple(futures)):
+            token_id = futures.pop(future)
             try:
                 token_rows = future.result()
             except Exception:
@@ -1281,6 +1284,10 @@ def _recover_unresolved_token_market_rows(
                 recovered_token_ids.add(token_id)
             elif len(unresolved_samples) < 10:
                 unresolved_samples.append(token_id)
+
+            next_token_id = next(pending_token_ids, None)
+            if next_token_id is not None:
+                futures[executor.submit(fetch_one, next_token_id)] = next_token_id
 
     return (
         rows,
@@ -1334,14 +1341,7 @@ def _build_orderbook_probe_samples(
 
 
 def _make_probe_client(client: PolymarketPublicClient) -> PolymarketPublicClient:
-    return PolymarketPublicClient(
-        client.gamma_base_url,
-        client.data_base_url,
-        client.clob_base_url,
-        client.timeout_seconds,
-        client.max_retries,
-        client.retry_base_delay_seconds,
-    )
+    return client
 
 
 def _probe_token_orderbook(
@@ -1591,17 +1591,25 @@ def _fetch_wallet_payloads(
         return {}
     payloads: dict[str, list[dict[str, Any]]] = {}
     workers = max(1, min(16, len(wallets)))
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {
-            executor.submit(client.fetch_wallet_trades, wallet, limit): wallet
-            for wallet in wallets
-        }
-        for future in as_completed(futures):
-            wallet = futures[future]
+    executor = shared_io_executor()
+    futures = {
+        executor.submit(client.fetch_wallet_trades, wallet, limit): wallet
+        for wallet in wallets[:workers]
+    }
+    pending_wallets = iter(wallets[workers:])
+    while futures:
+        for future in as_completed(tuple(futures)):
+            wallet = futures.pop(future)
             try:
                 payloads[wallet] = future.result()
             except Exception:
                 payloads[wallet] = []
+
+            next_wallet = next(pending_wallets, None)
+            if next_wallet is not None:
+                futures[executor.submit(client.fetch_wallet_trades, next_wallet, limit)] = (
+                    next_wallet
+                )
     return payloads
 
 

--- a/src/predictcel/polymarket.py
+++ b/src/predictcel/polymarket.py
@@ -4,16 +4,17 @@ import logging
 import random
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections import OrderedDict
+from concurrent.futures import as_completed
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
-from urllib.request import Request, urlopen
 
 import aiohttp
 from .models import MarketSnapshot, WalletTrade
+from .runtime import shared_io_executor
 
 logger = logging.getLogger(__name__)
 
@@ -70,11 +71,105 @@ class CircuitBreaker:
                 self.state = "OPEN"
 
 
+class _AsyncHttpTransport:
+    def __init__(self, timeout_seconds: int) -> None:
+        self.timeout_seconds = timeout_seconds
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._ready = threading.Event()
+        self._lock = threading.Lock()
+
+    def _ensure_started(self) -> None:
+        if self._thread is not None:
+            return
+        with self._lock:
+            if self._thread is not None:
+                return
+            self._ready.clear()
+            self._thread = threading.Thread(
+                target=self._run_loop,
+                name="predictcel-http",
+                daemon=True,
+            )
+            self._thread.start()
+        if not self._ready.wait(timeout=max(self.timeout_seconds, 1) + 5):
+            raise TimeoutError("Timed out starting HTTP transport")
+
+    def _run_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._session = loop.run_until_complete(self._create_session())
+        self._ready.set()
+        loop.run_forever()
+        if self._session is not None and not self._session.closed:
+            loop.run_until_complete(self._session.close())
+        loop.close()
+
+    async def _create_session(self) -> aiohttp.ClientSession:
+        connector = aiohttp.TCPConnector(
+            limit=100,
+            ttl_dns_cache=300,
+            enable_cleanup_closed=True,
+        )
+        timeout = aiohttp.ClientTimeout(total=self.timeout_seconds)
+        return aiohttp.ClientSession(connector=connector, timeout=timeout)
+
+    def run(self, coroutine, timeout_seconds: float | None = None):
+        self._ensure_started()
+        if self._loop is None:
+            raise RuntimeError("HTTP transport loop not available")
+        future = asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+        timeout = timeout_seconds
+        if timeout is None:
+            timeout = max(self.timeout_seconds, 1) + 5
+        return future.result(timeout=timeout)
+
+    async def fetch_json(self, url: str) -> Any:
+        if self._session is None:
+            raise RuntimeError("HTTP transport session not available")
+        try:
+            async with self._session.get(
+                url,
+                headers={"User-Agent": "PredictCel/0.1"},
+            ) as response:
+                text = await response.text()
+                if response.status >= 400:
+                    raise HTTPError(
+                        url,
+                        response.status,
+                        response.reason,
+                        hdrs=response.headers,
+                        fp=None,
+                    )
+        except aiohttp.ClientError as exc:
+            raise URLError(str(exc)) from exc
+        return json.loads(text)
+
+    def close(self) -> None:
+        with self._lock:
+            loop = self._loop
+            thread = self._thread
+            self._loop = None
+            self._thread = None
+            session = self._session
+            self._session = None
+        if loop is None or thread is None:
+            return
+        if session is not None and not session.closed:
+            asyncio.run_coroutine_threadsafe(session.close(), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+
+
 class PolymarketPublicClient:
     """Client for Polymarket public APIs with caching and resilience."""
 
     DEFAULT_Z_THRESHOLD = 3.0
     DEFAULT_CACHE_TTL_SECONDS = 300
+    DEFAULT_CACHE_MAX_ENTRIES = 2048
+    DEFAULT_RESPONSE_VALIDATION_SAMPLE_RATE = 0.01
 
     def __init__(
         self,
@@ -109,9 +204,16 @@ class PolymarketPublicClient:
         self.retry_base_delay_seconds = retry_base_delay_seconds
         self.use_redis = use_redis
         self.redis_client = None
-        self._request_cache: dict[str, Any] = {}
+        self._request_cache: OrderedDict[str, Any] = OrderedDict()
         self._cache_lock = threading.Lock()
         self._inflight_requests: dict[str, dict[str, Any]] = {}
+        self._cache_max_entries = self.DEFAULT_CACHE_MAX_ENTRIES
+        self._response_validation_sample_rate = (
+            self.DEFAULT_RESPONSE_VALIDATION_SAMPLE_RATE
+        )
+        self._wallet_trade_variant_lock = threading.Lock()
+        self._preferred_wallet_trade_variant: tuple[str, str] | None = None
+        self._http_transport = _AsyncHttpTransport(self.timeout_seconds)
         self._gamma_circuit_breaker = CircuitBreaker()
         self._data_circuit_breaker = CircuitBreaker()
         self._clob_circuit_breaker = CircuitBreaker()
@@ -142,6 +244,15 @@ class PolymarketPublicClient:
                 )
                 self.use_redis = False
                 self.redis_client = None
+
+    def close(self) -> None:
+        self._http_transport.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def fetch_active_markets(self, limit: int) -> list[dict[str, Any]]:
         """Fetch active markets from Gamma API."""
@@ -198,19 +309,20 @@ class PolymarketPublicClient:
         results: list[dict[str, Any]] = []
         seen_market_keys: set[str] = set()
         workers = max(1, min(max_workers, len(unique_slugs)))
-
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = {
-                executor.submit(self.fetch_market_by_slug, slug): slug
-                for slug in unique_slugs
-            }
-            for future in as_completed(futures):
-                slug = futures[future]
+        executor = shared_io_executor()
+        futures = {
+            executor.submit(self.fetch_market_by_slug, slug): slug
+            for slug in unique_slugs[:workers]
+        }
+        pending_slugs = iter(unique_slugs[workers:])
+        while futures:
+            for future in as_completed(tuple(futures)):
+                slug = futures.pop(future)
                 try:
                     payload = future.result()
                 except Exception as e:
                     logger.debug(f"Failed to fetch market for slug {slug}: {e}")
-                    continue
+                    payload = {}
 
                 rows = _extract_list(payload)
                 if (
@@ -242,6 +354,12 @@ class PolymarketPublicClient:
                         continue
                     seen_market_keys.add(key)
                     results.append(row)
+
+                next_slug = next(pending_slugs, None)
+                if next_slug is not None:
+                    futures[executor.submit(self.fetch_market_by_slug, next_slug)] = (
+                        next_slug
+                    )
 
         return results
 
@@ -283,20 +401,30 @@ class PolymarketPublicClient:
         Logs warnings if all endpoints fail.
         """
         request_variants = [
-            (f"{self.data_base_url}/v1/trades", {"user": wallet, "limit": limit}),
-            (f"{self.data_base_url}/v1/trades", {"address": wallet, "limit": limit}),
-            (f"{self.data_base_url}/trades", {"user": wallet, "limit": limit}),
-            (f"{self.data_base_url}/trades", {"address": wallet, "limit": limit}),
-            (f"{self.data_base_url}/activity", {"user": wallet, "limit": limit}),
-            (f"{self.data_base_url}/activity", {"address": wallet, "limit": limit}),
+            ("/v1/trades", "user"),
+            ("/v1/trades", "address"),
+            ("/trades", "user"),
+            ("/trades", "address"),
+            ("/activity", "user"),
+            ("/activity", "address"),
         ]
+        with self._wallet_trade_variant_lock:
+            preferred_variant = self._preferred_wallet_trade_variant
+        if preferred_variant in request_variants:
+            request_variants = [preferred_variant] + [
+                variant
+                for variant in request_variants
+                if variant != preferred_variant
+            ]
 
         wallet_key = wallet.lower()
         best_rows: list[dict[str, Any]] = []
         best_scored_rows: list[dict[str, Any]] = []
         errors: list[str] = []
 
-        for base_url, params in request_variants:
+        for path, wallet_param in request_variants:
+            base_url = f"{self.data_base_url}{path}"
+            params = {wallet_param: wallet, "limit": limit}
             query = urlencode(params)
             try:
                 payload = self._get_json(f"{base_url}?{query}")
@@ -320,6 +448,9 @@ class PolymarketPublicClient:
             if _score_trade_rows(candidate_rows) > _score_trade_rows(best_scored_rows):
                 best_scored_rows = candidate_rows
                 best_rows = candidate_rows
+                if candidate_rows:
+                    with self._wallet_trade_variant_lock:
+                        self._preferred_wallet_trade_variant = (path, wallet_param)
             elif len(candidate_rows) > len(best_rows):
                 best_rows = candidate_rows
 
@@ -498,35 +629,8 @@ class PolymarketPublicClient:
                         if inflight["followers"] <= 0 and inflight["event"].is_set():
                             self._inflight_requests.pop(url, None)
 
-            metrics["requests"] += 1
-            request = Request(url, headers={"User-Agent": "PredictCel/0.1"})
-
             try:
-                for attempt in range(self.max_retries):
-                    try:
-                        with urlopen(request, timeout=self.timeout_seconds) as response:
-                            payload = json.loads(response.read().decode("utf-8"))
-                            self._validate_response(payload, url)
-                            self._set_cached(url, payload)
-                            result = payload
-                            break
-                    except HTTPError as error:
-                        if self._is_missing_clob_order_book(url, error):
-                            result = {}
-                            break
-                        metrics["errors"] += 1
-                        if attempt >= self.max_retries - 1:
-                            raise
-                        delay = _retry_delay(self.retry_base_delay_seconds, attempt)
-                        time.sleep(delay)
-                    except (URLError, TimeoutError, OSError, json.JSONDecodeError):
-                        metrics["errors"] += 1
-                        if attempt >= self.max_retries - 1:
-                            raise
-                        delay = _retry_delay(self.retry_base_delay_seconds, attempt)
-                        time.sleep(delay)
-                else:
-                    raise RuntimeError(f"Request retries exhausted for {url}")
+                result = self._fetch_json_with_retries(url)
             except BaseException as error:
                 with self._cache_lock:
                     inflight["error"] = error
@@ -543,6 +647,30 @@ class PolymarketPublicClient:
             return result
 
         return self._breaker_for_url(url).call(_fetch_url)
+
+    def _fetch_json_with_retries(self, url: str) -> Any:
+        metrics = _get_metrics()
+        metrics["requests"] += 1
+        for attempt in range(self.max_retries):
+            try:
+                payload = self._http_transport.run(self._http_transport.fetch_json(url))
+                self._validate_response(payload, url)
+                return payload
+            except HTTPError as error:
+                if self._is_missing_clob_order_book(url, error):
+                    return {}
+                metrics["errors"] += 1
+                if attempt >= self.max_retries - 1:
+                    raise
+                delay = _retry_delay(self.retry_base_delay_seconds, attempt)
+                self._http_transport.run(asyncio.sleep(delay), timeout_seconds=delay + 5)
+            except (URLError, TimeoutError, OSError, json.JSONDecodeError):
+                metrics["errors"] += 1
+                if attempt >= self.max_retries - 1:
+                    raise
+                delay = _retry_delay(self.retry_base_delay_seconds, attempt)
+                self._http_transport.run(asyncio.sleep(delay), timeout_seconds=delay + 5)
+        raise RuntimeError(f"Request retries exhausted for {url}")
 
     def _get_cached(self, url: str) -> Any:
         """Get cached response if available and not expired."""
@@ -572,6 +700,7 @@ class PolymarketPublicClient:
         with self._cache_lock:
             if url in self._request_cache:
                 cached = self._request_cache[url]
+                self._request_cache.move_to_end(url)
                 if isinstance(cached, dict) and cached.get("_cached_at"):
                     if (
                         time.time() - cached["_cached_at"]
@@ -598,44 +727,22 @@ class PolymarketPublicClient:
                 logger.debug(f"Redis set failed: {e}")
 
         with self._cache_lock:
+            if url in self._request_cache:
+                self._request_cache.pop(url, None)
             cache_data = payload.copy() if isinstance(payload, dict) else payload
             if isinstance(cache_data, dict):
                 cache_data["_cached_at"] = time.time()
             self._request_cache[url] = cache_data
+            while len(self._request_cache) > self._cache_max_entries:
+                self._request_cache.popitem(last=False)
 
     def _validate_response(self, payload: Any, url: str) -> None:
         """Validate API response with anomaly detection."""
         if not isinstance(payload, (dict, list)):
             raise ValueError(f"Invalid response type for {url}: {type(payload)}")
 
-        if isinstance(payload, list):
-            prices = []
-            for item in payload:
-                if isinstance(item, dict):
-                    yes_ask = item.get("yes", item.get("yesPrice"))
-                    no_ask = item.get("no", item.get("noPrice"))
-                    if yes_ask is not None and isinstance(yes_ask, (int, float)):
-                        prices.append(yes_ask)
-                    if no_ask is not None and isinstance(no_ask, (int, float)):
-                        prices.append(no_ask)
-
-            if prices:
-                import statistics
-
-                mean_price = statistics.mean(prices)
-                stdev_price = statistics.stdev(prices) if len(prices) > 1 else 0
-
-                anomalies = 0
-                for price in prices:
-                    if stdev_price > 0:
-                        z_score = abs(price - mean_price) / stdev_price
-                        if z_score > self.DEFAULT_Z_THRESHOLD:
-                            anomalies += 1
-
-                if anomalies > 0:
-                    logger.warning(
-                        f"Detected {anomalies} anomalous prices in response from {url}"
-                    )
+        if isinstance(payload, list) and self._should_sample_validation():
+            self._validate_price_anomalies(payload, url)
 
         if "markets" in url and isinstance(payload, dict):
             data = payload.get("data", payload)
@@ -654,6 +761,45 @@ class PolymarketPublicClient:
                 ):
                     logger.error(f"Unexpected market data shape from {url}")
                     raise ValueError("Unexpected market data shape")
+
+    def _should_sample_validation(self) -> bool:
+        rate = self._response_validation_sample_rate
+        if rate >= 1.0:
+            return True
+        if rate <= 0:
+            return False
+        return random.random() < rate
+
+    def _validate_price_anomalies(self, payload: list[Any], url: str) -> None:
+        prices = []
+        for item in payload:
+            if isinstance(item, dict):
+                yes_ask = item.get("yes", item.get("yesPrice"))
+                no_ask = item.get("no", item.get("noPrice"))
+                if yes_ask is not None and isinstance(yes_ask, (int, float)):
+                    prices.append(yes_ask)
+                if no_ask is not None and isinstance(no_ask, (int, float)):
+                    prices.append(no_ask)
+
+        if not prices:
+            return
+
+        import statistics
+
+        mean_price = statistics.mean(prices)
+        stdev_price = statistics.stdev(prices) if len(prices) > 1 else 0
+
+        anomalies = 0
+        for price in prices:
+            if stdev_price > 0:
+                z_score = abs(price - mean_price) / stdev_price
+                if z_score > self.DEFAULT_Z_THRESHOLD:
+                    anomalies += 1
+
+        if anomalies > 0:
+            logger.warning(
+                f"Detected {anomalies} anomalous prices in response from {url}"
+            )
 
 
 def build_market_snapshots(items: list[dict[str, Any]]) -> dict[str, MarketSnapshot]:
@@ -687,18 +833,28 @@ def enrich_market_snapshots_with_orderbooks(
     enriched_unique: dict[str, MarketSnapshot] = {}
     workers = max(1, min(max_workers, len(unique_snapshots)))
 
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {
-            executor.submit(_enrich_one_snapshot, snapshot, client): market_id
-            for market_id, snapshot in unique_snapshots.items()
-        }
-        for future in as_completed(futures):
-            market_id = futures[future]
+    executor = shared_io_executor()
+    market_items = list(unique_snapshots.items())
+    futures = {
+        executor.submit(_enrich_one_snapshot, snapshot, client): market_id
+        for market_id, snapshot in market_items[:workers]
+    }
+    pending_items = iter(market_items[workers:])
+    while futures:
+        for future in as_completed(tuple(futures)):
+            market_id = futures.pop(future)
             try:
                 enriched_unique[market_id] = future.result()
             except Exception as e:
                 logger.debug(f"Failed to enrich snapshot {market_id}: {e}")
                 enriched_unique[market_id] = unique_snapshots[market_id]
+
+            next_item = next(pending_items, None)
+            if next_item is not None:
+                next_market_id, next_snapshot = next_item
+                futures[executor.submit(_enrich_one_snapshot, next_snapshot, client)] = (
+                    next_market_id
+                )
 
     enriched: dict[str, MarketSnapshot] = {}
     for canonical_id, aliases in aliases_by_canonical.items():

--- a/src/predictcel/runtime.py
+++ b/src/predictcel/runtime.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import atexit
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+_executor_lock = threading.Lock()
+_io_executor: ThreadPoolExecutor | None = None
+_compute_executor: ThreadPoolExecutor | None = None
+
+
+def shared_io_executor() -> ThreadPoolExecutor:
+    global _io_executor
+    with _executor_lock:
+        if _io_executor is None:
+            _io_executor = ThreadPoolExecutor(
+                max_workers=16,
+                thread_name_prefix="predictcel-io",
+            )
+        return _io_executor
+
+
+def shared_compute_executor() -> ThreadPoolExecutor:
+    global _compute_executor
+    with _executor_lock:
+        if _compute_executor is None:
+            _compute_executor = ThreadPoolExecutor(
+                max_workers=8,
+                thread_name_prefix="predictcel-compute",
+            )
+        return _compute_executor
+
+
+def shutdown_shared_executors() -> None:
+    global _io_executor, _compute_executor
+    with _executor_lock:
+        io_executor = _io_executor
+        compute_executor = _compute_executor
+        _io_executor = None
+        _compute_executor = None
+
+    if io_executor is not None:
+        io_executor.shutdown(wait=False, cancel_futures=False)
+    if compute_executor is not None:
+        compute_executor.shutdown(wait=False, cancel_futures=False)
+
+
+atexit.register(shutdown_shared_executors)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2405,61 +2405,35 @@ def test_build_wallet_registry_summary_ignores_static_explorer_bench_depth_for_p
     assert summary["promotion_watch_by_topic"] == {}
 
 
-def test_probe_token_orderbook_uses_fresh_client(monkeypatch) -> None:
+def test_probe_token_orderbook_uses_passed_client() -> None:
     observed = {}
 
-    class FreshProbeClient:
-        def __init__(
-            self,
-            gamma_base_url,
-            data_base_url,
-            clob_base_url,
-            timeout_seconds,
-            max_retries,
-            retry_base_delay_seconds,
-        ):
-            observed["args"] = (
-                gamma_base_url,
-                data_base_url,
-                clob_base_url,
-                timeout_seconds,
-                max_retries,
-                retry_base_delay_seconds,
-            )
-
+    class ReusedProbeClient(ProbeSourceClient):
         def fetch_order_book(self, token_id: str):
+            observed["token_id"] = token_id
             raise RuntimeError(f"root cause for {token_id}")
 
-    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FreshProbeClient)
+    client = ReusedProbeClient()
 
-    result = _probe_token_orderbook(ProbeSourceClient(), "token_yes")
+    result = _probe_token_orderbook(client, "token_yes")
 
     assert result == {
         "token_id": "token_yes",
         "error": "RuntimeError: root cause for token_yes",
     }
-    assert observed["args"] == (
-        "https://gamma-api.polymarket.com",
-        "https://data-api.polymarket.com",
-        "https://clob.polymarket.com",
-        15,
-        1,
-        0.5,
-    )
+    assert observed == {"token_id": "token_yes"}
 
 
-def test_probe_token_lookup_uses_fresh_client(monkeypatch) -> None:
-    class FreshProbeClient:
-        def __init__(self, *args):
-            pass
+def test_probe_token_lookup_uses_passed_client() -> None:
+    observed = {}
 
+    class ReusedProbeClient(ProbeSourceClient):
         def fetch_markets_by_clob_token_ids(
             self,
             token_ids: list[str],
             chunk_size: int = 25,
         ):
-            assert token_ids == ["token_yes"]
-            assert chunk_size == 1
+            observed["call"] = (token_ids, chunk_size)
             return [
                 {
                     "conditionId": "cond_1",
@@ -2468,9 +2442,7 @@ def test_probe_token_lookup_uses_fresh_client(monkeypatch) -> None:
                 }
             ]
 
-    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FreshProbeClient)
-
-    result = _probe_token_lookup(ProbeSourceClient(), "token_yes")
+    result = _probe_token_lookup(ReusedProbeClient(), "token_yes")
 
     assert result == {
         "matched_rows": 1,
@@ -2480,21 +2452,21 @@ def test_probe_token_lookup_uses_fresh_client(monkeypatch) -> None:
         "token_ids": ["token_yes", "token_no"],
         "matched_input_token": True,
     }
+    assert observed == {"call": (["token_yes"], 1)}
 
 
-def test_recover_unresolved_token_market_rows_uses_single_token_probes(
-    monkeypatch,
-) -> None:
-    class FreshProbeClient:
-        def __init__(self, *args):
-            pass
+def test_recover_unresolved_token_market_rows_uses_single_token_probes() -> None:
+    class ReusedProbeClient(ProbeSourceClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[tuple[list[str], int]] = []
 
         def fetch_markets_by_clob_token_ids(
             self,
             token_ids: list[str],
             chunk_size: int = 25,
         ):
-            assert chunk_size == 1
+            self.calls.append((token_ids, chunk_size))
             if token_ids == ["token_yes"]:
                 return [
                     {
@@ -2505,10 +2477,10 @@ def test_recover_unresolved_token_market_rows_uses_single_token_probes(
                 ]
             return []
 
-    monkeypatch.setattr("predictcel.main.PolymarketPublicClient", FreshProbeClient)
+    client = ReusedProbeClient()
 
     rows, stats, unresolved = _recover_unresolved_token_market_rows(
-        ProbeSourceClient(),
+        client,
         ["token_yes", "token_missing"],
     )
 
@@ -2521,6 +2493,10 @@ def test_recover_unresolved_token_market_rows_uses_single_token_probes(
     ]
     assert stats == {"requested": 2, "matched": 1, "unmatched": 1}
     assert unresolved == ["token_missing"]
+    assert sorted(client.calls) == [
+        (["token_missing"], 1),
+        (["token_yes"], 1),
+    ]
 
 
 def test_propagate_canonical_market_updates_rebinds_stale_aliases() -> None:

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -115,6 +115,29 @@ class FakeFilteredTradeClient(PolymarketPublicClient):
         }
 
 
+class CachedVariantTradeClient(PolymarketPublicClient):
+    def __init__(self):
+        super().__init__()
+        self.urls = []
+
+    def _get_json(self, url: str):
+        self.urls.append(url)
+        if "address=0xabc" in url:
+            return {
+                "trades": [
+                    {
+                        "asset": "token_yes",
+                        "side": "BUY_YES",
+                        "price": "0.54",
+                        "sizeUsd": "25",
+                        "createdAt": "2025-12-31T23:50:00Z",
+                        "user": "0xabc",
+                    }
+                ]
+            }
+        return {"trades": []}
+
+
 class FakeHTTPResponse:
     def __init__(self, payload):
         self.payload = payload
@@ -266,6 +289,19 @@ def test_fetch_wallet_trades_filters_rows_to_requested_wallet() -> None:
     assert rows[0]["asset"] == "token_right"
 
 
+def test_fetch_wallet_trades_caches_preferred_endpoint_variant() -> None:
+    client = CachedVariantTradeClient()
+
+    first_rows = client.fetch_wallet_trades("0xabc", 5)
+    second_rows = client.fetch_wallet_trades("0xabc", 5)
+
+    assert first_rows[0]["asset"] == "token_yes"
+    assert second_rows[0]["asset"] == "token_yes"
+    assert "user=0xabc" in client.urls[0]
+    assert "address=0xabc" in client.urls[1]
+    assert "address=0xabc" in client.urls[2]
+
+
 def test_fetch_market_trades_uses_repeated_market_query_params() -> None:
     client = FakeTradeClient()
 
@@ -370,10 +406,14 @@ def test_fetch_order_book_treats_missing_clob_book_as_empty_payload(
 ) -> None:
     client = PolymarketPublicClient(max_retries=1)
 
-    def fake_urlopen(request, timeout=15):
-        raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
+    class FakeTransport:
+        async def fetch_json(self, url: str):
+            raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
 
-    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+        def run(self, coroutine):
+            return asyncio.run(coroutine)
+
+    monkeypatch.setattr(client, "_http_transport", FakeTransport())
 
     book = client.fetch_order_book("missing_token")
 
@@ -384,17 +424,19 @@ def test_fetch_order_book_treats_missing_clob_book_as_empty_payload(
 def test_missing_clob_book_does_not_block_later_valid_books(monkeypatch) -> None:
     client = PolymarketPublicClient(max_retries=1)
 
-    def fake_urlopen(request, timeout=15):
-        if "missing_token" in request.full_url:
-            raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
-        return FakeHTTPResponse(
-            {
+    class FakeTransport:
+        async def fetch_json(self, url: str):
+            if "missing_token" in url:
+                raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+            return {
                 "bids": [{"price": "0.48", "size": "10"}],
                 "asks": [{"price": "0.52", "size": "12"}],
             }
-        )
 
-    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+        def run(self, coroutine):
+            return asyncio.run(coroutine)
+
+    monkeypatch.setattr(client, "_http_transport", FakeTransport())
 
     missing_book = client.fetch_order_book("missing_token")
     valid_book = client.fetch_order_book("valid_token")
@@ -408,19 +450,17 @@ def test_gamma_circuit_breaker_does_not_block_clob_requests(monkeypatch) -> None
     client = PolymarketPublicClient(max_retries=1)
     client._gamma_circuit_breaker.failure_threshold = 1
 
-    def fake_urlopen(request, timeout=15):
-        if request.full_url.startswith(client.gamma_base_url):
+    def fake_fetch_json_with_retries(url: str):
+        if url.startswith(client.gamma_base_url):
             raise URLError("gamma down")
-        if request.full_url.startswith(client.clob_base_url):
-            return FakeHTTPResponse(
-                {
-                    "bids": [{"price": "0.48", "size": "10"}],
-                    "asks": [{"price": "0.52", "size": "12"}],
-                }
-            )
-        raise AssertionError(f"Unexpected URL: {request.full_url}")
+        if url.startswith(client.clob_base_url):
+            return {
+                "bids": [{"price": "0.48", "size": "10"}],
+                "asks": [{"price": "0.52", "size": "12"}],
+            }
+        raise AssertionError(f"Unexpected URL: {url}")
 
-    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+    monkeypatch.setattr(client, "_fetch_json_with_retries", fake_fetch_json_with_retries)
 
     with pytest.raises(URLError):
         client.fetch_active_markets(1)
@@ -477,14 +517,14 @@ def test_get_json_deduplicates_inflight_requests(monkeypatch) -> None:
     release = threading.Event()
     calls = {"count": 0}
 
-    def fake_urlopen(request, timeout=15):
-        del timeout
+    def fake_fetch_json_with_retries(url: str):
+        del url
         calls["count"] += 1
         started.set()
         release.wait(timeout=1)
-        return FakeHTTPResponse({"markets": [{"conditionId": "cond_1"}]})
+        return {"markets": [{"conditionId": "cond_1"}]}
 
-    monkeypatch.setattr("predictcel.polymarket.urlopen", fake_urlopen)
+    monkeypatch.setattr(client, "_fetch_json_with_retries", fake_fetch_json_with_retries)
 
     def fetch():
         return client._get_json(f"{client.gamma_base_url}/markets?limit=1")
@@ -501,6 +541,19 @@ def test_get_json_deduplicates_inflight_requests(monkeypatch) -> None:
         {"markets": [{"conditionId": "cond_1"}]},
         {"markets": [{"conditionId": "cond_1"}]},
     ]
+
+
+def test_memory_cache_evicts_oldest_entries_when_bounded() -> None:
+    client = PolymarketPublicClient()
+    client._cache_max_entries = 2
+
+    client._set_cached("one", {"value": 1})
+    client._set_cached("two", {"value": 2})
+    client._set_cached("three", {"value": 3})
+
+    assert client._get_cached("one") is None
+    assert client._get_cached("two") == {"value": 2}
+    assert client._get_cached("three") == {"value": 3}
 
 
 def test_wallet_trade_from_data_uses_outcome_and_timestamp() -> None:
@@ -686,3 +739,23 @@ def test_validate_response_accepts_outcome_prices_market_payload() -> None:
         {"data": [{"conditionId": "cond_1", "outcomePrices": "[0.61, 0.35]"}]},
         "https://gamma-api.polymarket.com/markets?limit=1",
     )
+
+
+def test_validate_response_skips_anomaly_scan_when_not_sampled(monkeypatch) -> None:
+    client = PolymarketPublicClient()
+    called = {"value": False}
+
+    monkeypatch.setattr(client, "_should_sample_validation", lambda: False)
+
+    def fake_validate_price_anomalies(payload, url):
+        del payload, url
+        called["value"] = True
+
+    monkeypatch.setattr(client, "_validate_price_anomalies", fake_validate_price_anomalies)
+
+    client._validate_response(
+        [{"yes": 0.61, "no": 0.35}],
+        "https://gamma-api.polymarket.com/data",
+    )
+
+    assert called["value"] is False


### PR DESCRIPTION
## Summary
- reuse pooled HTTP transport and shared executors across hot live-data paths
- cache wallet trade endpoint preference, bound the in-memory cache, and sample expensive response validation
- reuse the existing probe client and update latency-focused tests for the new transport behavior

## Testing
- py -3 -m pytest tests/test_polymarket.py tests/test_main.py tests/test_copy_engine.py -q